### PR TITLE
Fix LeaderboardRecordList model mapper

### DIFF
--- a/lib/src/models/leaderboard.dart
+++ b/lib/src/models/leaderboard.dart
@@ -24,8 +24,7 @@ class LeaderboardRecordList with _$LeaderboardRecordList {
 
   factory LeaderboardRecordList.fromDto(api.LeaderboardRecordList dto) =>
       LeaderboardRecordList(
-        records:
-            dto.ownerRecords.map((e) => LeaderboardRecord.fromDto(e)).toList(),
+        records: dto.records.map((e) => LeaderboardRecord.fromDto(e)).toList(),
         ownerRecords:
             dto.ownerRecords.map((e) => LeaderboardRecord.fromDto(e)).toList(),
         nextCursor: dto.nextCursor,

--- a/test/grpc/leaderboard_test.dart
+++ b/test/grpc/leaderboard_test.dart
@@ -21,12 +21,17 @@ void main() {
     });
 
     test('list leaderboard records', () async {
+      await client.writeLeaderboardRecord(
+          session: session, leaderboardName: 'test', score: 10);
+
       final result = await client.listLeaderboardRecords(
         session: session,
         leaderboardName: 'test',
       );
 
       expect(result, isA<LeaderboardRecordList>());
+      expect(result.records.first.score, isNotNull);
+      expect(result.records.first.score!.toInt(), equals(10));
     });
 
     test('write leaderboard record', () async {
@@ -36,6 +41,21 @@ void main() {
       expect(result, isA<LeaderboardRecord>());
       expect(result.score, isNotNull);
       expect(result.score!.toInt(), equals(10));
+    });
+
+    test('list leaderboard records around user', () async {
+      await client.writeLeaderboardRecord(
+          session: session, leaderboardName: 'test', score: 10);
+
+      final result = await client.listLeaderboardRecordsAroundOwner(
+        session: session,
+        leaderboardName: 'test',
+        ownerId: session.userId,
+      );
+
+      expect(result, isA<LeaderboardRecordList>());
+      expect(result.records.first.score, isNotNull);
+      expect(result.records.first.score!.toInt(), equals(10));
     });
   });
 }


### PR DESCRIPTION
There's an issue in the `LeaderboardRecordList.fromDto` that doesn't map the records properly.
This PR fixes the issue and adds some tests for it.