### PR TITLE
Use SatoriRestApiClient as concrete SatoriBaseClient for Flutter native builds

### DIFF
--- a/satori/lib/satori.dart
+++ b/satori/lib/satori.dart
@@ -10,4 +10,6 @@ export 'src/models/session.dart';
 // Client
 export 'src/satori_client/satori_api_client.dart';
 export 'src/satori_client/satori_client.dart';
-export 'src/satori_client/stub/satori_client_stub.dart' if (dart.library.js) 'src/satori_client/stub/api_client.dart';
+export 'src/satori_client/stub/satori_client_stub.dart'
+    if (dart.library.io) 'src/satori_client/stub/api_client.dart'
+    if (dart.library.js) 'src/satori_client/stub/api_client.dart';


### PR DESCRIPTION
Potential fix for https://github.com/heroiclabs/nakama-dart/issues/159

I have only minimally tested the `SatoriRestApiClient` in Flutter native builds. I am unsure if a GRPC implementation is more appropriate here as in the Nakama client. Please disregard if this is the case.