### PR TITLE
Fix parsing session expiry

### DIFF
--- a/lib/src/models/session.dart
+++ b/lib/src/models/session.dart
@@ -34,10 +34,10 @@ class Session with _$Session {
           : {},
       userId: token['uid'] as String,
       expiresAt: DateTime.fromMillisecondsSinceEpoch(
-        token['exp'] as int,
+        token['exp'] as int * 1000,
       ),
       refreshExpiresAt: DateTime.fromMillisecondsSinceEpoch(
-        refreshToken['exp'] as int,
+        refreshToken['exp'] as int * 1000,
       ),
     );
   }


### PR DESCRIPTION
The commit b75e60e didn't entirely solve the issue #73.

as @Dragon863 pointed out in the issue:

> the timestamps for the session expiry seem to be reported incorrectly (at some point in 1970), I believe this is because in session.dart fromMillisecondsSinceEpoch is being called on the decoded token which stores the token in seconds since epoch. Whilst this can be worked around by changing the arguments to (token['exp'] as int) * 1000 in every line where this function is called in the file.

The factory constructor **fromDto** accepts a parameter _session_ containing a _token_ field given by the Nakama backend.
The exact same token will be passed as a field in the parameter _session_ of the factory constructor **fromApi**.

For this reason I expect the factory constructor **fromDto** to be changed like it has been done for the **fromApi**.