### PR TITLE
Fix defaults for `state` parameter of `listFriends`, `listGroupUsers` and `listUserGroups` in `NakamaGrpcClient`

### DIFF
--- a/nakama/lib/src/models/storage.dart
+++ b/nakama/lib/src/models/storage.dart
@@ -89,11 +89,15 @@ class StorageObjectWrite with _$StorageObjectWrite {
 
   factory StorageObjectWrite.fromJson(Map<String, Object?> json) => _$StorageObjectWriteFromJson(json);
 
-  api.WriteStorageObject toDto() => api.WriteStorageObject(
-        collection: collection,
-        key: key,
-        value: value,
-        permissionRead: Int32Value(value: permissionRead?.index ?? 1),
-        permissionWrite: Int32Value(value: permissionWrite?.index ?? 1),
-      );
+  api.WriteStorageObject toDto() {
+    final permissionRead = this.permissionRead ?? StorageReadPermission.ownerRead;
+    final permissionWrite = this.permissionWrite ?? StorageWritePermission.ownerWrite;
+    return api.WriteStorageObject(
+      collection: collection,
+      key: key,
+      value: value,
+      permissionRead: Int32Value(value: permissionRead.index),
+      permissionWrite: Int32Value(value: permissionWrite.index),
+    );
+  }
 }

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -875,7 +875,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       api.ListFriendsRequest(
         cursor: cursor,
         limit: api.Int32Value(value: limit),
-        state: api.Int32Value(value: friendshipState?.index),
+        state: friendshipState == null ? null : api.Int32Value(value: friendshipState.index),
       ),
       options: _getSessionCallOptions(session),
     );

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -1043,7 +1043,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
         groupId: groupId,
         cursor: cursor,
         limit: api.Int32Value(value: limit),
-        state: api.Int32Value(value: state?.index),
+        state: state == null ? null : api.Int32Value(value: state.index),
       ),
       options: _getSessionCallOptions(session),
     );

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -1021,7 +1021,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       api.ListUserGroupsRequest(
         cursor: cursor,
         limit: api.Int32Value(value: limit),
-        state: api.Int32Value(value: state?.index),
+        state: state == null ? null : api.Int32Value(value: state.index),
         userId: userId,
       ),
       options: _getSessionCallOptions(session),

--- a/nakama/test/grpc/friends_test.dart
+++ b/nakama/test/grpc/friends_test.dart
@@ -1,0 +1,44 @@
+import 'package:faker/faker.dart';
+import 'package:nakama/nakama.dart';
+import 'package:test/test.dart';
+
+import '../config.dart';
+
+void main() {
+  group('[gRPC] Friends Test', () {
+    late final NakamaBaseClient client;
+    late final Session session;
+
+    setUpAll(() async {
+      client = NakamaGrpcClient.init(
+        host: kTestHost,
+        ssl: false,
+        serverKey: kTestServerKey,
+      );
+
+      session = await client.authenticateDevice(deviceId: faker.guid.guid());
+    });
+
+    test('lists friends correctly', () async {
+      final otherUserA =
+          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final otherUserB =
+          await client.authenticateDevice(deviceId: faker.guid.guid());
+
+      await client.addFriends(
+        session: session,
+        ids: [otherUserA.userId, otherUserB.userId],
+      );
+
+      await client.addFriends(
+        session: otherUserA,
+        ids: [session.userId],
+      );
+
+      final friends = await client.listFriends(session: session);
+
+      expect(friends, isA<FriendsList>());
+      expect(friends.friends, hasLength(2));
+    });
+  });
+}

--- a/nakama/test/grpc/group_test.dart
+++ b/nakama/test/grpc/group_test.dart
@@ -117,5 +117,35 @@ void main() {
         groupId: memberGroup.id,
       );
     });
+
+    test('correctly lists users of a group', () async {
+      final group = await client.createGroup(
+        session: session,
+        name: faker.guid.guid(),
+      );
+
+      final otherUserSession =
+          await client.authenticateDevice(deviceId: faker.guid.guid());
+
+      await client.addGroupUsers(
+        session: session,
+        groupId: group.id,
+        userIds: [otherUserSession.userId],
+      );
+
+      final result = await client.listGroupUsers(
+        session: session,
+        groupId: group.id,
+      );
+
+      expect(result, isA<GroupUserList>());
+      expect(result.groupUsers, hasLength(2));
+
+      // Cleanup created group
+      await client.deleteGroup(
+        session: session,
+        groupId: group.id,
+      );
+    });
   });
 }

