### PR TITLE
- update sessionRefresh function to accept string instead of session …

### DIFF
--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -98,12 +98,12 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
   @override
   Future<model.Session> sessionRefresh({
-    required model.Session session,
+    required String refreshToken,
     Map<String, String>? vars,
   }) async {
     final res = await _api.v2AccountSessionRefreshPost(
       body: ApiSessionRefreshRequest(
-        token: session.refreshToken,
+        token: refreshToken,
         vars: vars,
       ),
     );

--- a/nakama/lib/src/nakama_client/nakama_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_client.dart
@@ -30,9 +30,10 @@ abstract class NakamaBaseClient {
   NakamaBaseClient();
 
   Future<model.Session> sessionRefresh({
-    required model.Session session,
+    required String refreshToken,
     Map<String, String>? vars,
   });
+
 
   /// Log out a session, invalidate a refresh token, or log out all
   /// sessions/refresh tokens for a user.

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -103,11 +103,11 @@ class NakamaGrpcClient extends NakamaBaseClient {
 
   @override
   Future<model.Session> sessionRefresh({
-    required model.Session session,
+    required String refreshToken,
     Map<String, String>? vars,
   }) async {
     final res = await _client.sessionRefresh(
-      api.SessionRefreshRequest(token: session.refreshToken, vars: vars),
+      api.SessionRefreshRequest(token: refreshToken, vars: vars),
     );
 
     return model.Session.fromDto(res);


### PR DESCRIPTION
Problem:
client.sessionRefresh function only accepts session object which can't be save in a shared preference to be reused even if the app is restarted similar to the usage in unity example of fish game.

Fix:
Update client.sessionRefresh to directly accept String instead of session object.

Also discussed here: https://forum.heroiclabs.com/t/restore-session-in-dart-using-authtoken-or-a-string-key/5139