### PR TITLE
Remove email field as a required parameter to enable Nakama's username/password authentication feature.

### DIFF
--- a/lib/src/api/proto/api/api.pb.dart
+++ b/lib/src/api/proto/api/api.pb.dart
@@ -622,8 +622,8 @@ class AccountEmail extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get email => $_getSZ(0);
   @$pb.TagNumber(1)
-  set email($core.String v) {
-    $_setString(0, v);
+  set email($core.String? v) {
+    if (v != null) $_setString(0, v);
   }
 
   @$pb.TagNumber(1)

--- a/lib/src/nakama_client/nakama_api_client.dart
+++ b/lib/src/nakama_client/nakama_api_client.dart
@@ -123,7 +123,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<model.Session> authenticateEmail({
-    required String email,
+    String? email,
     required String password,
     bool create = true,
     String? username,

--- a/lib/src/nakama_client/nakama_client.dart
+++ b/lib/src/nakama_client/nakama_client.dart
@@ -39,7 +39,7 @@ abstract class NakamaBaseClient {
   Future<void> sessionLogout({required model.Session session});
 
   Future<model.Session> authenticateEmail({
-    required String email,
+    String? email,
     required String password,
     bool create = false,
     String? username,

--- a/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/lib/src/nakama_client/nakama_grpc_client.dart
@@ -125,7 +125,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<model.Session> authenticateEmail({
-    required String email,
+    String? email,
     required String password,
     bool create = true,
     String? username,

--- a/lib/src/rest/apigrpc.swagger.chopper.dart
+++ b/lib/src/rest/apigrpc.swagger.chopper.dart
@@ -120,7 +120,7 @@ class _$Apigrpc extends Apigrpc {
 
   @override
   Future<Response<ApiSession>> _v2AccountAuthenticateEmailPost({
-    required ApiAccountEmail? body,
+    ApiAccountEmail? body,
     bool? create,
     String? username,
   }) {

--- a/lib/src/rest/apigrpc.swagger.dart
+++ b/lib/src/rest/apigrpc.swagger.dart
@@ -165,7 +165,7 @@ abstract class Apigrpc extends ChopperService {
   ///@param create Register the account if the user does not already exist.
   ///@param username Set the username on the account at register. Must be unique.
   Future<chopper.Response<ApiSession>> v2AccountAuthenticateEmailPost({
-    required ApiAccountEmail? body,
+    ApiAccountEmail? body,
     bool? create,
     String? username,
   }) {
@@ -183,7 +183,7 @@ abstract class Apigrpc extends ChopperService {
   ///@param username Set the username on the account at register. Must be unique.
   @Post(path: '/v2/account/authenticate/email')
   Future<chopper.Response<ApiSession>> _v2AccountAuthenticateEmailPost({
-    @Body() required ApiAccountEmail? body,
+    @Body() ApiAccountEmail? body,
     @Query('create') bool? create,
     @Query('username') String? username,
   });


### PR DESCRIPTION
#71 
Nakama server actually allows no email being supplied and will attempt to authenticate with only a supplied username.