### PR TITLE
Fixes bug where authenticateCustom fails when user has session

### DIFF
--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -654,6 +654,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     String? username,
     Map<String, String>? vars,
   }) async {
+    _session = null;
     try {
       final session = await _api.authenticateCustom(
         body: ApiAccountCustom(id: id, vars: vars),


### PR DESCRIPTION
All other authenticate methods null out the session, but authenticateCustom does not. This causes the call to fail when the user has a session. 

Fixes https://github.com/heroiclabs/nakama-dart/issues/140