### PR TITLE
fix: pass missing 'create' argument to _api.authenticateEmail

### DIFF
--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -156,6 +156,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
           vars: vars,
         ),
         username: username,
+        create: create,
       );
       return model.Session.fromApi(session);
     } on Exception catch (e) {


### PR DESCRIPTION
Hi, i discovered an issue during development where the create flag wasn't being passed to the inner _api.authenticateEmail call in the authenticateEmail method. 