### PR TITLE
Add missing envelope to api.Rpc mapping in WebsocketClient

### DIFF
--- a/nakama/lib/src/nakama_websocket_client.dart
+++ b/nakama/lib/src/nakama_websocket_client.dart
@@ -196,6 +196,8 @@ class NakamaWebsocketClient {
           return waitingFuture.complete(receivedEnvelope.party);
         } else if (waitingFuture is Completer<rtpb.PartyMatchmakerTicket>) {
           return waitingFuture.complete(receivedEnvelope.partyMatchmakerTicket);
+        } else if (waitingFuture is Completer<api.Rpc>) {
+          return waitingFuture.complete(receivedEnvelope.rpc);
         } else {
           return waitingFuture.complete();
         }


### PR DESCRIPTION
Fixes #74 