--- a/nakama/test/grpc/group_test.dart
+++ b/nakama/test/grpc/group_test.dart
@@ -72,7 +72,7 @@ void main() {
       );
     });
 
-    test('Correctly lists user\'s groups', () async {
+    test('correctly lists user\'s groups', () async {
       final List<Group> groups = List.empty(growable: true);
       // Create 3 groups
       for (var i = 0; i < 3; i++) {
@@ -83,6 +83,19 @@ void main() {
         groups.add(g);
       }
 
+      // Create group where user is a member
+      final otherUserSession =
+          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final memberGroup = await client.createGroup(
+        session: otherUserSession,
+        name: faker.guid.guid(),
+      );
+      await client.addGroupUsers(
+        session: otherUserSession,
+        groupId: memberGroup.id,
+        userIds: [session.userId],
+      );
+
       // list my groups
       final myGroups = await client.listUserGroups(
         session: session,
@@ -90,7 +103,7 @@ void main() {
       );
 
       expect(myGroups, isA<UserGroupList>());
-      expect(myGroups.userGroups, hasLength(3));
+      expect(myGroups.userGroups, hasLength(4));
 
       // Cleanup created groups
       for (final group in groups) {
@@ -99,6 +112,10 @@ void main() {
           groupId: group.id,
         );
       }
+      await client.deleteGroup(
+        session: otherUserSession,
+        groupId: memberGroup.id,
+      );
     });
   });
 }

--- a/nakama/test/rest/friends_test.dart
+++ b/nakama/test/rest/friends_test.dart
@@ -1,0 +1,44 @@
+import 'package:faker/faker.dart';
+import 'package:nakama/nakama.dart';
+import 'package:test/test.dart';
+
+import '../config.dart';
+
+void main() {
+  group('[REST] Friends Test', () {
+    late final NakamaBaseClient client;
+    late final Session session;
+
+    setUpAll(() async {
+      client = NakamaRestApiClient.init(
+        host: kTestHost,
+        ssl: false,
+        serverKey: kTestServerKey,
+      );
+
+      session = await client.authenticateDevice(deviceId: faker.guid.guid());
+    });
+
+    test('lists friends correctly', () async {
+      final otherUserA =
+          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final otherUserB =
+          await client.authenticateDevice(deviceId: faker.guid.guid());
+
+      await client.addFriends(
+        session: session,
+        ids: [otherUserA.userId, otherUserB.userId],
+      );
+
+      await client.addFriends(
+        session: otherUserA,
+        ids: [session.userId],
+      );
+
+      final friends = await client.listFriends(session: session);
+
+      expect(friends, isA<FriendsList>());
+      expect(friends.friends, hasLength(2));
+    });
+  });
+}

--- a/nakama/test/rest/group_test.dart
+++ b/nakama/test/rest/group_test.dart
@@ -115,5 +115,35 @@ void main() {
         groupId: memberGroup.id,
       );
     });
+
+    test('correctly lists users of a group', () async {
+      final group = await client.createGroup(
+        session: session,
+        name: faker.guid.guid(),
+      );
+
+      final otherUserSession =
+          await client.authenticateDevice(deviceId: faker.guid.guid());
+
+      await client.addGroupUsers(
+        session: session,
+        groupId: group.id,
+        userIds: [otherUserSession.userId],
+      );
+
+      final result = await client.listGroupUsers(
+        session: session,
+        groupId: group.id,
+      );
+
+      expect(result, isA<GroupUserList>());
+      expect(result.groupUsers, hasLength(2));
+
+      // Cleanup created group
+      await client.deleteGroup(
+        session: session,
+        groupId: group.id,
+      );
+    });
   });
 }


### PR DESCRIPTION
Passing `null` to `Int32Value` is interpreted as a `0` value. But these parameters are optional, so we must only provide a `Int32Value` to the gRPC call if the user provides one.