### PR TITLE
ChannelMessage in models is not exported

### DIFF
--- a/nakama/lib/nakama.dart
+++ b/nakama/lib/nakama.dart
@@ -10,6 +10,7 @@ export 'src/enum/leaderboard_operator.dart';
 export 'src/enum/storage_permission.dart';
 // Public models
 export 'src/models/account.dart';
+export 'src/models/channel_message.dart';
 export 'src/models/chat.dart';
 export 'src/models/friends.dart';
 export 'src/models/group.dart';


### PR DESCRIPTION
This aims to fix what _might be_ a regression related to the issue #84.
The fix submitted by @zhangyc has been lost during a [merge](https://github.com/heroiclabs/nakama-dart/pull/97/commits/95b518e2f8b85ddb67dda183b8d6eadf9bab175a).

The issue above was closed with a positive feedback, thus I may expect this to be an overlook.
I hope I got the right reasoning behind this change and that my PR is appreciated.