### PR TITLE
Fix RPC payload encoding for Web

### DIFF
--- a/nakama/example/lib/features/rpc/custom/providers/rpc_provider.dart
+++ b/nakama/example/lib/features/rpc/custom/providers/rpc_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nakama_example/features/common/providers/session_provider.dart';
 import 'package:nakama_example/services/nakama_service.dart';
@@ -14,8 +15,22 @@ class RpcCustomNotifier extends StateNotifier<String?> {
     return state!;
   }
 
+  Future<String> callWithPayload(String id, dynamic payload) async {
+    final session = ref.read(sessionProvider)!;
+    state = await NakamaClient.instance!
+        .rpc(id: id, session: session, payload: jsonEncode(payload));
+    return state!;
+  }
+
   Future<String> callWS(String id) async {
     final result = await NakamaWSClient.instance!.rpc(id: id);
+    state = result.payload;
+    return state!;
+  }
+
+  Future<String> callWSWithPayload(String id, dynamic payload) async {
+    final result = await NakamaWSClient.instance!
+        .rpc(id: id, payload: jsonEncode(payload));
     state = result.payload;
     return state!;
   }

--- a/nakama/example/lib/features/rpc/custom/views/pages/rpc_custom.dart
+++ b/nakama/example/lib/features/rpc/custom/views/pages/rpc_custom.dart
@@ -47,11 +47,37 @@ class RpcCustomPage extends ConsumerWidget {
                   onPressed: () async => _callRpc(
                     context,
                     ref,
+                    () => ref.read(rpcCustomProvider.notifier).callWithPayload(
+                        'hello_world', {'name': 'HTTP with payload'}),
+                  ),
+                  child: const Text('Call "hello_world" (HTTP) with payload'),
+                ),
+              ),
+              SizedBox(
+                width: double.infinity,
+                child: TextButton(
+                  onPressed: () async => _callRpc(
+                    context,
+                    ref,
                     () => ref
                         .read(rpcCustomProvider.notifier)
                         .callWS('hello_world'),
                   ),
                   child: const Text('Call "hello_world (WebSocket)"'),
+                ),
+              ),
+              SizedBox(
+                width: double.infinity,
+                child: TextButton(
+                  onPressed: () async => _callRpc(
+                    context,
+                    ref,
+                    () => ref
+                        .read(rpcCustomProvider.notifier)
+                        .callWSWithPayload(
+                            'hello_world', {'name': 'Websocket with payload'}),
+                  ),
+                  child: const Text('Call "hello_world (WebSocket)" with payload'),
                 ),
               ),
             ],

--- a/nakama/example/pubspec.lock
+++ b/nakama/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   crypto:
     dependency: transitive
     description:
@@ -249,7 +249,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:

--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -14,6 +14,7 @@ import 'package:nakama/src/models/session.dart' as model;
 import 'package:nakama/src/models/storage.dart' as model;
 import 'package:nakama/src/models/tournament.dart' as model;
 import 'package:nakama/src/rest/api_client.gen.dart';
+import 'package:nakama/src/utils/prepare_payload.dart';
 
 const _kDefaultAppKey = 'default';
 
@@ -1554,7 +1555,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
       if (payload == null) {
         res = await _api.rpcFunc2(id: id);
       } else {
-        res = await _api.rpcFunc(id: id, body: payload);
+        res = await _api.rpcFunc(id: id, body: preparePayload(payload));
       }
 
       return res.payload;

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -17,6 +17,7 @@ import 'package:nakama/src/models/notification.dart' as model;
 import 'package:nakama/src/models/session.dart' as model;
 import 'package:nakama/src/models/storage.dart' as model;
 import 'package:nakama/src/models/tournament.dart' as model;
+import 'package:nakama/src/utils/prepare_payload.dart';
 
 const _kDefaultAppKey = 'default';
 
@@ -1313,7 +1314,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     final res = await _client.rpcFunc(
       api.Rpc(
         id: id,
-        payload: payload,
+        payload: payload == null ? null : preparePayload(payload),
       ),
       options: _getSessionCallOptions(session),
     );

--- a/nakama/lib/src/utils/prepare_payload.dart
+++ b/nakama/lib/src/utils/prepare_payload.dart
@@ -1,0 +1,9 @@
+import 'dart:convert';
+
+import 'package:nakama/src/utils/stub/platform_stub.dart'
+    if (dart.library.io) 'platform_io.dart'
+    if (dart.library.js) 'platform_web.dart';
+
+String preparePayload(String payload) {
+  return isWeb ? jsonEncode(payload) : payload;
+}

--- a/nakama/lib/src/utils/prepare_payload.dart
+++ b/nakama/lib/src/utils/prepare_payload.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
 import 'package:nakama/src/utils/stub/platform_stub.dart'
-    if (dart.library.io) 'platform_io.dart'
-    if (dart.library.js) 'platform_web.dart';
+    if (dart.library.io) 'package:nakama/src/utils/stub/platform_io.dart'
+    if (dart.library.js) 'package:nakama/src/utils/stub/platform_web.dart';
 
 String preparePayload(String payload) {
   return isWeb ? jsonEncode(payload) : payload;

--- a/nakama/lib/src/utils/stub/platform_io.dart
+++ b/nakama/lib/src/utils/stub/platform_io.dart
@@ -1,0 +1,2 @@
+// Used when compiling for native platforms
+bool get isWeb => false;

--- a/nakama/lib/src/utils/stub/platform_stub.dart
+++ b/nakama/lib/src/utils/stub/platform_stub.dart
@@ -1,0 +1,2 @@
+// Fallback if neither dart:html nor dart:io is available
+bool get isWeb => false;

--- a/nakama/lib/src/utils/stub/platform_web.dart
+++ b/nakama/lib/src/utils/stub/platform_web.dart
@@ -1,0 +1,2 @@
+// Used when compiling for web
+bool get isWeb => true;


### PR DESCRIPTION
This PR fixes #107 by removing the need for double-encoding `(jsonEncode(jsonEncode(payload)))` on web.