### PR TITLE
Update dependencies, regenerate code and improve static analysis

### DIFF
--- a/nakama/example/lib/features/group/providers/groups_provider.dart
+++ b/nakama/example/lib/features/group/providers/groups_provider.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:math';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nakama/nakama.dart';
 import 'package:nakama_example/features/common/providers/session_provider.dart';
@@ -49,6 +51,6 @@ class GroupsNotifier extends StateNotifier<List<Group>> {
 final groupsProvider =
     StateNotifierProvider<GroupsNotifier, List<Group>>((ref) {
   final notifier = GroupsNotifier(ref);
-  notifier.listGroups();
+  unawaited(notifier.listGroups());
   return notifier;
 });

--- a/nakama/example/lib/features/leaderboard/providers/leaderboards_provider.dart
+++ b/nakama/example/lib/features/leaderboard/providers/leaderboards_provider.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nakama_example/features/leaderboard/providers/leaderboard_provider.dart';
 import 'package:nakama_example/features/rpc/custom/providers/rpc_provider.dart';
@@ -12,7 +14,8 @@ class LeaderboardsNotifier extends StateNotifier<List<String>> {
     final leaderboards = await ref
         .read(rpcCustomProvider.notifier)
         .callWithPayload('list_leaderboards_rpc', {});
-    final leaderboardNames = (jsonDecode(leaderboards) as List)
+    final leaderboardNames = (jsonDecode(leaderboards) as List<dynamic>)
+        .cast<Map<String, dynamic>>()
         .map((leaderboard) => leaderboard['id'] as String)
         .toList();
     state = leaderboardNames;
@@ -36,6 +39,6 @@ class LeaderboardsNotifier extends StateNotifier<List<String>> {
 final leaderboardsProvider =
     StateNotifierProvider<LeaderboardsNotifier, List<String>>((ref) {
   final notifier = LeaderboardsNotifier(ref);
-  notifier.listLeaderboards();
+  unawaited(notifier.listLeaderboards());
   return notifier;
 });

--- a/nakama/example/lib/features/leaderboard/views/pages/leaderboard.dart
+++ b/nakama/example/lib/features/leaderboard/views/pages/leaderboard.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nakama_example/features/common/providers/session_provider.dart';
@@ -14,12 +16,12 @@ class LeaderboardPage extends ConsumerWidget {
 
     // Fetch leaderboard records when the page is loaded
     ref.listen(leaderboardProvider.notifier, (previous, next) {
-      ref.read(leaderboardProvider.notifier).listRecords(leaderboardName);
+      unawaited(ref.read(leaderboardProvider.notifier).listRecords(leaderboardName));
     });
 
     // Fetch records initially
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(leaderboardProvider.notifier).listRecords(leaderboardName);
+      unawaited(ref.read(leaderboardProvider.notifier).listRecords(leaderboardName));
     });
 
     return Scaffold(

--- a/nakama/example/lib/features/match/providers/matches_provider.dart
+++ b/nakama/example/lib/features/match/providers/matches_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -48,6 +49,6 @@ class MatchesNotifier extends StateNotifier<List<Match>> {
 final matchesProvider =
     StateNotifierProvider.autoDispose<MatchesNotifier, List<Match>>((ref) {
   final notifier = MatchesNotifier(ref);
-  notifier.listMatches();
+  unawaited(notifier.listMatches());
   return notifier;
 });

--- a/nakama/example/lib/main.dart
+++ b/nakama/example/lib/main.dart
@@ -7,9 +7,9 @@ import 'package:nakama_example/features/chat/views/chats.dart';
 import 'package:nakama_example/features/common/routes.dart';
 import 'package:nakama_example/features/group/views/groups.dart';
 import 'package:nakama_example/features/home/list_features/views/pages/list_features.dart';
-import 'package:nakama_example/features/match/views/matches.dart';
 import 'package:nakama_example/features/leaderboard/views/pages/leaderboard.dart';
 import 'package:nakama_example/features/leaderboard/views/pages/leaderboards.dart';
+import 'package:nakama_example/features/match/views/matches.dart';
 import 'package:nakama_example/features/rpc/custom/views/pages/rpc_custom.dart';
 
 void main() {

--- a/nakama/example/pubspec.lock
+++ b/nakama/example/pubspec.lock
@@ -45,18 +45,18 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   dio:
     dependency: transitive
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.9.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -98,10 +98,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -122,18 +122,18 @@ packages:
     dependency: transitive
     description:
       name: grpc
-      sha256: "2dde469ddd8bbd7a33a0765da417abe1ad2142813efce3a86c512041294e2b26"
+      sha256: "807a4da90fc1ba94dccc3a44653d3ff7bcf26818f030259d6a8f9fab405cb880"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.1"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.6.0"
   http2:
     dependency: transitive
     description:
@@ -198,6 +198,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   nakama:
     dependency: "direct main"
     description:
@@ -217,18 +225,18 @@ packages:
     dependency: transitive
     description:
       name: protobuf
-      sha256: "579fe5557eae58e3adca2e999e38f02441d8aa908703854a9e0a0f47fa857731"
+      sha256: "2fcc8a202ca7ec17dab7c97d6b6d91cf03aa07fe6f65f8afbb6dfa52cc5bd902"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.1.0"
   retrofit:
     dependency: transitive
     description:
       name: retrofit
-      sha256: c6cc9ad3374e6d07008343140a67afffaaa34cdf6bf08d4847d91417a99dcf45
+      sha256: "7d78824afa6eeeaf6ac58220910ee7a97597b39e93360d4bda230b7c6df45089"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.2"
+    version: "4.9.0"
   riverpod:
     dependency: transitive
     description:
@@ -331,5 +339,5 @@ packages:
     source: hosted
     version: "3.0.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/nakama/lib/nakama.dart
+++ b/nakama/lib/nakama.dart
@@ -1,5 +1,3 @@
-library nakama;
-
 export 'package:fixnum/fixnum.dart' show Int64;
 
 // Enums

--- a/nakama/lib/src/api/api.dart
+++ b/nakama/lib/src/api/api.dart
@@ -1,5 +1,3 @@
-library api;
-
 // In64 used in protobuf
 export 'package:fixnum/fixnum.dart' show Int64;
 

--- a/nakama/lib/src/api/proto/api/api.pb.dart
+++ b/nakama/lib/src/api/proto/api/api.pb.dart
@@ -1,9 +1,14 @@
-///
-//  Generated code. Do not modify.
-//  source: api/api.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from api/api.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
@@ -12,64 +17,14 @@ import 'package:protobuf/protobuf.dart' as $pb;
 
 import '../google/protobuf/timestamp.pb.dart' as $0;
 import '../google/protobuf/wrappers.pb.dart' as $1;
-
 import 'api.pbenum.dart';
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 export 'api.pbenum.dart';
 
+/// A user with additional account details. Always the current user.
 class Account extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Account',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<User>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'user',
-        subBuilder: User.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'wallet')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'email')
-    ..pc<AccountDevice>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'devices',
-        $pb.PbFieldType.PM,
-        subBuilder: AccountDevice.create)
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'customId')
-    ..aOM<$0.Timestamp>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'verifyTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'disableTime',
-        subBuilder: $0.Timestamp.create)
-    ..hasRequiredFields = false;
-
-  Account._() : super();
   factory Account({
     User? user,
     $core.String? wallet,
@@ -79,49 +34,54 @@ class Account extends $pb.GeneratedMessage {
     $0.Timestamp? verifyTime,
     $0.Timestamp? disableTime,
   }) {
-    final _result = create();
-    if (user != null) {
-      _result.user = user;
-    }
-    if (wallet != null) {
-      _result.wallet = wallet;
-    }
-    if (email != null) {
-      _result.email = email;
-    }
-    if (devices != null) {
-      _result.devices.addAll(devices);
-    }
-    if (customId != null) {
-      _result.customId = customId;
-    }
-    if (verifyTime != null) {
-      _result.verifyTime = verifyTime;
-    }
-    if (disableTime != null) {
-      _result.disableTime = disableTime;
-    }
-    return _result;
+    final result = create();
+    if (user != null) result.user = user;
+    if (wallet != null) result.wallet = wallet;
+    if (email != null) result.email = email;
+    if (devices != null) result.devices.addAll(devices);
+    if (customId != null) result.customId = customId;
+    if (verifyTime != null) result.verifyTime = verifyTime;
+    if (disableTime != null) result.disableTime = disableTime;
+    return result;
   }
-  factory Account.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Account.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Account clone() => Account()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Account._();
+
+  factory Account.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Account.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Account',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<User>(1, _omitFieldNames ? '' : 'user', subBuilder: User.create)
+    ..aOS(2, _omitFieldNames ? '' : 'wallet')
+    ..aOS(3, _omitFieldNames ? '' : 'email')
+    ..pPM<AccountDevice>(4, _omitFieldNames ? '' : 'devices',
+        subBuilder: AccountDevice.create)
+    ..aOS(5, _omitFieldNames ? '' : 'customId')
+    ..aOM<$0.Timestamp>(6, _omitFieldNames ? '' : 'verifyTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(7, _omitFieldNames ? '' : 'disableTime',
+        subBuilder: $0.Timestamp.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Account clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Account copyWith(void Function(Account) updates) =>
-      super.copyWith((message) => updates(message as Account))
-          as Account; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Account)) as Account;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Account create() => Account._();
+  @$core.override
   Account createEmptyInstance() => create();
   static $pb.PbList<Account> createRepeated() => $pb.PbList<Account>();
   @$core.pragma('dart2js:noInline')
@@ -129,147 +89,123 @@ class Account extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Account>(create);
   static Account? _defaultInstance;
 
+  /// The user object.
   @$pb.TagNumber(1)
   User get user => $_getN(0);
   @$pb.TagNumber(1)
-  set user(User v) {
-    setField(1, v);
-  }
-
+  set user(User value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasUser() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUser() => clearField(1);
+  void clearUser() => $_clearField(1);
   @$pb.TagNumber(1)
   User ensureUser() => $_ensure(0);
 
+  /// The user's wallet data.
   @$pb.TagNumber(2)
   $core.String get wallet => $_getSZ(1);
   @$pb.TagNumber(2)
-  set wallet($core.String v) {
-    $_setString(1, v);
-  }
-
+  set wallet($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasWallet() => $_has(1);
   @$pb.TagNumber(2)
-  void clearWallet() => clearField(2);
+  void clearWallet() => $_clearField(2);
 
+  /// The email address of the user.
   @$pb.TagNumber(3)
   $core.String get email => $_getSZ(2);
   @$pb.TagNumber(3)
-  set email($core.String v) {
-    $_setString(2, v);
-  }
-
+  set email($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasEmail() => $_has(2);
   @$pb.TagNumber(3)
-  void clearEmail() => clearField(3);
+  void clearEmail() => $_clearField(3);
 
+  /// The devices which belong to the user's account.
   @$pb.TagNumber(4)
-  $core.List<AccountDevice> get devices => $_getList(3);
+  $pb.PbList<AccountDevice> get devices => $_getList(3);
 
+  /// The custom id in the user's account.
   @$pb.TagNumber(5)
   $core.String get customId => $_getSZ(4);
   @$pb.TagNumber(5)
-  set customId($core.String v) {
-    $_setString(4, v);
-  }
-
+  set customId($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasCustomId() => $_has(4);
   @$pb.TagNumber(5)
-  void clearCustomId() => clearField(5);
+  void clearCustomId() => $_clearField(5);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the user's email was verified.
   @$pb.TagNumber(6)
   $0.Timestamp get verifyTime => $_getN(5);
   @$pb.TagNumber(6)
-  set verifyTime($0.Timestamp v) {
-    setField(6, v);
-  }
-
+  set verifyTime($0.Timestamp value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasVerifyTime() => $_has(5);
   @$pb.TagNumber(6)
-  void clearVerifyTime() => clearField(6);
+  void clearVerifyTime() => $_clearField(6);
   @$pb.TagNumber(6)
   $0.Timestamp ensureVerifyTime() => $_ensure(5);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the user's account was disabled/banned.
   @$pb.TagNumber(7)
   $0.Timestamp get disableTime => $_getN(6);
   @$pb.TagNumber(7)
-  set disableTime($0.Timestamp v) {
-    setField(7, v);
-  }
-
+  set disableTime($0.Timestamp value) => $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasDisableTime() => $_has(6);
   @$pb.TagNumber(7)
-  void clearDisableTime() => clearField(7);
+  void clearDisableTime() => $_clearField(7);
   @$pb.TagNumber(7)
   $0.Timestamp ensureDisableTime() => $_ensure(6);
 }
 
+/// Obtain a new authentication token using a refresh token.
 class AccountRefresh extends $pb.GeneratedMessage {
+  factory AccountRefresh({
+    $core.String? token,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (token != null) result.token = token;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountRefresh._();
+
+  factory AccountRefresh.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountRefresh.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountRefresh',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountRefresh',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'token')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountRefresh.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountRefresh._() : super();
-  factory AccountRefresh({
-    $core.String? token,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (token != null) {
-      _result.token = token;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountRefresh.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountRefresh.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountRefresh clone() => AccountRefresh()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountRefresh clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountRefresh copyWith(void Function(AccountRefresh) updates) =>
       super.copyWith((message) => updates(message as AccountRefresh))
-          as AccountRefresh; // ignore: deprecated_member_use
+          as AccountRefresh;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountRefresh create() => AccountRefresh._();
+  @$core.override
   AccountRefresh createEmptyInstance() => create();
   static $pb.PbList<AccountRefresh> createRepeated() =>
       $pb.PbList<AccountRefresh>();
@@ -278,81 +214,67 @@ class AccountRefresh extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountRefresh>(create);
   static AccountRefresh? _defaultInstance;
 
+  /// Refresh token.
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) {
-    $_setString(0, v);
-  }
-
+  set token($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
-  void clearToken() => clearField(1);
+  void clearToken() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Send a Apple Sign In token to the server. Used with authenticate/link/unlink.
 class AccountApple extends $pb.GeneratedMessage {
+  factory AccountApple({
+    $core.String? token,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (token != null) result.token = token;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountApple._();
+
+  factory AccountApple.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountApple.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountApple',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountApple',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'token')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountApple.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountApple._() : super();
-  factory AccountApple({
-    $core.String? token,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (token != null) {
-      _result.token = token;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountApple.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountApple.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountApple clone() => AccountApple()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountApple clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountApple copyWith(void Function(AccountApple) updates) =>
       super.copyWith((message) => updates(message as AccountApple))
-          as AccountApple; // ignore: deprecated_member_use
+          as AccountApple;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountApple create() => AccountApple._();
+  @$core.override
   AccountApple createEmptyInstance() => create();
   static $pb.PbList<AccountApple> createRepeated() =>
       $pb.PbList<AccountApple>();
@@ -361,81 +283,67 @@ class AccountApple extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountApple>(create);
   static AccountApple? _defaultInstance;
 
+  /// The ID token received from Apple to validate.
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) {
-    $_setString(0, v);
-  }
-
+  set token($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
-  void clearToken() => clearField(1);
+  void clearToken() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Send a custom ID to the server. Used with authenticate/link/unlink.
 class AccountCustom extends $pb.GeneratedMessage {
+  factory AccountCustom({
+    $core.String? id,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (id != null) result.id = id;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountCustom._();
+
+  factory AccountCustom.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountCustom.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountCustom',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountCustom',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountCustom.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountCustom._() : super();
-  factory AccountCustom({
-    $core.String? id,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountCustom.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountCustom.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountCustom clone() => AccountCustom()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountCustom clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountCustom copyWith(void Function(AccountCustom) updates) =>
       super.copyWith((message) => updates(message as AccountCustom))
-          as AccountCustom; // ignore: deprecated_member_use
+          as AccountCustom;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountCustom create() => AccountCustom._();
+  @$core.override
   AccountCustom createEmptyInstance() => create();
   static $pb.PbList<AccountCustom> createRepeated() =>
       $pb.PbList<AccountCustom>();
@@ -444,81 +352,67 @@ class AccountCustom extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountCustom>(create);
   static AccountCustom? _defaultInstance;
 
+  /// A custom identifier.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Send a device to the server. Used with authenticate/link/unlink and user.
 class AccountDevice extends $pb.GeneratedMessage {
+  factory AccountDevice({
+    $core.String? id,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (id != null) result.id = id;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountDevice._();
+
+  factory AccountDevice.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountDevice.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountDevice',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountDevice',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountDevice.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountDevice._() : super();
-  factory AccountDevice({
-    $core.String? id,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountDevice.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountDevice.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountDevice clone() => AccountDevice()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountDevice clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountDevice copyWith(void Function(AccountDevice) updates) =>
       super.copyWith((message) => updates(message as AccountDevice))
-          as AccountDevice; // ignore: deprecated_member_use
+          as AccountDevice;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountDevice create() => AccountDevice._();
+  @$core.override
   AccountDevice createEmptyInstance() => create();
   static $pb.PbList<AccountDevice> createRepeated() =>
       $pb.PbList<AccountDevice>();
@@ -527,90 +421,70 @@ class AccountDevice extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountDevice>(create);
   static AccountDevice? _defaultInstance;
 
+  /// A device identifier. Should be obtained by a platform-specific device API.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Send an email with password to the server. Used with authenticate/link/unlink.
 class AccountEmail extends $pb.GeneratedMessage {
+  factory AccountEmail({
+    $core.String? email,
+    $core.String? password,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (email != null) result.email = email;
+    if (password != null) result.password = password;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountEmail._();
+
+  factory AccountEmail.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountEmail.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountEmail',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountEmail',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'email')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'password')
-    ..m<$core.String, $core.String>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'email')
+    ..aOS(2, _omitFieldNames ? '' : 'password')
+    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountEmail.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountEmail._() : super();
-  factory AccountEmail({
-    $core.String? email,
-    $core.String? password,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (email != null) {
-      _result.email = email;
-    }
-    if (password != null) {
-      _result.password = password;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountEmail.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountEmail.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountEmail clone() => AccountEmail()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountEmail clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountEmail copyWith(void Function(AccountEmail) updates) =>
       super.copyWith((message) => updates(message as AccountEmail))
-          as AccountEmail; // ignore: deprecated_member_use
+          as AccountEmail;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountEmail create() => AccountEmail._();
+  @$core.override
   AccountEmail createEmptyInstance() => create();
   static $pb.PbList<AccountEmail> createRepeated() =>
       $pb.PbList<AccountEmail>();
@@ -619,93 +493,77 @@ class AccountEmail extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountEmail>(create);
   static AccountEmail? _defaultInstance;
 
+  /// A valid RFC-5322 email address.
   @$pb.TagNumber(1)
   $core.String get email => $_getSZ(0);
   @$pb.TagNumber(1)
-  set email($core.String v) {
-    $_setString(0, v);
-  }
-
+  set email($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasEmail() => $_has(0);
   @$pb.TagNumber(1)
-  void clearEmail() => clearField(1);
+  void clearEmail() => $_clearField(1);
 
+  /// A password for the user account.
   @$pb.TagNumber(2)
   $core.String get password => $_getSZ(1);
   @$pb.TagNumber(2)
-  set password($core.String v) {
-    $_setString(1, v);
-  }
-
+  set password($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasPassword() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPassword() => clearField(2);
+  void clearPassword() => $_clearField(2);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(3)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(2);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(2);
 }
 
+/// Send a Facebook token to the server. Used with authenticate/link/unlink.
 class AccountFacebook extends $pb.GeneratedMessage {
+  factory AccountFacebook({
+    $core.String? token,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (token != null) result.token = token;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountFacebook._();
+
+  factory AccountFacebook.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountFacebook.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountFacebook',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountFacebook',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'token')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountFacebook.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountFacebook._() : super();
-  factory AccountFacebook({
-    $core.String? token,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (token != null) {
-      _result.token = token;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountFacebook.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountFacebook.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountFacebook clone() => AccountFacebook()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountFacebook clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountFacebook copyWith(void Function(AccountFacebook) updates) =>
       super.copyWith((message) => updates(message as AccountFacebook))
-          as AccountFacebook; // ignore: deprecated_member_use
+          as AccountFacebook;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountFacebook create() => AccountFacebook._();
+  @$core.override
   AccountFacebook createEmptyInstance() => create();
   static $pb.PbList<AccountFacebook> createRepeated() =>
       $pb.PbList<AccountFacebook>();
@@ -714,84 +572,69 @@ class AccountFacebook extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountFacebook>(create);
   static AccountFacebook? _defaultInstance;
 
+  /// The OAuth token received from Facebook to access their profile API.
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) {
-    $_setString(0, v);
-  }
-
+  set token($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
-  void clearToken() => clearField(1);
+  void clearToken() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Send a Facebook Instant Game token to the server. Used with authenticate/link/unlink.
 class AccountFacebookInstantGame extends $pb.GeneratedMessage {
+  factory AccountFacebookInstantGame({
+    $core.String? signedPlayerInfo,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (signedPlayerInfo != null) result.signedPlayerInfo = signedPlayerInfo;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountFacebookInstantGame._();
+
+  factory AccountFacebookInstantGame.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountFacebookInstantGame.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountFacebookInstantGame',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountFacebookInstantGame',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'signedPlayerInfo')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'signedPlayerInfo')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountFacebookInstantGame.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountFacebookInstantGame._() : super();
-  factory AccountFacebookInstantGame({
-    $core.String? signedPlayerInfo,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (signedPlayerInfo != null) {
-      _result.signedPlayerInfo = signedPlayerInfo;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountFacebookInstantGame.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountFacebookInstantGame.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountFacebookInstantGame clone() =>
-      AccountFacebookInstantGame()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountFacebookInstantGame clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountFacebookInstantGame copyWith(
           void Function(AccountFacebookInstantGame) updates) =>
       super.copyWith(
               (message) => updates(message as AccountFacebookInstantGame))
-          as AccountFacebookInstantGame; // ignore: deprecated_member_use
+          as AccountFacebookInstantGame;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountFacebookInstantGame create() => AccountFacebookInstantGame._();
+  @$core.override
   AccountFacebookInstantGame createEmptyInstance() => create();
   static $pb.PbList<AccountFacebookInstantGame> createRepeated() =>
       $pb.PbList<AccountFacebookInstantGame>();
@@ -800,74 +643,23 @@ class AccountFacebookInstantGame extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountFacebookInstantGame>(create);
   static AccountFacebookInstantGame? _defaultInstance;
 
+  /// The OAuth token received from a Facebook Instant Game that may be decoded with the Application Secret (must be available with the nakama configuration)
   @$pb.TagNumber(1)
   $core.String get signedPlayerInfo => $_getSZ(0);
   @$pb.TagNumber(1)
-  set signedPlayerInfo($core.String v) {
-    $_setString(0, v);
-  }
-
+  set signedPlayerInfo($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasSignedPlayerInfo() => $_has(0);
   @$pb.TagNumber(1)
-  void clearSignedPlayerInfo() => clearField(1);
+  void clearSignedPlayerInfo() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Send Apple's Game Center account credentials to the server. Used with authenticate/link/unlink.
 class AccountGameCenter extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountGameCenter',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'playerId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'bundleId')
-    ..aInt64(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'timestampSeconds')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'salt')
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'signature')
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'publicKeyUrl')
-    ..m<$core.String, $core.String>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
-        entryClassName: 'AccountGameCenter.VarsEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
-        packageName: const $pb.PackageName('nakama.api'))
-    ..hasRequiredFields = false;
-
-  AccountGameCenter._() : super();
   factory AccountGameCenter({
     $core.String? playerId,
     $core.String? bundleId,
@@ -875,51 +667,58 @@ class AccountGameCenter extends $pb.GeneratedMessage {
     $core.String? salt,
     $core.String? signature,
     $core.String? publicKeyUrl,
-    $core.Map<$core.String, $core.String>? vars,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
   }) {
-    final _result = create();
-    if (playerId != null) {
-      _result.playerId = playerId;
-    }
-    if (bundleId != null) {
-      _result.bundleId = bundleId;
-    }
-    if (timestampSeconds != null) {
-      _result.timestampSeconds = timestampSeconds;
-    }
-    if (salt != null) {
-      _result.salt = salt;
-    }
-    if (signature != null) {
-      _result.signature = signature;
-    }
-    if (publicKeyUrl != null) {
-      _result.publicKeyUrl = publicKeyUrl;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
+    final result = create();
+    if (playerId != null) result.playerId = playerId;
+    if (bundleId != null) result.bundleId = bundleId;
+    if (timestampSeconds != null) result.timestampSeconds = timestampSeconds;
+    if (salt != null) result.salt = salt;
+    if (signature != null) result.signature = signature;
+    if (publicKeyUrl != null) result.publicKeyUrl = publicKeyUrl;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
   }
-  factory AccountGameCenter.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountGameCenter.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountGameCenter clone() => AccountGameCenter()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AccountGameCenter._();
+
+  factory AccountGameCenter.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountGameCenter.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AccountGameCenter',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'playerId')
+    ..aOS(2, _omitFieldNames ? '' : 'bundleId')
+    ..aInt64(3, _omitFieldNames ? '' : 'timestampSeconds')
+    ..aOS(4, _omitFieldNames ? '' : 'salt')
+    ..aOS(5, _omitFieldNames ? '' : 'signature')
+    ..aOS(6, _omitFieldNames ? '' : 'publicKeyUrl')
+    ..m<$core.String, $core.String>(7, _omitFieldNames ? '' : 'vars',
+        entryClassName: 'AccountGameCenter.VarsEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OS,
+        packageName: const $pb.PackageName('nakama.api'))
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountGameCenter clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountGameCenter copyWith(void Function(AccountGameCenter) updates) =>
       super.copyWith((message) => updates(message as AccountGameCenter))
-          as AccountGameCenter; // ignore: deprecated_member_use
+          as AccountGameCenter;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountGameCenter create() => AccountGameCenter._();
+  @$core.override
   AccountGameCenter createEmptyInstance() => create();
   static $pb.PbList<AccountGameCenter> createRepeated() =>
       $pb.PbList<AccountGameCenter>();
@@ -928,141 +727,117 @@ class AccountGameCenter extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountGameCenter>(create);
   static AccountGameCenter? _defaultInstance;
 
+  /// Player ID (generated by GameCenter).
   @$pb.TagNumber(1)
   $core.String get playerId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set playerId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set playerId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPlayerId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPlayerId() => clearField(1);
+  void clearPlayerId() => $_clearField(1);
 
+  /// Bundle ID (generated by GameCenter).
   @$pb.TagNumber(2)
   $core.String get bundleId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set bundleId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set bundleId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasBundleId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearBundleId() => clearField(2);
+  void clearBundleId() => $_clearField(2);
 
+  /// Time since UNIX epoch when the signature was created.
   @$pb.TagNumber(3)
   $fixnum.Int64 get timestampSeconds => $_getI64(2);
   @$pb.TagNumber(3)
-  set timestampSeconds($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set timestampSeconds($fixnum.Int64 value) => $_setInt64(2, value);
   @$pb.TagNumber(3)
   $core.bool hasTimestampSeconds() => $_has(2);
   @$pb.TagNumber(3)
-  void clearTimestampSeconds() => clearField(3);
+  void clearTimestampSeconds() => $_clearField(3);
 
+  /// A random "NSString" used to compute the hash and keep it randomized.
   @$pb.TagNumber(4)
   $core.String get salt => $_getSZ(3);
   @$pb.TagNumber(4)
-  set salt($core.String v) {
-    $_setString(3, v);
-  }
-
+  set salt($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasSalt() => $_has(3);
   @$pb.TagNumber(4)
-  void clearSalt() => clearField(4);
+  void clearSalt() => $_clearField(4);
 
+  /// The verification signature data generated.
   @$pb.TagNumber(5)
   $core.String get signature => $_getSZ(4);
   @$pb.TagNumber(5)
-  set signature($core.String v) {
-    $_setString(4, v);
-  }
-
+  set signature($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasSignature() => $_has(4);
   @$pb.TagNumber(5)
-  void clearSignature() => clearField(5);
+  void clearSignature() => $_clearField(5);
 
+  /// The URL for the public encryption key.
   @$pb.TagNumber(6)
   $core.String get publicKeyUrl => $_getSZ(5);
   @$pb.TagNumber(6)
-  set publicKeyUrl($core.String v) {
-    $_setString(5, v);
-  }
-
+  set publicKeyUrl($core.String value) => $_setString(5, value);
   @$pb.TagNumber(6)
   $core.bool hasPublicKeyUrl() => $_has(5);
   @$pb.TagNumber(6)
-  void clearPublicKeyUrl() => clearField(6);
+  void clearPublicKeyUrl() => $_clearField(6);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(7)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(6);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(6);
 }
 
+/// Send a Google token to the server. Used with authenticate/link/unlink.
 class AccountGoogle extends $pb.GeneratedMessage {
+  factory AccountGoogle({
+    $core.String? token,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (token != null) result.token = token;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountGoogle._();
+
+  factory AccountGoogle.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountGoogle.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountGoogle',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountGoogle',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'token')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountGoogle.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountGoogle._() : super();
-  factory AccountGoogle({
-    $core.String? token,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (token != null) {
-      _result.token = token;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountGoogle.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountGoogle.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountGoogle clone() => AccountGoogle()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountGoogle clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountGoogle copyWith(void Function(AccountGoogle) updates) =>
       super.copyWith((message) => updates(message as AccountGoogle))
-          as AccountGoogle; // ignore: deprecated_member_use
+          as AccountGoogle;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountGoogle create() => AccountGoogle._();
+  @$core.override
   AccountGoogle createEmptyInstance() => create();
   static $pb.PbList<AccountGoogle> createRepeated() =>
       $pb.PbList<AccountGoogle>();
@@ -1071,81 +846,67 @@ class AccountGoogle extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountGoogle>(create);
   static AccountGoogle? _defaultInstance;
 
+  /// The OAuth token received from Google to access their profile API.
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) {
-    $_setString(0, v);
-  }
-
+  set token($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
-  void clearToken() => clearField(1);
+  void clearToken() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Send a Steam token to the server. Used with authenticate/link/unlink.
 class AccountSteam extends $pb.GeneratedMessage {
+  factory AccountSteam({
+    $core.String? token,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (token != null) result.token = token;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  AccountSteam._();
+
+  factory AccountSteam.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AccountSteam.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AccountSteam',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'AccountSteam',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'token')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'AccountSteam.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  AccountSteam._() : super();
-  factory AccountSteam({
-    $core.String? token,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (token != null) {
-      _result.token = token;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory AccountSteam.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AccountSteam.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AccountSteam clone() => AccountSteam()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AccountSteam clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AccountSteam copyWith(void Function(AccountSteam) updates) =>
       super.copyWith((message) => updates(message as AccountSteam))
-          as AccountSteam; // ignore: deprecated_member_use
+          as AccountSteam;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AccountSteam create() => AccountSteam._();
+  @$core.override
   AccountSteam createEmptyInstance() => create();
   static $pb.PbList<AccountSteam> createRepeated() =>
       $pb.PbList<AccountSteam>();
@@ -1154,77 +915,66 @@ class AccountSteam extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AccountSteam>(create);
   static AccountSteam? _defaultInstance;
 
+  /// The account token received from Steam to access their profile API.
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) {
-    $_setString(0, v);
-  }
-
+  set token($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
-  void clearToken() => clearField(1);
+  void clearToken() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Add one or more friends to the current user.
 class AddFriendsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AddFriendsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pPS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ids')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'usernames')
-    ..hasRequiredFields = false;
-
-  AddFriendsRequest._() : super();
   factory AddFriendsRequest({
     $core.Iterable<$core.String>? ids,
     $core.Iterable<$core.String>? usernames,
+    $core.String? metadata,
   }) {
-    final _result = create();
-    if (ids != null) {
-      _result.ids.addAll(ids);
-    }
-    if (usernames != null) {
-      _result.usernames.addAll(usernames);
-    }
-    return _result;
+    final result = create();
+    if (ids != null) result.ids.addAll(ids);
+    if (usernames != null) result.usernames.addAll(usernames);
+    if (metadata != null) result.metadata = metadata;
+    return result;
   }
-  factory AddFriendsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AddFriendsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AddFriendsRequest clone() => AddFriendsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AddFriendsRequest._();
+
+  factory AddFriendsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AddFriendsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AddFriendsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'ids')
+    ..pPS(2, _omitFieldNames ? '' : 'usernames')
+    ..aOS(3, _omitFieldNames ? '' : 'metadata')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AddFriendsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AddFriendsRequest copyWith(void Function(AddFriendsRequest) updates) =>
       super.copyWith((message) => updates(message as AddFriendsRequest))
-          as AddFriendsRequest; // ignore: deprecated_member_use
+          as AddFriendsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AddFriendsRequest create() => AddFriendsRequest._();
+  @$core.override
   AddFriendsRequest createEmptyInstance() => create();
   static $pb.PbList<AddFriendsRequest> createRepeated() =>
       $pb.PbList<AddFriendsRequest>();
@@ -1233,69 +983,67 @@ class AddFriendsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AddFriendsRequest>(create);
   static AddFriendsRequest? _defaultInstance;
 
+  /// The account id of a user.
   @$pb.TagNumber(1)
-  $core.List<$core.String> get ids => $_getList(0);
+  $pb.PbList<$core.String> get ids => $_getList(0);
 
+  /// The account username of a user.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get usernames => $_getList(1);
+  $pb.PbList<$core.String> get usernames => $_getList(1);
+
+  /// Optional metadata to add to friends.
+  @$pb.TagNumber(3)
+  $core.String get metadata => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set metadata($core.String value) => $_setString(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasMetadata() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearMetadata() => $_clearField(3);
 }
 
+/// Add users to a group.
 class AddGroupUsersRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AddGroupUsersRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIds')
-    ..hasRequiredFields = false;
-
-  AddGroupUsersRequest._() : super();
   factory AddGroupUsersRequest({
     $core.String? groupId,
     $core.Iterable<$core.String>? userIds,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIds != null) {
-      _result.userIds.addAll(userIds);
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    if (userIds != null) result.userIds.addAll(userIds);
+    return result;
   }
-  factory AddGroupUsersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AddGroupUsersRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AddGroupUsersRequest clone() =>
-      AddGroupUsersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AddGroupUsersRequest._();
+
+  factory AddGroupUsersRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AddGroupUsersRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AddGroupUsersRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..pPS(2, _omitFieldNames ? '' : 'userIds')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AddGroupUsersRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AddGroupUsersRequest copyWith(void Function(AddGroupUsersRequest) updates) =>
       super.copyWith((message) => updates(message as AddGroupUsersRequest))
-          as AddGroupUsersRequest; // ignore: deprecated_member_use
+          as AddGroupUsersRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AddGroupUsersRequest create() => AddGroupUsersRequest._();
+  @$core.override
   AddGroupUsersRequest createEmptyInstance() => create();
   static $pb.PbList<AddGroupUsersRequest> createRepeated() =>
       $pb.PbList<AddGroupUsersRequest>();
@@ -1304,83 +1052,68 @@ class AddGroupUsersRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AddGroupUsersRequest>(create);
   static AddGroupUsersRequest? _defaultInstance;
 
+  /// The group to add users to.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 
+  /// The users to add.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get userIds => $_getList(1);
+  $pb.PbList<$core.String> get userIds => $_getList(1);
 }
 
+/// Authenticate against the server with a refresh token.
 class SessionRefreshRequest extends $pb.GeneratedMessage {
+  factory SessionRefreshRequest({
+    $core.String? token,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? vars,
+  }) {
+    final result = create();
+    if (token != null) result.token = token;
+    if (vars != null) result.vars.addEntries(vars);
+    return result;
+  }
+
+  SessionRefreshRequest._();
+
+  factory SessionRefreshRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory SessionRefreshRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'SessionRefreshRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'SessionRefreshRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'vars',
+    ..aOS(1, _omitFieldNames ? '' : 'token')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'vars',
         entryClassName: 'SessionRefreshRequest.VarsEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
     ..hasRequiredFields = false;
 
-  SessionRefreshRequest._() : super();
-  factory SessionRefreshRequest({
-    $core.String? token,
-    $core.Map<$core.String, $core.String>? vars,
-  }) {
-    final _result = create();
-    if (token != null) {
-      _result.token = token;
-    }
-    if (vars != null) {
-      _result.vars.addAll(vars);
-    }
-    return _result;
-  }
-  factory SessionRefreshRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SessionRefreshRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  SessionRefreshRequest clone() =>
-      SessionRefreshRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  SessionRefreshRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   SessionRefreshRequest copyWith(
           void Function(SessionRefreshRequest) updates) =>
       super.copyWith((message) => updates(message as SessionRefreshRequest))
-          as SessionRefreshRequest; // ignore: deprecated_member_use
+          as SessionRefreshRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static SessionRefreshRequest create() => SessionRefreshRequest._();
+  @$core.override
   SessionRefreshRequest createEmptyInstance() => create();
   static $pb.PbList<SessionRefreshRequest> createRepeated() =>
       $pb.PbList<SessionRefreshRequest>();
@@ -1389,78 +1122,63 @@ class SessionRefreshRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SessionRefreshRequest>(create);
   static SessionRefreshRequest? _defaultInstance;
 
+  /// Refresh token.
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) {
-    $_setString(0, v);
-  }
-
+  set token($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
-  void clearToken() => clearField(1);
+  void clearToken() => $_clearField(1);
 
+  /// Extra information that will be bundled in the session token.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get vars => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get vars => $_getMap(1);
 }
 
+/// Log out a session, invalidate a refresh token, or log out all sessions/refresh tokens for a user.
 class SessionLogoutRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'SessionLogoutRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'refreshToken')
-    ..hasRequiredFields = false;
-
-  SessionLogoutRequest._() : super();
   factory SessionLogoutRequest({
     $core.String? token,
     $core.String? refreshToken,
   }) {
-    final _result = create();
-    if (token != null) {
-      _result.token = token;
-    }
-    if (refreshToken != null) {
-      _result.refreshToken = refreshToken;
-    }
-    return _result;
+    final result = create();
+    if (token != null) result.token = token;
+    if (refreshToken != null) result.refreshToken = refreshToken;
+    return result;
   }
-  factory SessionLogoutRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SessionLogoutRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  SessionLogoutRequest clone() =>
-      SessionLogoutRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  SessionLogoutRequest._();
+
+  factory SessionLogoutRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory SessionLogoutRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'SessionLogoutRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'token')
+    ..aOS(2, _omitFieldNames ? '' : 'refreshToken')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  SessionLogoutRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   SessionLogoutRequest copyWith(void Function(SessionLogoutRequest) updates) =>
       super.copyWith((message) => updates(message as SessionLogoutRequest))
-          as SessionLogoutRequest; // ignore: deprecated_member_use
+          as SessionLogoutRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static SessionLogoutRequest create() => SessionLogoutRequest._();
+  @$core.override
   SessionLogoutRequest createEmptyInstance() => create();
   static $pb.PbList<SessionLogoutRequest> createRepeated() =>
       $pb.PbList<SessionLogoutRequest>();
@@ -1469,99 +1187,75 @@ class SessionLogoutRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SessionLogoutRequest>(create);
   static SessionLogoutRequest? _defaultInstance;
 
+  /// Session token to log out.
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) {
-    $_setString(0, v);
-  }
-
+  set token($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
-  void clearToken() => clearField(1);
+  void clearToken() => $_clearField(1);
 
+  /// Refresh token to invalidate.
   @$pb.TagNumber(2)
   $core.String get refreshToken => $_getSZ(1);
   @$pb.TagNumber(2)
-  set refreshToken($core.String v) {
-    $_setString(1, v);
-  }
-
+  set refreshToken($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasRefreshToken() => $_has(1);
   @$pb.TagNumber(2)
-  void clearRefreshToken() => clearField(2);
+  void clearRefreshToken() => $_clearField(2);
 }
 
+/// Authenticate against the server with Apple Sign In.
 class AuthenticateAppleRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateAppleRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountApple>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountApple.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..hasRequiredFields = false;
-
-  AuthenticateAppleRequest._() : super();
   factory AuthenticateAppleRequest({
     AccountApple? account,
     $1.BoolValue? create_2,
     $core.String? username,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    return result;
   }
-  factory AuthenticateAppleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateAppleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateAppleRequest clone() =>
-      AuthenticateAppleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AuthenticateAppleRequest._();
+
+  factory AuthenticateAppleRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateAppleRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateAppleRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountApple>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountApple.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateAppleRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateAppleRequest copyWith(
           void Function(AuthenticateAppleRequest) updates) =>
       super.copyWith((message) => updates(message as AuthenticateAppleRequest))
-          as AuthenticateAppleRequest; // ignore: deprecated_member_use
+          as AuthenticateAppleRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateAppleRequest create() => AuthenticateAppleRequest._();
+  @$core.override
   AuthenticateAppleRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateAppleRequest> createRepeated() =>
       $pb.PbList<AuthenticateAppleRequest>();
@@ -1570,115 +1264,89 @@ class AuthenticateAppleRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AuthenticateAppleRequest>(create);
   static AuthenticateAppleRequest? _defaultInstance;
 
+  /// The Apple account details.
   @$pb.TagNumber(1)
   AccountApple get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountApple v) {
-    setField(1, v);
-  }
-
+  set account(AccountApple value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountApple ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 }
 
+/// Authenticate against the server with a custom ID.
 class AuthenticateCustomRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateCustomRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountCustom>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountCustom.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..hasRequiredFields = false;
-
-  AuthenticateCustomRequest._() : super();
   factory AuthenticateCustomRequest({
     AccountCustom? account,
     $1.BoolValue? create_2,
     $core.String? username,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    return result;
   }
-  factory AuthenticateCustomRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateCustomRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateCustomRequest clone() =>
-      AuthenticateCustomRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AuthenticateCustomRequest._();
+
+  factory AuthenticateCustomRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateCustomRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateCustomRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountCustom>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountCustom.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateCustomRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateCustomRequest copyWith(
           void Function(AuthenticateCustomRequest) updates) =>
       super.copyWith((message) => updates(message as AuthenticateCustomRequest))
-          as AuthenticateCustomRequest; // ignore: deprecated_member_use
+          as AuthenticateCustomRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateCustomRequest create() => AuthenticateCustomRequest._();
+  @$core.override
   AuthenticateCustomRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateCustomRequest> createRepeated() =>
       $pb.PbList<AuthenticateCustomRequest>();
@@ -1687,115 +1355,89 @@ class AuthenticateCustomRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AuthenticateCustomRequest>(create);
   static AuthenticateCustomRequest? _defaultInstance;
 
+  /// The custom account details.
   @$pb.TagNumber(1)
   AccountCustom get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountCustom v) {
-    setField(1, v);
-  }
-
+  set account(AccountCustom value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountCustom ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 }
 
+/// Authenticate against the server with a device ID.
 class AuthenticateDeviceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateDeviceRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountDevice>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountDevice.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..hasRequiredFields = false;
-
-  AuthenticateDeviceRequest._() : super();
   factory AuthenticateDeviceRequest({
     AccountDevice? account,
     $1.BoolValue? create_2,
     $core.String? username,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    return result;
   }
-  factory AuthenticateDeviceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateDeviceRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateDeviceRequest clone() =>
-      AuthenticateDeviceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AuthenticateDeviceRequest._();
+
+  factory AuthenticateDeviceRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateDeviceRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateDeviceRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountDevice>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountDevice.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateDeviceRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateDeviceRequest copyWith(
           void Function(AuthenticateDeviceRequest) updates) =>
       super.copyWith((message) => updates(message as AuthenticateDeviceRequest))
-          as AuthenticateDeviceRequest; // ignore: deprecated_member_use
+          as AuthenticateDeviceRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateDeviceRequest create() => AuthenticateDeviceRequest._();
+  @$core.override
   AuthenticateDeviceRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateDeviceRequest> createRepeated() =>
       $pb.PbList<AuthenticateDeviceRequest>();
@@ -1804,115 +1446,89 @@ class AuthenticateDeviceRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AuthenticateDeviceRequest>(create);
   static AuthenticateDeviceRequest? _defaultInstance;
 
+  /// The device account details.
   @$pb.TagNumber(1)
   AccountDevice get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountDevice v) {
-    setField(1, v);
-  }
-
+  set account(AccountDevice value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountDevice ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 }
 
+/// Authenticate against the server with email+password.
 class AuthenticateEmailRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateEmailRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountEmail>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountEmail.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..hasRequiredFields = false;
-
-  AuthenticateEmailRequest._() : super();
   factory AuthenticateEmailRequest({
     AccountEmail? account,
     $1.BoolValue? create_2,
     $core.String? username,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    return result;
   }
-  factory AuthenticateEmailRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateEmailRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateEmailRequest clone() =>
-      AuthenticateEmailRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AuthenticateEmailRequest._();
+
+  factory AuthenticateEmailRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateEmailRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateEmailRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountEmail>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountEmail.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateEmailRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateEmailRequest copyWith(
           void Function(AuthenticateEmailRequest) updates) =>
       super.copyWith((message) => updates(message as AuthenticateEmailRequest))
-          as AuthenticateEmailRequest; // ignore: deprecated_member_use
+          as AuthenticateEmailRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateEmailRequest create() => AuthenticateEmailRequest._();
+  @$core.override
   AuthenticateEmailRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateEmailRequest> createRepeated() =>
       $pb.PbList<AuthenticateEmailRequest>();
@@ -1921,127 +1537,95 @@ class AuthenticateEmailRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AuthenticateEmailRequest>(create);
   static AuthenticateEmailRequest? _defaultInstance;
 
+  /// The email account details.
   @$pb.TagNumber(1)
   AccountEmail get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountEmail v) {
-    setField(1, v);
-  }
-
+  set account(AccountEmail value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountEmail ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 }
 
+/// Authenticate against the server with Facebook.
 class AuthenticateFacebookRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateFacebookRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountFacebook>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountFacebook.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..aOM<$1.BoolValue>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sync',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  AuthenticateFacebookRequest._() : super();
   factory AuthenticateFacebookRequest({
     AccountFacebook? account,
     $1.BoolValue? create_2,
     $core.String? username,
     $1.BoolValue? sync,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    if (sync != null) {
-      _result.sync = sync;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    if (sync != null) result.sync = sync;
+    return result;
   }
-  factory AuthenticateFacebookRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateFacebookRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateFacebookRequest clone() =>
-      AuthenticateFacebookRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AuthenticateFacebookRequest._();
+
+  factory AuthenticateFacebookRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateFacebookRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateFacebookRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountFacebook>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountFacebook.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..aOM<$1.BoolValue>(4, _omitFieldNames ? '' : 'sync',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateFacebookRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateFacebookRequest copyWith(
           void Function(AuthenticateFacebookRequest) updates) =>
       super.copyWith(
               (message) => updates(message as AuthenticateFacebookRequest))
-          as AuthenticateFacebookRequest; // ignore: deprecated_member_use
+          as AuthenticateFacebookRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateFacebookRequest create() =>
       AuthenticateFacebookRequest._();
+  @$core.override
   AuthenticateFacebookRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateFacebookRequest> createRepeated() =>
       $pb.PbList<AuthenticateFacebookRequest>();
@@ -2050,132 +1634,104 @@ class AuthenticateFacebookRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AuthenticateFacebookRequest>(create);
   static AuthenticateFacebookRequest? _defaultInstance;
 
+  /// The Facebook account details.
   @$pb.TagNumber(1)
   AccountFacebook get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountFacebook v) {
-    setField(1, v);
-  }
-
+  set account(AccountFacebook value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountFacebook ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 
+  /// Import Facebook friends for the user.
   @$pb.TagNumber(4)
   $1.BoolValue get sync => $_getN(3);
   @$pb.TagNumber(4)
-  set sync($1.BoolValue v) {
-    setField(4, v);
-  }
-
+  set sync($1.BoolValue value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasSync() => $_has(3);
   @$pb.TagNumber(4)
-  void clearSync() => clearField(4);
+  void clearSync() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.BoolValue ensureSync() => $_ensure(3);
 }
 
+/// Authenticate against the server with Facebook Instant Game token.
 class AuthenticateFacebookInstantGameRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateFacebookInstantGameRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountFacebookInstantGame>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountFacebookInstantGame.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..hasRequiredFields = false;
-
-  AuthenticateFacebookInstantGameRequest._() : super();
   factory AuthenticateFacebookInstantGameRequest({
     AccountFacebookInstantGame? account,
     $1.BoolValue? create_2,
     $core.String? username,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    return result;
   }
+
+  AuthenticateFacebookInstantGameRequest._();
+
   factory AuthenticateFacebookInstantGameRequest.fromBuffer(
-          $core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateFacebookInstantGameRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateFacebookInstantGameRequest clone() =>
-      AuthenticateFacebookInstantGameRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateFacebookInstantGameRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateFacebookInstantGameRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountFacebookInstantGame>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountFacebookInstantGame.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateFacebookInstantGameRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateFacebookInstantGameRequest copyWith(
           void Function(AuthenticateFacebookInstantGameRequest) updates) =>
       super.copyWith((message) =>
               updates(message as AuthenticateFacebookInstantGameRequest))
-          as AuthenticateFacebookInstantGameRequest; // ignore: deprecated_member_use
+          as AuthenticateFacebookInstantGameRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateFacebookInstantGameRequest create() =>
       AuthenticateFacebookInstantGameRequest._();
+  @$core.override
   AuthenticateFacebookInstantGameRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateFacebookInstantGameRequest> createRepeated() =>
       $pb.PbList<AuthenticateFacebookInstantGameRequest>();
@@ -2185,117 +1741,91 @@ class AuthenticateFacebookInstantGameRequest extends $pb.GeneratedMessage {
           AuthenticateFacebookInstantGameRequest>(create);
   static AuthenticateFacebookInstantGameRequest? _defaultInstance;
 
+  /// The Facebook Instant Game account details.
   @$pb.TagNumber(1)
   AccountFacebookInstantGame get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountFacebookInstantGame v) {
-    setField(1, v);
-  }
-
+  set account(AccountFacebookInstantGame value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountFacebookInstantGame ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 }
 
+/// Authenticate against the server with Apple's Game Center.
 class AuthenticateGameCenterRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateGameCenterRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountGameCenter>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountGameCenter.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..hasRequiredFields = false;
-
-  AuthenticateGameCenterRequest._() : super();
   factory AuthenticateGameCenterRequest({
     AccountGameCenter? account,
     $1.BoolValue? create_2,
     $core.String? username,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    return result;
   }
-  factory AuthenticateGameCenterRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateGameCenterRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateGameCenterRequest clone() =>
-      AuthenticateGameCenterRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AuthenticateGameCenterRequest._();
+
+  factory AuthenticateGameCenterRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateGameCenterRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateGameCenterRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountGameCenter>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountGameCenter.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateGameCenterRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateGameCenterRequest copyWith(
           void Function(AuthenticateGameCenterRequest) updates) =>
       super.copyWith(
               (message) => updates(message as AuthenticateGameCenterRequest))
-          as AuthenticateGameCenterRequest; // ignore: deprecated_member_use
+          as AuthenticateGameCenterRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateGameCenterRequest create() =>
       AuthenticateGameCenterRequest._();
+  @$core.override
   AuthenticateGameCenterRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateGameCenterRequest> createRepeated() =>
       $pb.PbList<AuthenticateGameCenterRequest>();
@@ -2304,115 +1834,89 @@ class AuthenticateGameCenterRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AuthenticateGameCenterRequest>(create);
   static AuthenticateGameCenterRequest? _defaultInstance;
 
+  /// The Game Center account details.
   @$pb.TagNumber(1)
   AccountGameCenter get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountGameCenter v) {
-    setField(1, v);
-  }
-
+  set account(AccountGameCenter value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountGameCenter ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 }
 
+/// Authenticate against the server with Google.
 class AuthenticateGoogleRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateGoogleRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountGoogle>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountGoogle.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..hasRequiredFields = false;
-
-  AuthenticateGoogleRequest._() : super();
   factory AuthenticateGoogleRequest({
     AccountGoogle? account,
     $1.BoolValue? create_2,
     $core.String? username,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    return result;
   }
-  factory AuthenticateGoogleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateGoogleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateGoogleRequest clone() =>
-      AuthenticateGoogleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AuthenticateGoogleRequest._();
+
+  factory AuthenticateGoogleRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateGoogleRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateGoogleRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountGoogle>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountGoogle.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateGoogleRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateGoogleRequest copyWith(
           void Function(AuthenticateGoogleRequest) updates) =>
       super.copyWith((message) => updates(message as AuthenticateGoogleRequest))
-          as AuthenticateGoogleRequest; // ignore: deprecated_member_use
+          as AuthenticateGoogleRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateGoogleRequest create() => AuthenticateGoogleRequest._();
+  @$core.override
   AuthenticateGoogleRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateGoogleRequest> createRepeated() =>
       $pb.PbList<AuthenticateGoogleRequest>();
@@ -2421,125 +1925,93 @@ class AuthenticateGoogleRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AuthenticateGoogleRequest>(create);
   static AuthenticateGoogleRequest? _defaultInstance;
 
+  /// The Google account details.
   @$pb.TagNumber(1)
   AccountGoogle get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountGoogle v) {
-    setField(1, v);
-  }
-
+  set account(AccountGoogle value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountGoogle ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 }
 
+/// Authenticate against the server with Steam.
 class AuthenticateSteamRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'AuthenticateSteamRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountSteam>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountSteam.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'create',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..aOM<$1.BoolValue>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sync',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  AuthenticateSteamRequest._() : super();
   factory AuthenticateSteamRequest({
     AccountSteam? account,
     $1.BoolValue? create_2,
     $core.String? username,
     $1.BoolValue? sync,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (create_2 != null) {
-      _result.create_2 = create_2;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    if (sync != null) {
-      _result.sync = sync;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (create_2 != null) result.create_2 = create_2;
+    if (username != null) result.username = username;
+    if (sync != null) result.sync = sync;
+    return result;
   }
-  factory AuthenticateSteamRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AuthenticateSteamRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  AuthenticateSteamRequest clone() =>
-      AuthenticateSteamRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  AuthenticateSteamRequest._();
+
+  factory AuthenticateSteamRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AuthenticateSteamRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AuthenticateSteamRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountSteam>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountSteam.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'create',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..aOM<$1.BoolValue>(4, _omitFieldNames ? '' : 'sync',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AuthenticateSteamRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   AuthenticateSteamRequest copyWith(
           void Function(AuthenticateSteamRequest) updates) =>
       super.copyWith((message) => updates(message as AuthenticateSteamRequest))
-          as AuthenticateSteamRequest; // ignore: deprecated_member_use
+          as AuthenticateSteamRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AuthenticateSteamRequest create() => AuthenticateSteamRequest._();
+  @$core.override
   AuthenticateSteamRequest createEmptyInstance() => create();
   static $pb.PbList<AuthenticateSteamRequest> createRepeated() =>
       $pb.PbList<AuthenticateSteamRequest>();
@@ -2548,117 +2020,95 @@ class AuthenticateSteamRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<AuthenticateSteamRequest>(create);
   static AuthenticateSteamRequest? _defaultInstance;
 
+  /// The Steam account details.
   @$pb.TagNumber(1)
   AccountSteam get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountSteam v) {
-    setField(1, v);
-  }
-
+  set account(AccountSteam value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountSteam ensureAccount() => $_ensure(0);
 
+  /// Register the account if the user does not already exist.
   @$pb.TagNumber(2)
   $1.BoolValue get create_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set create_2($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set create_2($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCreate_2() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreate_2() => clearField(2);
+  void clearCreate_2() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureCreate_2() => $_ensure(1);
 
+  /// Set the username on the account at register. Must be unique.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 
+  /// Import Steam friends for the user.
   @$pb.TagNumber(4)
   $1.BoolValue get sync => $_getN(3);
   @$pb.TagNumber(4)
-  set sync($1.BoolValue v) {
-    setField(4, v);
-  }
-
+  set sync($1.BoolValue value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasSync() => $_has(3);
   @$pb.TagNumber(4)
-  void clearSync() => clearField(4);
+  void clearSync() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.BoolValue ensureSync() => $_ensure(3);
 }
 
+/// Ban users from a group.
 class BanGroupUsersRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'BanGroupUsersRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIds')
-    ..hasRequiredFields = false;
-
-  BanGroupUsersRequest._() : super();
   factory BanGroupUsersRequest({
     $core.String? groupId,
     $core.Iterable<$core.String>? userIds,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIds != null) {
-      _result.userIds.addAll(userIds);
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    if (userIds != null) result.userIds.addAll(userIds);
+    return result;
   }
-  factory BanGroupUsersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BanGroupUsersRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  BanGroupUsersRequest clone() =>
-      BanGroupUsersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  BanGroupUsersRequest._();
+
+  factory BanGroupUsersRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory BanGroupUsersRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'BanGroupUsersRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..pPS(2, _omitFieldNames ? '' : 'userIds')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  BanGroupUsersRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   BanGroupUsersRequest copyWith(void Function(BanGroupUsersRequest) updates) =>
       super.copyWith((message) => updates(message as BanGroupUsersRequest))
-          as BanGroupUsersRequest; // ignore: deprecated_member_use
+          as BanGroupUsersRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static BanGroupUsersRequest create() => BanGroupUsersRequest._();
+  @$core.override
   BanGroupUsersRequest createEmptyInstance() => create();
   static $pb.PbList<BanGroupUsersRequest> createRepeated() =>
       $pb.PbList<BanGroupUsersRequest>();
@@ -2667,77 +2117,63 @@ class BanGroupUsersRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<BanGroupUsersRequest>(create);
   static BanGroupUsersRequest? _defaultInstance;
 
+  /// The group to ban users from.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 
+  /// The users to ban.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get userIds => $_getList(1);
+  $pb.PbList<$core.String> get userIds => $_getList(1);
 }
 
+/// Block one or more friends for the current user.
 class BlockFriendsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'BlockFriendsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pPS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ids')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'usernames')
-    ..hasRequiredFields = false;
-
-  BlockFriendsRequest._() : super();
   factory BlockFriendsRequest({
     $core.Iterable<$core.String>? ids,
     $core.Iterable<$core.String>? usernames,
   }) {
-    final _result = create();
-    if (ids != null) {
-      _result.ids.addAll(ids);
-    }
-    if (usernames != null) {
-      _result.usernames.addAll(usernames);
-    }
-    return _result;
+    final result = create();
+    if (ids != null) result.ids.addAll(ids);
+    if (usernames != null) result.usernames.addAll(usernames);
+    return result;
   }
-  factory BlockFriendsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BlockFriendsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  BlockFriendsRequest clone() => BlockFriendsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  BlockFriendsRequest._();
+
+  factory BlockFriendsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory BlockFriendsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'BlockFriendsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'ids')
+    ..pPS(2, _omitFieldNames ? '' : 'usernames')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  BlockFriendsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   BlockFriendsRequest copyWith(void Function(BlockFriendsRequest) updates) =>
       super.copyWith((message) => updates(message as BlockFriendsRequest))
-          as BlockFriendsRequest; // ignore: deprecated_member_use
+          as BlockFriendsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static BlockFriendsRequest create() => BlockFriendsRequest._();
+  @$core.override
   BlockFriendsRequest createEmptyInstance() => create();
   static $pb.PbList<BlockFriendsRequest> createRepeated() =>
       $pb.PbList<BlockFriendsRequest>();
@@ -2746,95 +2182,17 @@ class BlockFriendsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<BlockFriendsRequest>(create);
   static BlockFriendsRequest? _defaultInstance;
 
+  /// The account id of a user.
   @$pb.TagNumber(1)
-  $core.List<$core.String> get ids => $_getList(0);
+  $pb.PbList<$core.String> get ids => $_getList(0);
 
+  /// The account username of a user.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get usernames => $_getList(1);
+  $pb.PbList<$core.String> get usernames => $_getList(1);
 }
 
+/// A message sent on a channel.
 class ChannelMessage extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelMessage',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'messageId')
-    ..aOM<$1.Int32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'code',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'senderId')
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'content')
-    ..aOM<$0.Timestamp>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$1.BoolValue>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persistent',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'roomName')
-    ..aOS(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..aOS(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIdOne')
-    ..aOS(
-        13,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIdTwo')
-    ..hasRequiredFields = false;
-
-  ChannelMessage._() : super();
   factory ChannelMessage({
     $core.String? channelId,
     $core.String? messageId,
@@ -2850,67 +2208,68 @@ class ChannelMessage extends $pb.GeneratedMessage {
     $core.String? userIdOne,
     $core.String? userIdTwo,
   }) {
-    final _result = create();
-    if (channelId != null) {
-      _result.channelId = channelId;
-    }
-    if (messageId != null) {
-      _result.messageId = messageId;
-    }
-    if (code != null) {
-      _result.code = code;
-    }
-    if (senderId != null) {
-      _result.senderId = senderId;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    if (content != null) {
-      _result.content = content;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    if (persistent != null) {
-      _result.persistent = persistent;
-    }
-    if (roomName != null) {
-      _result.roomName = roomName;
-    }
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIdOne != null) {
-      _result.userIdOne = userIdOne;
-    }
-    if (userIdTwo != null) {
-      _result.userIdTwo = userIdTwo;
-    }
-    return _result;
+    final result = create();
+    if (channelId != null) result.channelId = channelId;
+    if (messageId != null) result.messageId = messageId;
+    if (code != null) result.code = code;
+    if (senderId != null) result.senderId = senderId;
+    if (username != null) result.username = username;
+    if (content != null) result.content = content;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    if (persistent != null) result.persistent = persistent;
+    if (roomName != null) result.roomName = roomName;
+    if (groupId != null) result.groupId = groupId;
+    if (userIdOne != null) result.userIdOne = userIdOne;
+    if (userIdTwo != null) result.userIdTwo = userIdTwo;
+    return result;
   }
-  factory ChannelMessage.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelMessage.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelMessage clone() => ChannelMessage()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelMessage._();
+
+  factory ChannelMessage.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelMessage.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelMessage',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'channelId')
+    ..aOS(2, _omitFieldNames ? '' : 'messageId')
+    ..aOM<$1.Int32Value>(3, _omitFieldNames ? '' : 'code',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(4, _omitFieldNames ? '' : 'senderId')
+    ..aOS(5, _omitFieldNames ? '' : 'username')
+    ..aOS(6, _omitFieldNames ? '' : 'content')
+    ..aOM<$0.Timestamp>(7, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(8, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$1.BoolValue>(9, _omitFieldNames ? '' : 'persistent',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(10, _omitFieldNames ? '' : 'roomName')
+    ..aOS(11, _omitFieldNames ? '' : 'groupId')
+    ..aOS(12, _omitFieldNames ? '' : 'userIdOne')
+    ..aOS(13, _omitFieldNames ? '' : 'userIdTwo')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelMessage clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelMessage copyWith(void Function(ChannelMessage) updates) =>
       super.copyWith((message) => updates(message as ChannelMessage))
-          as ChannelMessage; // ignore: deprecated_member_use
+          as ChannelMessage;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelMessage create() => ChannelMessage._();
+  @$core.override
   ChannelMessage createEmptyInstance() => create();
   static $pb.PbList<ChannelMessage> createRepeated() =>
       $pb.PbList<ChannelMessage>();
@@ -2919,246 +2278,194 @@ class ChannelMessage extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelMessage>(create);
   static ChannelMessage? _defaultInstance;
 
+  /// The channel this message belongs to.
   @$pb.TagNumber(1)
   $core.String get channelId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set channelId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set channelId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasChannelId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearChannelId() => clearField(1);
+  void clearChannelId() => $_clearField(1);
 
+  /// The unique ID of this message.
   @$pb.TagNumber(2)
   $core.String get messageId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set messageId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set messageId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMessageId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMessageId() => clearField(2);
+  void clearMessageId() => $_clearField(2);
 
+  /// The code representing a message type or category.
   @$pb.TagNumber(3)
   $1.Int32Value get code => $_getN(2);
   @$pb.TagNumber(3)
-  set code($1.Int32Value v) {
-    setField(3, v);
-  }
-
+  set code($1.Int32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasCode() => $_has(2);
   @$pb.TagNumber(3)
-  void clearCode() => clearField(3);
+  void clearCode() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.Int32Value ensureCode() => $_ensure(2);
 
+  /// Message sender, usually a user ID.
   @$pb.TagNumber(4)
   $core.String get senderId => $_getSZ(3);
   @$pb.TagNumber(4)
-  set senderId($core.String v) {
-    $_setString(3, v);
-  }
-
+  set senderId($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasSenderId() => $_has(3);
   @$pb.TagNumber(4)
-  void clearSenderId() => clearField(4);
+  void clearSenderId() => $_clearField(4);
 
+  /// The username of the message sender, if any.
   @$pb.TagNumber(5)
   $core.String get username => $_getSZ(4);
   @$pb.TagNumber(5)
-  set username($core.String v) {
-    $_setString(4, v);
-  }
-
+  set username($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasUsername() => $_has(4);
   @$pb.TagNumber(5)
-  void clearUsername() => clearField(5);
+  void clearUsername() => $_clearField(5);
 
+  /// The content payload.
   @$pb.TagNumber(6)
   $core.String get content => $_getSZ(5);
   @$pb.TagNumber(6)
-  set content($core.String v) {
-    $_setString(5, v);
-  }
-
+  set content($core.String value) => $_setString(5, value);
   @$pb.TagNumber(6)
   $core.bool hasContent() => $_has(5);
   @$pb.TagNumber(6)
-  void clearContent() => clearField(6);
+  void clearContent() => $_clearField(6);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the message was created.
   @$pb.TagNumber(7)
   $0.Timestamp get createTime => $_getN(6);
   @$pb.TagNumber(7)
-  set createTime($0.Timestamp v) {
-    setField(7, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasCreateTime() => $_has(6);
   @$pb.TagNumber(7)
-  void clearCreateTime() => clearField(7);
+  void clearCreateTime() => $_clearField(7);
   @$pb.TagNumber(7)
   $0.Timestamp ensureCreateTime() => $_ensure(6);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the message was last updated.
   @$pb.TagNumber(8)
   $0.Timestamp get updateTime => $_getN(7);
   @$pb.TagNumber(8)
-  set updateTime($0.Timestamp v) {
-    setField(8, v);
-  }
-
+  set updateTime($0.Timestamp value) => $_setField(8, value);
   @$pb.TagNumber(8)
   $core.bool hasUpdateTime() => $_has(7);
   @$pb.TagNumber(8)
-  void clearUpdateTime() => clearField(8);
+  void clearUpdateTime() => $_clearField(8);
   @$pb.TagNumber(8)
   $0.Timestamp ensureUpdateTime() => $_ensure(7);
 
+  /// True if the message was persisted to the channel's history, false otherwise.
   @$pb.TagNumber(9)
   $1.BoolValue get persistent => $_getN(8);
   @$pb.TagNumber(9)
-  set persistent($1.BoolValue v) {
-    setField(9, v);
-  }
-
+  set persistent($1.BoolValue value) => $_setField(9, value);
   @$pb.TagNumber(9)
   $core.bool hasPersistent() => $_has(8);
   @$pb.TagNumber(9)
-  void clearPersistent() => clearField(9);
+  void clearPersistent() => $_clearField(9);
   @$pb.TagNumber(9)
   $1.BoolValue ensurePersistent() => $_ensure(8);
 
+  /// The name of the chat room, or an empty string if this message was not sent through a chat room.
   @$pb.TagNumber(10)
   $core.String get roomName => $_getSZ(9);
   @$pb.TagNumber(10)
-  set roomName($core.String v) {
-    $_setString(9, v);
-  }
-
+  set roomName($core.String value) => $_setString(9, value);
   @$pb.TagNumber(10)
   $core.bool hasRoomName() => $_has(9);
   @$pb.TagNumber(10)
-  void clearRoomName() => clearField(10);
+  void clearRoomName() => $_clearField(10);
 
+  /// The ID of the group, or an empty string if this message was not sent through a group channel.
   @$pb.TagNumber(11)
   $core.String get groupId => $_getSZ(10);
   @$pb.TagNumber(11)
-  set groupId($core.String v) {
-    $_setString(10, v);
-  }
-
+  set groupId($core.String value) => $_setString(10, value);
   @$pb.TagNumber(11)
   $core.bool hasGroupId() => $_has(10);
   @$pb.TagNumber(11)
-  void clearGroupId() => clearField(11);
+  void clearGroupId() => $_clearField(11);
 
+  /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
   @$pb.TagNumber(12)
   $core.String get userIdOne => $_getSZ(11);
   @$pb.TagNumber(12)
-  set userIdOne($core.String v) {
-    $_setString(11, v);
-  }
-
+  set userIdOne($core.String value) => $_setString(11, value);
   @$pb.TagNumber(12)
   $core.bool hasUserIdOne() => $_has(11);
   @$pb.TagNumber(12)
-  void clearUserIdOne() => clearField(12);
+  void clearUserIdOne() => $_clearField(12);
 
+  /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
   @$pb.TagNumber(13)
   $core.String get userIdTwo => $_getSZ(12);
   @$pb.TagNumber(13)
-  set userIdTwo($core.String v) {
-    $_setString(12, v);
-  }
-
+  set userIdTwo($core.String value) => $_setString(12, value);
   @$pb.TagNumber(13)
   $core.bool hasUserIdTwo() => $_has(12);
   @$pb.TagNumber(13)
-  void clearUserIdTwo() => clearField(13);
+  void clearUserIdTwo() => $_clearField(13);
 }
 
+/// A list of channel messages, usually a result of a list operation.
 class ChannelMessageList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelMessageList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<ChannelMessage>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'messages',
-        $pb.PbFieldType.PM,
-        subBuilder: ChannelMessage.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'nextCursor')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'prevCursor')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cacheableCursor')
-    ..hasRequiredFields = false;
-
-  ChannelMessageList._() : super();
   factory ChannelMessageList({
     $core.Iterable<ChannelMessage>? messages,
     $core.String? nextCursor,
     $core.String? prevCursor,
     $core.String? cacheableCursor,
   }) {
-    final _result = create();
-    if (messages != null) {
-      _result.messages.addAll(messages);
-    }
-    if (nextCursor != null) {
-      _result.nextCursor = nextCursor;
-    }
-    if (prevCursor != null) {
-      _result.prevCursor = prevCursor;
-    }
-    if (cacheableCursor != null) {
-      _result.cacheableCursor = cacheableCursor;
-    }
-    return _result;
+    final result = create();
+    if (messages != null) result.messages.addAll(messages);
+    if (nextCursor != null) result.nextCursor = nextCursor;
+    if (prevCursor != null) result.prevCursor = prevCursor;
+    if (cacheableCursor != null) result.cacheableCursor = cacheableCursor;
+    return result;
   }
-  factory ChannelMessageList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelMessageList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelMessageList clone() => ChannelMessageList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelMessageList._();
+
+  factory ChannelMessageList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelMessageList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelMessageList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<ChannelMessage>(1, _omitFieldNames ? '' : 'messages',
+        subBuilder: ChannelMessage.create)
+    ..aOS(2, _omitFieldNames ? '' : 'nextCursor')
+    ..aOS(3, _omitFieldNames ? '' : 'prevCursor')
+    ..aOS(4, _omitFieldNames ? '' : 'cacheableCursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelMessageList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelMessageList copyWith(void Function(ChannelMessageList) updates) =>
       super.copyWith((message) => updates(message as ChannelMessageList))
-          as ChannelMessageList; // ignore: deprecated_member_use
+          as ChannelMessageList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelMessageList create() => ChannelMessageList._();
+  @$core.override
   ChannelMessageList createEmptyInstance() => create();
   static $pb.PbList<ChannelMessageList> createRepeated() =>
       $pb.PbList<ChannelMessageList>();
@@ -3167,90 +2474,43 @@ class ChannelMessageList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageList>(create);
   static ChannelMessageList? _defaultInstance;
 
+  /// A list of messages.
   @$pb.TagNumber(1)
-  $core.List<ChannelMessage> get messages => $_getList(0);
+  $pb.PbList<ChannelMessage> get messages => $_getList(0);
 
+  /// The cursor to send when retrieving the next page, if any.
   @$pb.TagNumber(2)
   $core.String get nextCursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set nextCursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set nextCursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasNextCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearNextCursor() => clearField(2);
+  void clearNextCursor() => $_clearField(2);
 
+  /// The cursor to send when retrieving the previous page, if any.
   @$pb.TagNumber(3)
   $core.String get prevCursor => $_getSZ(2);
   @$pb.TagNumber(3)
-  set prevCursor($core.String v) {
-    $_setString(2, v);
-  }
-
+  set prevCursor($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasPrevCursor() => $_has(2);
   @$pb.TagNumber(3)
-  void clearPrevCursor() => clearField(3);
+  void clearPrevCursor() => $_clearField(3);
 
+  /// Cacheable cursor to list newer messages. Durable and designed to be stored, unlike next/prev cursors.
   @$pb.TagNumber(4)
   $core.String get cacheableCursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set cacheableCursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set cacheableCursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCacheableCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCacheableCursor() => clearField(4);
+  void clearCacheableCursor() => $_clearField(4);
 }
 
+/// Create a group with the current user as owner.
 class CreateGroupRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'CreateGroupRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'description')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'langTag')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'avatarUrl')
-    ..aOB(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'open')
-    ..a<$core.int>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxCount',
-        $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
-
-  CreateGroupRequest._() : super();
   factory CreateGroupRequest({
     $core.String? name,
     $core.String? description,
@@ -3259,46 +2519,50 @@ class CreateGroupRequest extends $pb.GeneratedMessage {
     $core.bool? open,
     $core.int? maxCount,
   }) {
-    final _result = create();
-    if (name != null) {
-      _result.name = name;
-    }
-    if (description != null) {
-      _result.description = description;
-    }
-    if (langTag != null) {
-      _result.langTag = langTag;
-    }
-    if (avatarUrl != null) {
-      _result.avatarUrl = avatarUrl;
-    }
-    if (open != null) {
-      _result.open = open;
-    }
-    if (maxCount != null) {
-      _result.maxCount = maxCount;
-    }
-    return _result;
+    final result = create();
+    if (name != null) result.name = name;
+    if (description != null) result.description = description;
+    if (langTag != null) result.langTag = langTag;
+    if (avatarUrl != null) result.avatarUrl = avatarUrl;
+    if (open != null) result.open = open;
+    if (maxCount != null) result.maxCount = maxCount;
+    return result;
   }
-  factory CreateGroupRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CreateGroupRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  CreateGroupRequest clone() => CreateGroupRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  CreateGroupRequest._();
+
+  factory CreateGroupRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory CreateGroupRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'CreateGroupRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'description')
+    ..aOS(3, _omitFieldNames ? '' : 'langTag')
+    ..aOS(4, _omitFieldNames ? '' : 'avatarUrl')
+    ..aOB(5, _omitFieldNames ? '' : 'open')
+    ..aI(6, _omitFieldNames ? '' : 'maxCount')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  CreateGroupRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   CreateGroupRequest copyWith(void Function(CreateGroupRequest) updates) =>
       super.copyWith((message) => updates(message as CreateGroupRequest))
-          as CreateGroupRequest; // ignore: deprecated_member_use
+          as CreateGroupRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static CreateGroupRequest create() => CreateGroupRequest._();
+  @$core.override
   CreateGroupRequest createEmptyInstance() => create();
   static $pb.PbList<CreateGroupRequest> createRepeated() =>
       $pb.PbList<CreateGroupRequest>();
@@ -3307,135 +2571,109 @@ class CreateGroupRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<CreateGroupRequest>(create);
   static CreateGroupRequest? _defaultInstance;
 
+  /// A unique name for the group.
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
-  void clearName() => clearField(1);
+  void clearName() => $_clearField(1);
 
+  /// A description for the group.
   @$pb.TagNumber(2)
   $core.String get description => $_getSZ(1);
   @$pb.TagNumber(2)
-  set description($core.String v) {
-    $_setString(1, v);
-  }
-
+  set description($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasDescription() => $_has(1);
   @$pb.TagNumber(2)
-  void clearDescription() => clearField(2);
+  void clearDescription() => $_clearField(2);
 
+  /// The language expected to be a tag which follows the BCP-47 spec.
   @$pb.TagNumber(3)
   $core.String get langTag => $_getSZ(2);
   @$pb.TagNumber(3)
-  set langTag($core.String v) {
-    $_setString(2, v);
-  }
-
+  set langTag($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasLangTag() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLangTag() => clearField(3);
+  void clearLangTag() => $_clearField(3);
 
+  /// A URL for an avatar image.
   @$pb.TagNumber(4)
   $core.String get avatarUrl => $_getSZ(3);
   @$pb.TagNumber(4)
-  set avatarUrl($core.String v) {
-    $_setString(3, v);
-  }
-
+  set avatarUrl($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasAvatarUrl() => $_has(3);
   @$pb.TagNumber(4)
-  void clearAvatarUrl() => clearField(4);
+  void clearAvatarUrl() => $_clearField(4);
 
+  /// Mark a group as open or not where only admins can accept members.
   @$pb.TagNumber(5)
   $core.bool get open => $_getBF(4);
   @$pb.TagNumber(5)
-  set open($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set open($core.bool value) => $_setBool(4, value);
   @$pb.TagNumber(5)
   $core.bool hasOpen() => $_has(4);
   @$pb.TagNumber(5)
-  void clearOpen() => clearField(5);
+  void clearOpen() => $_clearField(5);
 
+  /// Maximum number of group members.
   @$pb.TagNumber(6)
   $core.int get maxCount => $_getIZ(5);
   @$pb.TagNumber(6)
-  set maxCount($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set maxCount($core.int value) => $_setSignedInt32(5, value);
   @$pb.TagNumber(6)
   $core.bool hasMaxCount() => $_has(5);
   @$pb.TagNumber(6)
-  void clearMaxCount() => clearField(6);
+  void clearMaxCount() => $_clearField(6);
 }
 
+/// Delete one or more friends for the current user.
 class DeleteFriendsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DeleteFriendsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pPS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ids')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'usernames')
-    ..hasRequiredFields = false;
-
-  DeleteFriendsRequest._() : super();
   factory DeleteFriendsRequest({
     $core.Iterable<$core.String>? ids,
     $core.Iterable<$core.String>? usernames,
   }) {
-    final _result = create();
-    if (ids != null) {
-      _result.ids.addAll(ids);
-    }
-    if (usernames != null) {
-      _result.usernames.addAll(usernames);
-    }
-    return _result;
+    final result = create();
+    if (ids != null) result.ids.addAll(ids);
+    if (usernames != null) result.usernames.addAll(usernames);
+    return result;
   }
-  factory DeleteFriendsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteFriendsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DeleteFriendsRequest clone() =>
-      DeleteFriendsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DeleteFriendsRequest._();
+
+  factory DeleteFriendsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DeleteFriendsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DeleteFriendsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'ids')
+    ..pPS(2, _omitFieldNames ? '' : 'usernames')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DeleteFriendsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DeleteFriendsRequest copyWith(void Function(DeleteFriendsRequest) updates) =>
       super.copyWith((message) => updates(message as DeleteFriendsRequest))
-          as DeleteFriendsRequest; // ignore: deprecated_member_use
+          as DeleteFriendsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DeleteFriendsRequest create() => DeleteFriendsRequest._();
+  @$core.override
   DeleteFriendsRequest createEmptyInstance() => create();
   static $pb.PbList<DeleteFriendsRequest> createRepeated() =>
       $pb.PbList<DeleteFriendsRequest>();
@@ -3444,59 +2682,54 @@ class DeleteFriendsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<DeleteFriendsRequest>(create);
   static DeleteFriendsRequest? _defaultInstance;
 
+  /// The account id of a user.
   @$pb.TagNumber(1)
-  $core.List<$core.String> get ids => $_getList(0);
+  $pb.PbList<$core.String> get ids => $_getList(0);
 
+  /// The account username of a user.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get usernames => $_getList(1);
+  $pb.PbList<$core.String> get usernames => $_getList(1);
 }
 
+/// Delete a group the user has access to.
 class DeleteGroupRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DeleteGroupRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..hasRequiredFields = false;
-
-  DeleteGroupRequest._() : super();
   factory DeleteGroupRequest({
     $core.String? groupId,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    return result;
   }
-  factory DeleteGroupRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteGroupRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DeleteGroupRequest clone() => DeleteGroupRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DeleteGroupRequest._();
+
+  factory DeleteGroupRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DeleteGroupRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DeleteGroupRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DeleteGroupRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DeleteGroupRequest copyWith(void Function(DeleteGroupRequest) updates) =>
       super.copyWith((message) => updates(message as DeleteGroupRequest))
-          as DeleteGroupRequest; // ignore: deprecated_member_use
+          as DeleteGroupRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DeleteGroupRequest create() => DeleteGroupRequest._();
+  @$core.override
   DeleteGroupRequest createEmptyInstance() => create();
   static $pb.PbList<DeleteGroupRequest> createRepeated() =>
       $pb.PbList<DeleteGroupRequest>();
@@ -3505,69 +2738,59 @@ class DeleteGroupRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<DeleteGroupRequest>(create);
   static DeleteGroupRequest? _defaultInstance;
 
+  /// The id of a group.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 }
 
+/// Delete a leaderboard record.
 class DeleteLeaderboardRecordRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DeleteLeaderboardRecordRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaderboardId')
-    ..hasRequiredFields = false;
-
-  DeleteLeaderboardRecordRequest._() : super();
   factory DeleteLeaderboardRecordRequest({
     $core.String? leaderboardId,
   }) {
-    final _result = create();
-    if (leaderboardId != null) {
-      _result.leaderboardId = leaderboardId;
-    }
-    return _result;
+    final result = create();
+    if (leaderboardId != null) result.leaderboardId = leaderboardId;
+    return result;
   }
-  factory DeleteLeaderboardRecordRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteLeaderboardRecordRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DeleteLeaderboardRecordRequest clone() =>
-      DeleteLeaderboardRecordRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DeleteLeaderboardRecordRequest._();
+
+  factory DeleteLeaderboardRecordRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DeleteLeaderboardRecordRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DeleteLeaderboardRecordRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'leaderboardId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DeleteLeaderboardRecordRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DeleteLeaderboardRecordRequest copyWith(
           void Function(DeleteLeaderboardRecordRequest) updates) =>
       super.copyWith(
               (message) => updates(message as DeleteLeaderboardRecordRequest))
-          as DeleteLeaderboardRecordRequest; // ignore: deprecated_member_use
+          as DeleteLeaderboardRecordRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DeleteLeaderboardRecordRequest create() =>
       DeleteLeaderboardRecordRequest._();
+  @$core.override
   DeleteLeaderboardRecordRequest createEmptyInstance() => create();
   static $pb.PbList<DeleteLeaderboardRecordRequest> createRepeated() =>
       $pb.PbList<DeleteLeaderboardRecordRequest>();
@@ -3576,68 +2799,58 @@ class DeleteLeaderboardRecordRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<DeleteLeaderboardRecordRequest>(create);
   static DeleteLeaderboardRecordRequest? _defaultInstance;
 
+  /// The leaderboard ID to delete from.
   @$pb.TagNumber(1)
   $core.String get leaderboardId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set leaderboardId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set leaderboardId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasLeaderboardId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLeaderboardId() => clearField(1);
+  void clearLeaderboardId() => $_clearField(1);
 }
 
+/// Delete one or more notifications for the current user.
 class DeleteNotificationsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DeleteNotificationsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pPS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ids')
-    ..hasRequiredFields = false;
-
-  DeleteNotificationsRequest._() : super();
   factory DeleteNotificationsRequest({
     $core.Iterable<$core.String>? ids,
   }) {
-    final _result = create();
-    if (ids != null) {
-      _result.ids.addAll(ids);
-    }
-    return _result;
+    final result = create();
+    if (ids != null) result.ids.addAll(ids);
+    return result;
   }
-  factory DeleteNotificationsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteNotificationsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DeleteNotificationsRequest clone() =>
-      DeleteNotificationsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DeleteNotificationsRequest._();
+
+  factory DeleteNotificationsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DeleteNotificationsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DeleteNotificationsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'ids')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DeleteNotificationsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DeleteNotificationsRequest copyWith(
           void Function(DeleteNotificationsRequest) updates) =>
       super.copyWith(
               (message) => updates(message as DeleteNotificationsRequest))
-          as DeleteNotificationsRequest; // ignore: deprecated_member_use
+          as DeleteNotificationsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DeleteNotificationsRequest create() => DeleteNotificationsRequest._();
+  @$core.override
   DeleteNotificationsRequest createEmptyInstance() => create();
   static $pb.PbList<DeleteNotificationsRequest> createRepeated() =>
       $pb.PbList<DeleteNotificationsRequest>();
@@ -3646,60 +2859,53 @@ class DeleteNotificationsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<DeleteNotificationsRequest>(create);
   static DeleteNotificationsRequest? _defaultInstance;
 
+  /// The id of notifications.
   @$pb.TagNumber(1)
-  $core.List<$core.String> get ids => $_getList(0);
+  $pb.PbList<$core.String> get ids => $_getList(0);
 }
 
+/// Delete a leaderboard record.
 class DeleteTournamentRecordRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DeleteTournamentRecordRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'tournamentId')
-    ..hasRequiredFields = false;
-
-  DeleteTournamentRecordRequest._() : super();
   factory DeleteTournamentRecordRequest({
     $core.String? tournamentId,
   }) {
-    final _result = create();
-    if (tournamentId != null) {
-      _result.tournamentId = tournamentId;
-    }
-    return _result;
+    final result = create();
+    if (tournamentId != null) result.tournamentId = tournamentId;
+    return result;
   }
-  factory DeleteTournamentRecordRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteTournamentRecordRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DeleteTournamentRecordRequest clone() =>
-      DeleteTournamentRecordRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DeleteTournamentRecordRequest._();
+
+  factory DeleteTournamentRecordRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DeleteTournamentRecordRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DeleteTournamentRecordRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'tournamentId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DeleteTournamentRecordRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DeleteTournamentRecordRequest copyWith(
           void Function(DeleteTournamentRecordRequest) updates) =>
       super.copyWith(
               (message) => updates(message as DeleteTournamentRecordRequest))
-          as DeleteTournamentRecordRequest; // ignore: deprecated_member_use
+          as DeleteTournamentRecordRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DeleteTournamentRecordRequest create() =>
       DeleteTournamentRecordRequest._();
+  @$core.override
   DeleteTournamentRecordRequest createEmptyInstance() => create();
   static $pb.PbList<DeleteTournamentRecordRequest> createRepeated() =>
       $pb.PbList<DeleteTournamentRecordRequest>();
@@ -3708,85 +2914,63 @@ class DeleteTournamentRecordRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<DeleteTournamentRecordRequest>(create);
   static DeleteTournamentRecordRequest? _defaultInstance;
 
+  /// The tournament ID to delete from.
   @$pb.TagNumber(1)
   $core.String get tournamentId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set tournamentId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set tournamentId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTournamentId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTournamentId() => clearField(1);
+  void clearTournamentId() => $_clearField(1);
 }
 
+/// Storage objects to delete.
 class DeleteStorageObjectId extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DeleteStorageObjectId',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'collection')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'key')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'version')
-    ..hasRequiredFields = false;
-
-  DeleteStorageObjectId._() : super();
   factory DeleteStorageObjectId({
     $core.String? collection,
     $core.String? key,
     $core.String? version,
   }) {
-    final _result = create();
-    if (collection != null) {
-      _result.collection = collection;
-    }
-    if (key != null) {
-      _result.key = key;
-    }
-    if (version != null) {
-      _result.version = version;
-    }
-    return _result;
+    final result = create();
+    if (collection != null) result.collection = collection;
+    if (key != null) result.key = key;
+    if (version != null) result.version = version;
+    return result;
   }
-  factory DeleteStorageObjectId.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteStorageObjectId.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DeleteStorageObjectId clone() =>
-      DeleteStorageObjectId()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DeleteStorageObjectId._();
+
+  factory DeleteStorageObjectId.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DeleteStorageObjectId.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DeleteStorageObjectId',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'collection')
+    ..aOS(2, _omitFieldNames ? '' : 'key')
+    ..aOS(3, _omitFieldNames ? '' : 'version')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DeleteStorageObjectId clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DeleteStorageObjectId copyWith(
           void Function(DeleteStorageObjectId) updates) =>
       super.copyWith((message) => updates(message as DeleteStorageObjectId))
-          as DeleteStorageObjectId; // ignore: deprecated_member_use
+          as DeleteStorageObjectId;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DeleteStorageObjectId create() => DeleteStorageObjectId._();
+  @$core.override
   DeleteStorageObjectId createEmptyInstance() => create();
   static $pb.PbList<DeleteStorageObjectId> createRepeated() =>
       $pb.PbList<DeleteStorageObjectId>();
@@ -3795,95 +2979,80 @@ class DeleteStorageObjectId extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<DeleteStorageObjectId>(create);
   static DeleteStorageObjectId? _defaultInstance;
 
+  /// The collection which stores the object.
   @$pb.TagNumber(1)
   $core.String get collection => $_getSZ(0);
   @$pb.TagNumber(1)
-  set collection($core.String v) {
-    $_setString(0, v);
-  }
-
+  set collection($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCollection() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCollection() => clearField(1);
+  void clearCollection() => $_clearField(1);
 
+  /// The key of the object within the collection.
   @$pb.TagNumber(2)
   $core.String get key => $_getSZ(1);
   @$pb.TagNumber(2)
-  set key($core.String v) {
-    $_setString(1, v);
-  }
-
+  set key($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasKey() => $_has(1);
   @$pb.TagNumber(2)
-  void clearKey() => clearField(2);
+  void clearKey() => $_clearField(2);
 
+  /// The version hash of the object.
   @$pb.TagNumber(3)
   $core.String get version => $_getSZ(2);
   @$pb.TagNumber(3)
-  set version($core.String v) {
-    $_setString(2, v);
-  }
-
+  set version($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasVersion() => $_has(2);
   @$pb.TagNumber(3)
-  void clearVersion() => clearField(3);
+  void clearVersion() => $_clearField(3);
 }
 
+/// Batch delete storage objects.
 class DeleteStorageObjectsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DeleteStorageObjectsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<DeleteStorageObjectId>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'objectIds',
-        $pb.PbFieldType.PM,
-        subBuilder: DeleteStorageObjectId.create)
-    ..hasRequiredFields = false;
-
-  DeleteStorageObjectsRequest._() : super();
   factory DeleteStorageObjectsRequest({
     $core.Iterable<DeleteStorageObjectId>? objectIds,
   }) {
-    final _result = create();
-    if (objectIds != null) {
-      _result.objectIds.addAll(objectIds);
-    }
-    return _result;
+    final result = create();
+    if (objectIds != null) result.objectIds.addAll(objectIds);
+    return result;
   }
-  factory DeleteStorageObjectsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeleteStorageObjectsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DeleteStorageObjectsRequest clone() =>
-      DeleteStorageObjectsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DeleteStorageObjectsRequest._();
+
+  factory DeleteStorageObjectsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DeleteStorageObjectsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DeleteStorageObjectsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<DeleteStorageObjectId>(1, _omitFieldNames ? '' : 'objectIds',
+        subBuilder: DeleteStorageObjectId.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DeleteStorageObjectsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DeleteStorageObjectsRequest copyWith(
           void Function(DeleteStorageObjectsRequest) updates) =>
       super.copyWith(
               (message) => updates(message as DeleteStorageObjectsRequest))
-          as DeleteStorageObjectsRequest; // ignore: deprecated_member_use
+          as DeleteStorageObjectsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DeleteStorageObjectsRequest create() =>
       DeleteStorageObjectsRequest._();
+  @$core.override
   DeleteStorageObjectsRequest createEmptyInstance() => create();
   static $pb.PbList<DeleteStorageObjectsRequest> createRepeated() =>
       $pb.PbList<DeleteStorageObjectsRequest>();
@@ -3892,88 +3061,63 @@ class DeleteStorageObjectsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<DeleteStorageObjectsRequest>(create);
   static DeleteStorageObjectsRequest? _defaultInstance;
 
+  /// Batch of storage objects.
   @$pb.TagNumber(1)
-  $core.List<DeleteStorageObjectId> get objectIds => $_getList(0);
+  $pb.PbList<DeleteStorageObjectId> get objectIds => $_getList(0);
 }
 
+/// Represents an event to be passed through the server to registered event handlers.
 class Event extends $pb.GeneratedMessage {
+  factory Event({
+    $core.String? name,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? properties,
+    $0.Timestamp? timestamp,
+    $core.bool? external,
+  }) {
+    final result = create();
+    if (name != null) result.name = name;
+    if (properties != null) result.properties.addEntries(properties);
+    if (timestamp != null) result.timestamp = timestamp;
+    if (external != null) result.external = external;
+    return result;
+  }
+
+  Event._();
+
+  factory Event.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Event.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Event',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'Event',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..m<$core.String, $core.String>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'properties',
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..m<$core.String, $core.String>(2, _omitFieldNames ? '' : 'properties',
         entryClassName: 'Event.PropertiesEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.api'))
-    ..aOM<$0.Timestamp>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'timestamp',
+    ..aOM<$0.Timestamp>(3, _omitFieldNames ? '' : 'timestamp',
         subBuilder: $0.Timestamp.create)
-    ..aOB(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'external')
+    ..aOB(4, _omitFieldNames ? '' : 'external')
     ..hasRequiredFields = false;
 
-  Event._() : super();
-  factory Event({
-    $core.String? name,
-    $core.Map<$core.String, $core.String>? properties,
-    $0.Timestamp? timestamp,
-    $core.bool? external,
-  }) {
-    final _result = create();
-    if (name != null) {
-      _result.name = name;
-    }
-    if (properties != null) {
-      _result.properties.addAll(properties);
-    }
-    if (timestamp != null) {
-      _result.timestamp = timestamp;
-    }
-    if (external != null) {
-      _result.external = external;
-    }
-    return _result;
-  }
-  factory Event.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Event.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Event clone() => Event()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Event clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Event copyWith(void Function(Event) updates) =>
-      super.copyWith((message) => updates(message as Event))
-          as Event; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Event)) as Event;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Event create() => Event._();
+  @$core.override
   Event createEmptyInstance() => create();
   static $pb.PbList<Event> createRepeated() => $pb.PbList<Event>();
   @$core.pragma('dart2js:noInline')
@@ -3981,115 +3125,92 @@ class Event extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Event>(create);
   static Event? _defaultInstance;
 
+  /// An event name, type, category, or identifier.
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
-  void clearName() => clearField(1);
+  void clearName() => $_clearField(1);
 
+  /// Arbitrary event property values.
   @$pb.TagNumber(2)
-  $core.Map<$core.String, $core.String> get properties => $_getMap(1);
+  $pb.PbMap<$core.String, $core.String> get properties => $_getMap(1);
 
+  /// The time when the event was triggered.
   @$pb.TagNumber(3)
   $0.Timestamp get timestamp => $_getN(2);
   @$pb.TagNumber(3)
-  set timestamp($0.Timestamp v) {
-    setField(3, v);
-  }
-
+  set timestamp($0.Timestamp value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasTimestamp() => $_has(2);
   @$pb.TagNumber(3)
-  void clearTimestamp() => clearField(3);
+  void clearTimestamp() => $_clearField(3);
   @$pb.TagNumber(3)
   $0.Timestamp ensureTimestamp() => $_ensure(2);
 
+  /// True if the event came directly from a client call, false otherwise.
   @$pb.TagNumber(4)
   $core.bool get external => $_getBF(3);
   @$pb.TagNumber(4)
-  set external($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set external($core.bool value) => $_setBool(3, value);
   @$pb.TagNumber(4)
   $core.bool hasExternal() => $_has(3);
   @$pb.TagNumber(4)
-  void clearExternal() => clearField(4);
+  void clearExternal() => $_clearField(4);
 }
 
+/// A friend of a user.
 class Friend extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Friend',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<User>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'user',
-        subBuilder: User.create)
-    ..aOM<$1.Int32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'state',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$0.Timestamp>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..hasRequiredFields = false;
-
-  Friend._() : super();
   factory Friend({
     User? user,
     $1.Int32Value? state,
     $0.Timestamp? updateTime,
+    $core.String? metadata,
   }) {
-    final _result = create();
-    if (user != null) {
-      _result.user = user;
-    }
-    if (state != null) {
-      _result.state = state;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    return _result;
+    final result = create();
+    if (user != null) result.user = user;
+    if (state != null) result.state = state;
+    if (updateTime != null) result.updateTime = updateTime;
+    if (metadata != null) result.metadata = metadata;
+    return result;
   }
-  factory Friend.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Friend.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Friend clone() => Friend()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Friend._();
+
+  factory Friend.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Friend.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Friend',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<User>(1, _omitFieldNames ? '' : 'user', subBuilder: User.create)
+    ..aOM<$1.Int32Value>(2, _omitFieldNames ? '' : 'state',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$0.Timestamp>(3, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOS(4, _omitFieldNames ? '' : 'metadata')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Friend clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Friend copyWith(void Function(Friend) updates) =>
-      super.copyWith((message) => updates(message as Friend))
-          as Friend; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Friend)) as Friend;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Friend create() => Friend._();
+  @$core.override
   Friend createEmptyInstance() => create();
   static $pb.PbList<Friend> createRepeated() => $pb.PbList<Friend>();
   @$core.pragma('dart2js:noInline')
@@ -4097,106 +3218,95 @@ class Friend extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Friend>(create);
   static Friend? _defaultInstance;
 
+  /// The user object.
   @$pb.TagNumber(1)
   User get user => $_getN(0);
   @$pb.TagNumber(1)
-  set user(User v) {
-    setField(1, v);
-  }
-
+  set user(User value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasUser() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUser() => clearField(1);
+  void clearUser() => $_clearField(1);
   @$pb.TagNumber(1)
   User ensureUser() => $_ensure(0);
 
+  /// The friend status.
   @$pb.TagNumber(2)
   $1.Int32Value get state => $_getN(1);
   @$pb.TagNumber(2)
-  set state($1.Int32Value v) {
-    setField(2, v);
-  }
-
+  set state($1.Int32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasState() => $_has(1);
   @$pb.TagNumber(2)
-  void clearState() => clearField(2);
+  void clearState() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.Int32Value ensureState() => $_ensure(1);
 
+  /// Time of the latest relationship update.
   @$pb.TagNumber(3)
   $0.Timestamp get updateTime => $_getN(2);
   @$pb.TagNumber(3)
-  set updateTime($0.Timestamp v) {
-    setField(3, v);
-  }
-
+  set updateTime($0.Timestamp value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasUpdateTime() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUpdateTime() => clearField(3);
+  void clearUpdateTime() => $_clearField(3);
   @$pb.TagNumber(3)
   $0.Timestamp ensureUpdateTime() => $_ensure(2);
+
+  /// Metadata.
+  @$pb.TagNumber(4)
+  $core.String get metadata => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set metadata($core.String value) => $_setString(3, value);
+  @$pb.TagNumber(4)
+  $core.bool hasMetadata() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMetadata() => $_clearField(4);
 }
 
+/// A collection of zero or more friends of the user.
 class FriendList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'FriendList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<Friend>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'friends',
-        $pb.PbFieldType.PM,
-        subBuilder: Friend.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  FriendList._() : super();
   factory FriendList({
     $core.Iterable<Friend>? friends,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (friends != null) {
-      _result.friends.addAll(friends);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (friends != null) result.friends.addAll(friends);
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory FriendList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory FriendList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  FriendList clone() => FriendList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  FriendList._();
+
+  factory FriendList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory FriendList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'FriendList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<Friend>(1, _omitFieldNames ? '' : 'friends',
+        subBuilder: Friend.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  FriendList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   FriendList copyWith(void Function(FriendList) updates) =>
-      super.copyWith((message) => updates(message as FriendList))
-          as FriendList; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FriendList)) as FriendList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static FriendList create() => FriendList._();
+  @$core.override
   FriendList createEmptyInstance() => create();
   static $pb.PbList<FriendList> createRepeated() => $pb.PbList<FriendList>();
   @$core.pragma('dart2js:noInline')
@@ -4204,86 +3314,213 @@ class FriendList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<FriendList>(create);
   static FriendList? _defaultInstance;
 
+  /// The Friend objects.
   @$pb.TagNumber(1)
-  $core.List<Friend> get friends => $_getList(0);
+  $pb.PbList<Friend> get friends => $_getList(0);
 
+  /// Cursor for the next page of results, if any.
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 }
 
-class GetUsersRequest extends $pb.GeneratedMessage {
+/// A friend of a friend.
+class FriendsOfFriendsList_FriendOfFriend extends $pb.GeneratedMessage {
+  factory FriendsOfFriendsList_FriendOfFriend({
+    $core.String? referrer,
+    User? user,
+  }) {
+    final result = create();
+    if (referrer != null) result.referrer = referrer;
+    if (user != null) result.user = user;
+    return result;
+  }
+
+  FriendsOfFriendsList_FriendOfFriend._();
+
+  factory FriendsOfFriendsList_FriendOfFriend.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory FriendsOfFriendsList_FriendOfFriend.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GetUsersRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'FriendsOfFriendsList.FriendOfFriend',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..pPS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ids')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'usernames')
-    ..pPS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'facebookIds')
+    ..aOS(1, _omitFieldNames ? '' : 'referrer')
+    ..aOM<User>(2, _omitFieldNames ? '' : 'user', subBuilder: User.create)
     ..hasRequiredFields = false;
 
-  GetUsersRequest._() : super();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  FriendsOfFriendsList_FriendOfFriend clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  FriendsOfFriendsList_FriendOfFriend copyWith(
+          void Function(FriendsOfFriendsList_FriendOfFriend) updates) =>
+      super.copyWith((message) =>
+              updates(message as FriendsOfFriendsList_FriendOfFriend))
+          as FriendsOfFriendsList_FriendOfFriend;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FriendsOfFriendsList_FriendOfFriend create() =>
+      FriendsOfFriendsList_FriendOfFriend._();
+  @$core.override
+  FriendsOfFriendsList_FriendOfFriend createEmptyInstance() => create();
+  static $pb.PbList<FriendsOfFriendsList_FriendOfFriend> createRepeated() =>
+      $pb.PbList<FriendsOfFriendsList_FriendOfFriend>();
+  @$core.pragma('dart2js:noInline')
+  static FriendsOfFriendsList_FriendOfFriend getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
+          FriendsOfFriendsList_FriendOfFriend>(create);
+  static FriendsOfFriendsList_FriendOfFriend? _defaultInstance;
+
+  /// The user who referred its friend.
+  @$pb.TagNumber(1)
+  $core.String get referrer => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set referrer($core.String value) => $_setString(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasReferrer() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearReferrer() => $_clearField(1);
+
+  /// User.
+  @$pb.TagNumber(2)
+  User get user => $_getN(1);
+  @$pb.TagNumber(2)
+  set user(User value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasUser() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearUser() => $_clearField(2);
+  @$pb.TagNumber(2)
+  User ensureUser() => $_ensure(1);
+}
+
+/// A List of friends of friends
+class FriendsOfFriendsList extends $pb.GeneratedMessage {
+  factory FriendsOfFriendsList({
+    $core.Iterable<FriendsOfFriendsList_FriendOfFriend>? friendsOfFriends,
+    $core.String? cursor,
+  }) {
+    final result = create();
+    if (friendsOfFriends != null)
+      result.friendsOfFriends.addAll(friendsOfFriends);
+    if (cursor != null) result.cursor = cursor;
+    return result;
+  }
+
+  FriendsOfFriendsList._();
+
+  factory FriendsOfFriendsList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory FriendsOfFriendsList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'FriendsOfFriendsList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<FriendsOfFriendsList_FriendOfFriend>(
+        1, _omitFieldNames ? '' : 'friendsOfFriends',
+        subBuilder: FriendsOfFriendsList_FriendOfFriend.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  FriendsOfFriendsList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  FriendsOfFriendsList copyWith(void Function(FriendsOfFriendsList) updates) =>
+      super.copyWith((message) => updates(message as FriendsOfFriendsList))
+          as FriendsOfFriendsList;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FriendsOfFriendsList create() => FriendsOfFriendsList._();
+  @$core.override
+  FriendsOfFriendsList createEmptyInstance() => create();
+  static $pb.PbList<FriendsOfFriendsList> createRepeated() =>
+      $pb.PbList<FriendsOfFriendsList>();
+  @$core.pragma('dart2js:noInline')
+  static FriendsOfFriendsList getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<FriendsOfFriendsList>(create);
+  static FriendsOfFriendsList? _defaultInstance;
+
+  /// User friends of friends.
+  @$pb.TagNumber(1)
+  $pb.PbList<FriendsOfFriendsList_FriendOfFriend> get friendsOfFriends =>
+      $_getList(0);
+
+  /// Cursor for the next page of results, if any.
+  @$pb.TagNumber(2)
+  $core.String get cursor => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set cursor($core.String value) => $_setString(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasCursor() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCursor() => $_clearField(2);
+}
+
+/// Fetch a batch of zero or more users from the server.
+class GetUsersRequest extends $pb.GeneratedMessage {
   factory GetUsersRequest({
     $core.Iterable<$core.String>? ids,
     $core.Iterable<$core.String>? usernames,
     $core.Iterable<$core.String>? facebookIds,
   }) {
-    final _result = create();
-    if (ids != null) {
-      _result.ids.addAll(ids);
-    }
-    if (usernames != null) {
-      _result.usernames.addAll(usernames);
-    }
-    if (facebookIds != null) {
-      _result.facebookIds.addAll(facebookIds);
-    }
-    return _result;
+    final result = create();
+    if (ids != null) result.ids.addAll(ids);
+    if (usernames != null) result.usernames.addAll(usernames);
+    if (facebookIds != null) result.facebookIds.addAll(facebookIds);
+    return result;
   }
-  factory GetUsersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetUsersRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetUsersRequest clone() => GetUsersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  GetUsersRequest._();
+
+  factory GetUsersRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GetUsersRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GetUsersRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'ids')
+    ..pPS(2, _omitFieldNames ? '' : 'usernames')
+    ..pPS(3, _omitFieldNames ? '' : 'facebookIds')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetUsersRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   GetUsersRequest copyWith(void Function(GetUsersRequest) updates) =>
       super.copyWith((message) => updates(message as GetUsersRequest))
-          as GetUsersRequest; // ignore: deprecated_member_use
+          as GetUsersRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static GetUsersRequest create() => GetUsersRequest._();
+  @$core.override
   GetUsersRequest createEmptyInstance() => create();
   static $pb.PbList<GetUsersRequest> createRepeated() =>
       $pb.PbList<GetUsersRequest>();
@@ -4292,64 +3529,59 @@ class GetUsersRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<GetUsersRequest>(create);
   static GetUsersRequest? _defaultInstance;
 
+  /// The account id of a user.
   @$pb.TagNumber(1)
-  $core.List<$core.String> get ids => $_getList(0);
+  $pb.PbList<$core.String> get ids => $_getList(0);
 
+  /// The account username of a user.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get usernames => $_getList(1);
+  $pb.PbList<$core.String> get usernames => $_getList(1);
 
+  /// The Facebook ID of a user.
   @$pb.TagNumber(3)
-  $core.List<$core.String> get facebookIds => $_getList(2);
+  $pb.PbList<$core.String> get facebookIds => $_getList(2);
 }
 
+/// Fetch a subscription by product id.
 class GetSubscriptionRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GetSubscriptionRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'productId')
-    ..hasRequiredFields = false;
-
-  GetSubscriptionRequest._() : super();
   factory GetSubscriptionRequest({
     $core.String? productId,
   }) {
-    final _result = create();
-    if (productId != null) {
-      _result.productId = productId;
-    }
-    return _result;
+    final result = create();
+    if (productId != null) result.productId = productId;
+    return result;
   }
-  factory GetSubscriptionRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetSubscriptionRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetSubscriptionRequest clone() =>
-      GetSubscriptionRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  GetSubscriptionRequest._();
+
+  factory GetSubscriptionRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GetSubscriptionRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GetSubscriptionRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'productId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetSubscriptionRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   GetSubscriptionRequest copyWith(
           void Function(GetSubscriptionRequest) updates) =>
       super.copyWith((message) => updates(message as GetSubscriptionRequest))
-          as GetSubscriptionRequest; // ignore: deprecated_member_use
+          as GetSubscriptionRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static GetSubscriptionRequest create() => GetSubscriptionRequest._();
+  @$core.override
   GetSubscriptionRequest createEmptyInstance() => create();
   static $pb.PbList<GetSubscriptionRequest> createRepeated() =>
       $pb.PbList<GetSubscriptionRequest>();
@@ -4358,97 +3590,19 @@ class GetSubscriptionRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<GetSubscriptionRequest>(create);
   static GetSubscriptionRequest? _defaultInstance;
 
+  /// Product id of the subscription
   @$pb.TagNumber(1)
   $core.String get productId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set productId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set productId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasProductId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearProductId() => clearField(1);
+  void clearProductId() => $_clearField(1);
 }
 
+/// A group in the server.
 class Group extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Group',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'creatorId')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'description')
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'langTag')
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'metadata')
-    ..aOS(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'avatarUrl')
-    ..aOM<$1.BoolValue>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'open',
-        subBuilder: $1.BoolValue.create)
-    ..a<$core.int>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'edgeCount',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxCount',
-        $pb.PbFieldType.O3)
-    ..aOM<$0.Timestamp>(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..hasRequiredFields = false;
-
-  Group._() : super();
   factory Group({
     $core.String? id,
     $core.String? creatorId,
@@ -4463,64 +3617,64 @@ class Group extends $pb.GeneratedMessage {
     $0.Timestamp? createTime,
     $0.Timestamp? updateTime,
   }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (creatorId != null) {
-      _result.creatorId = creatorId;
-    }
-    if (name != null) {
-      _result.name = name;
-    }
-    if (description != null) {
-      _result.description = description;
-    }
-    if (langTag != null) {
-      _result.langTag = langTag;
-    }
-    if (metadata != null) {
-      _result.metadata = metadata;
-    }
-    if (avatarUrl != null) {
-      _result.avatarUrl = avatarUrl;
-    }
-    if (open != null) {
-      _result.open = open;
-    }
-    if (edgeCount != null) {
-      _result.edgeCount = edgeCount;
-    }
-    if (maxCount != null) {
-      _result.maxCount = maxCount;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    return _result;
+    final result = create();
+    if (id != null) result.id = id;
+    if (creatorId != null) result.creatorId = creatorId;
+    if (name != null) result.name = name;
+    if (description != null) result.description = description;
+    if (langTag != null) result.langTag = langTag;
+    if (metadata != null) result.metadata = metadata;
+    if (avatarUrl != null) result.avatarUrl = avatarUrl;
+    if (open != null) result.open = open;
+    if (edgeCount != null) result.edgeCount = edgeCount;
+    if (maxCount != null) result.maxCount = maxCount;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    return result;
   }
-  factory Group.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Group.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Group clone() => Group()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Group._();
+
+  factory Group.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Group.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Group',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..aOS(2, _omitFieldNames ? '' : 'creatorId')
+    ..aOS(3, _omitFieldNames ? '' : 'name')
+    ..aOS(4, _omitFieldNames ? '' : 'description')
+    ..aOS(5, _omitFieldNames ? '' : 'langTag')
+    ..aOS(6, _omitFieldNames ? '' : 'metadata')
+    ..aOS(7, _omitFieldNames ? '' : 'avatarUrl')
+    ..aOM<$1.BoolValue>(8, _omitFieldNames ? '' : 'open',
+        subBuilder: $1.BoolValue.create)
+    ..aI(9, _omitFieldNames ? '' : 'edgeCount')
+    ..aI(10, _omitFieldNames ? '' : 'maxCount')
+    ..aOM<$0.Timestamp>(11, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(12, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Group clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Group copyWith(void Function(Group) updates) =>
-      super.copyWith((message) => updates(message as Group))
-          as Group; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Group)) as Group;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Group create() => Group._();
+  @$core.override
   Group createEmptyInstance() => create();
   static $pb.PbList<Group> createRepeated() => $pb.PbList<Group>();
   @$core.pragma('dart2js:noInline')
@@ -4528,214 +3682,174 @@ class Group extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Group>(create);
   static Group? _defaultInstance;
 
+  /// The id of a group.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// The id of the user who created the group.
   @$pb.TagNumber(2)
   $core.String get creatorId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set creatorId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set creatorId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCreatorId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCreatorId() => clearField(2);
+  void clearCreatorId() => $_clearField(2);
 
+  /// The unique name of the group.
   @$pb.TagNumber(3)
   $core.String get name => $_getSZ(2);
   @$pb.TagNumber(3)
-  set name($core.String v) {
-    $_setString(2, v);
-  }
-
+  set name($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasName() => $_has(2);
   @$pb.TagNumber(3)
-  void clearName() => clearField(3);
+  void clearName() => $_clearField(3);
 
+  /// A description for the group.
   @$pb.TagNumber(4)
   $core.String get description => $_getSZ(3);
   @$pb.TagNumber(4)
-  set description($core.String v) {
-    $_setString(3, v);
-  }
-
+  set description($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasDescription() => $_has(3);
   @$pb.TagNumber(4)
-  void clearDescription() => clearField(4);
+  void clearDescription() => $_clearField(4);
 
+  /// The language expected to be a tag which follows the BCP-47 spec.
   @$pb.TagNumber(5)
   $core.String get langTag => $_getSZ(4);
   @$pb.TagNumber(5)
-  set langTag($core.String v) {
-    $_setString(4, v);
-  }
-
+  set langTag($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasLangTag() => $_has(4);
   @$pb.TagNumber(5)
-  void clearLangTag() => clearField(5);
+  void clearLangTag() => $_clearField(5);
 
+  /// Additional information stored as a JSON object.
   @$pb.TagNumber(6)
   $core.String get metadata => $_getSZ(5);
   @$pb.TagNumber(6)
-  set metadata($core.String v) {
-    $_setString(5, v);
-  }
-
+  set metadata($core.String value) => $_setString(5, value);
   @$pb.TagNumber(6)
   $core.bool hasMetadata() => $_has(5);
   @$pb.TagNumber(6)
-  void clearMetadata() => clearField(6);
+  void clearMetadata() => $_clearField(6);
 
+  /// A URL for an avatar image.
   @$pb.TagNumber(7)
   $core.String get avatarUrl => $_getSZ(6);
   @$pb.TagNumber(7)
-  set avatarUrl($core.String v) {
-    $_setString(6, v);
-  }
-
+  set avatarUrl($core.String value) => $_setString(6, value);
   @$pb.TagNumber(7)
   $core.bool hasAvatarUrl() => $_has(6);
   @$pb.TagNumber(7)
-  void clearAvatarUrl() => clearField(7);
+  void clearAvatarUrl() => $_clearField(7);
 
+  /// Anyone can join open groups, otherwise only admins can accept members.
   @$pb.TagNumber(8)
   $1.BoolValue get open => $_getN(7);
   @$pb.TagNumber(8)
-  set open($1.BoolValue v) {
-    setField(8, v);
-  }
-
+  set open($1.BoolValue value) => $_setField(8, value);
   @$pb.TagNumber(8)
   $core.bool hasOpen() => $_has(7);
   @$pb.TagNumber(8)
-  void clearOpen() => clearField(8);
+  void clearOpen() => $_clearField(8);
   @$pb.TagNumber(8)
   $1.BoolValue ensureOpen() => $_ensure(7);
 
+  /// The current count of all members in the group.
   @$pb.TagNumber(9)
   $core.int get edgeCount => $_getIZ(8);
   @$pb.TagNumber(9)
-  set edgeCount($core.int v) {
-    $_setSignedInt32(8, v);
-  }
-
+  set edgeCount($core.int value) => $_setSignedInt32(8, value);
   @$pb.TagNumber(9)
   $core.bool hasEdgeCount() => $_has(8);
   @$pb.TagNumber(9)
-  void clearEdgeCount() => clearField(9);
+  void clearEdgeCount() => $_clearField(9);
 
+  /// The maximum number of members allowed.
   @$pb.TagNumber(10)
   $core.int get maxCount => $_getIZ(9);
   @$pb.TagNumber(10)
-  set maxCount($core.int v) {
-    $_setSignedInt32(9, v);
-  }
-
+  set maxCount($core.int value) => $_setSignedInt32(9, value);
   @$pb.TagNumber(10)
   $core.bool hasMaxCount() => $_has(9);
   @$pb.TagNumber(10)
-  void clearMaxCount() => clearField(10);
+  void clearMaxCount() => $_clearField(10);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the group was created.
   @$pb.TagNumber(11)
   $0.Timestamp get createTime => $_getN(10);
   @$pb.TagNumber(11)
-  set createTime($0.Timestamp v) {
-    setField(11, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(11, value);
   @$pb.TagNumber(11)
   $core.bool hasCreateTime() => $_has(10);
   @$pb.TagNumber(11)
-  void clearCreateTime() => clearField(11);
+  void clearCreateTime() => $_clearField(11);
   @$pb.TagNumber(11)
   $0.Timestamp ensureCreateTime() => $_ensure(10);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the group was last updated.
   @$pb.TagNumber(12)
   $0.Timestamp get updateTime => $_getN(11);
   @$pb.TagNumber(12)
-  set updateTime($0.Timestamp v) {
-    setField(12, v);
-  }
-
+  set updateTime($0.Timestamp value) => $_setField(12, value);
   @$pb.TagNumber(12)
   $core.bool hasUpdateTime() => $_has(11);
   @$pb.TagNumber(12)
-  void clearUpdateTime() => clearField(12);
+  void clearUpdateTime() => $_clearField(12);
   @$pb.TagNumber(12)
   $0.Timestamp ensureUpdateTime() => $_ensure(11);
 }
 
+/// One or more groups returned from a listing operation.
 class GroupList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GroupList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<Group>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groups',
-        $pb.PbFieldType.PM,
-        subBuilder: Group.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  GroupList._() : super();
   factory GroupList({
     $core.Iterable<Group>? groups,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (groups != null) {
-      _result.groups.addAll(groups);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (groups != null) result.groups.addAll(groups);
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory GroupList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GroupList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GroupList clone() => GroupList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  GroupList._();
+
+  factory GroupList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GroupList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GroupList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<Group>(1, _omitFieldNames ? '' : 'groups', subBuilder: Group.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GroupList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   GroupList copyWith(void Function(GroupList) updates) =>
-      super.copyWith((message) => updates(message as GroupList))
-          as GroupList; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as GroupList)) as GroupList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static GroupList create() => GroupList._();
+  @$core.override
   GroupList createEmptyInstance() => create();
   static $pb.PbList<GroupList> createRepeated() => $pb.PbList<GroupList>();
   @$core.pragma('dart2js:noInline')
@@ -4743,81 +3857,65 @@ class GroupList extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GroupList>(create);
   static GroupList? _defaultInstance;
 
+  /// One or more groups.
   @$pb.TagNumber(1)
-  $core.List<Group> get groups => $_getList(0);
+  $pb.PbList<Group> get groups => $_getList(0);
 
+  /// A cursor used to get the next page.
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 }
 
+/// A single user-role pair.
 class GroupUserList_GroupUser extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GroupUserList.GroupUser',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<User>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'user',
-        subBuilder: User.create)
-    ..aOM<$1.Int32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'state',
-        subBuilder: $1.Int32Value.create)
-    ..hasRequiredFields = false;
-
-  GroupUserList_GroupUser._() : super();
   factory GroupUserList_GroupUser({
     User? user,
     $1.Int32Value? state,
   }) {
-    final _result = create();
-    if (user != null) {
-      _result.user = user;
-    }
-    if (state != null) {
-      _result.state = state;
-    }
-    return _result;
+    final result = create();
+    if (user != null) result.user = user;
+    if (state != null) result.state = state;
+    return result;
   }
-  factory GroupUserList_GroupUser.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GroupUserList_GroupUser.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GroupUserList_GroupUser clone() =>
-      GroupUserList_GroupUser()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  GroupUserList_GroupUser._();
+
+  factory GroupUserList_GroupUser.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GroupUserList_GroupUser.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GroupUserList.GroupUser',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<User>(1, _omitFieldNames ? '' : 'user', subBuilder: User.create)
+    ..aOM<$1.Int32Value>(2, _omitFieldNames ? '' : 'state',
+        subBuilder: $1.Int32Value.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GroupUserList_GroupUser clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   GroupUserList_GroupUser copyWith(
           void Function(GroupUserList_GroupUser) updates) =>
       super.copyWith((message) => updates(message as GroupUserList_GroupUser))
-          as GroupUserList_GroupUser; // ignore: deprecated_member_use
+          as GroupUserList_GroupUser;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static GroupUserList_GroupUser create() => GroupUserList_GroupUser._();
+  @$core.override
   GroupUserList_GroupUser createEmptyInstance() => create();
   static $pb.PbList<GroupUserList_GroupUser> createRepeated() =>
       $pb.PbList<GroupUserList_GroupUser>();
@@ -4826,92 +3924,74 @@ class GroupUserList_GroupUser extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<GroupUserList_GroupUser>(create);
   static GroupUserList_GroupUser? _defaultInstance;
 
+  /// User.
   @$pb.TagNumber(1)
   User get user => $_getN(0);
   @$pb.TagNumber(1)
-  set user(User v) {
-    setField(1, v);
-  }
-
+  set user(User value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasUser() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUser() => clearField(1);
+  void clearUser() => $_clearField(1);
   @$pb.TagNumber(1)
   User ensureUser() => $_ensure(0);
 
+  /// Their relationship to the group.
   @$pb.TagNumber(2)
   $1.Int32Value get state => $_getN(1);
   @$pb.TagNumber(2)
-  set state($1.Int32Value v) {
-    setField(2, v);
-  }
-
+  set state($1.Int32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasState() => $_has(1);
   @$pb.TagNumber(2)
-  void clearState() => clearField(2);
+  void clearState() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.Int32Value ensureState() => $_ensure(1);
 }
 
+/// A list of users belonging to a group, along with their role.
 class GroupUserList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GroupUserList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<GroupUserList_GroupUser>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupUsers',
-        $pb.PbFieldType.PM,
-        subBuilder: GroupUserList_GroupUser.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  GroupUserList._() : super();
   factory GroupUserList({
     $core.Iterable<GroupUserList_GroupUser>? groupUsers,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (groupUsers != null) {
-      _result.groupUsers.addAll(groupUsers);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (groupUsers != null) result.groupUsers.addAll(groupUsers);
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory GroupUserList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GroupUserList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GroupUserList clone() => GroupUserList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  GroupUserList._();
+
+  factory GroupUserList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GroupUserList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GroupUserList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<GroupUserList_GroupUser>(1, _omitFieldNames ? '' : 'groupUsers',
+        subBuilder: GroupUserList_GroupUser.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GroupUserList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   GroupUserList copyWith(void Function(GroupUserList) updates) =>
       super.copyWith((message) => updates(message as GroupUserList))
-          as GroupUserList; // ignore: deprecated_member_use
+          as GroupUserList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static GroupUserList create() => GroupUserList._();
+  @$core.override
   GroupUserList createEmptyInstance() => create();
   static $pb.PbList<GroupUserList> createRepeated() =>
       $pb.PbList<GroupUserList>();
@@ -4920,83 +4000,68 @@ class GroupUserList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<GroupUserList>(create);
   static GroupUserList? _defaultInstance;
 
+  /// User-role pairs for a group.
   @$pb.TagNumber(1)
-  $core.List<GroupUserList_GroupUser> get groupUsers => $_getList(0);
+  $pb.PbList<GroupUserList_GroupUser> get groupUsers => $_getList(0);
 
+  /// Cursor for the next page of results, if any.
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 }
 
+/// Import Facebook friends into the current user's account.
 class ImportFacebookFriendsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ImportFacebookFriendsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountFacebook>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountFacebook.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reset',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  ImportFacebookFriendsRequest._() : super();
   factory ImportFacebookFriendsRequest({
     AccountFacebook? account,
     $1.BoolValue? reset,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (reset != null) {
-      _result.reset = reset;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (reset != null) result.reset = reset;
+    return result;
   }
-  factory ImportFacebookFriendsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ImportFacebookFriendsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ImportFacebookFriendsRequest clone() =>
-      ImportFacebookFriendsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ImportFacebookFriendsRequest._();
+
+  factory ImportFacebookFriendsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ImportFacebookFriendsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ImportFacebookFriendsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountFacebook>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountFacebook.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'reset',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ImportFacebookFriendsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ImportFacebookFriendsRequest copyWith(
           void Function(ImportFacebookFriendsRequest) updates) =>
       super.copyWith(
               (message) => updates(message as ImportFacebookFriendsRequest))
-          as ImportFacebookFriendsRequest; // ignore: deprecated_member_use
+          as ImportFacebookFriendsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ImportFacebookFriendsRequest create() =>
       ImportFacebookFriendsRequest._();
+  @$core.override
   ImportFacebookFriendsRequest createEmptyInstance() => create();
   static $pb.PbList<ImportFacebookFriendsRequest> createRepeated() =>
       $pb.PbList<ImportFacebookFriendsRequest>();
@@ -5005,94 +4070,76 @@ class ImportFacebookFriendsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ImportFacebookFriendsRequest>(create);
   static ImportFacebookFriendsRequest? _defaultInstance;
 
+  /// The Facebook account details.
   @$pb.TagNumber(1)
   AccountFacebook get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountFacebook v) {
-    setField(1, v);
-  }
-
+  set account(AccountFacebook value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountFacebook ensureAccount() => $_ensure(0);
 
+  /// Reset the current user's friends list.
   @$pb.TagNumber(2)
   $1.BoolValue get reset => $_getN(1);
   @$pb.TagNumber(2)
-  set reset($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set reset($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasReset() => $_has(1);
   @$pb.TagNumber(2)
-  void clearReset() => clearField(2);
+  void clearReset() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureReset() => $_ensure(1);
 }
 
+/// Import Facebook friends into the current user's account.
 class ImportSteamFriendsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ImportSteamFriendsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountSteam>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountSteam.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reset',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  ImportSteamFriendsRequest._() : super();
   factory ImportSteamFriendsRequest({
     AccountSteam? account,
     $1.BoolValue? reset,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (reset != null) {
-      _result.reset = reset;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (reset != null) result.reset = reset;
+    return result;
   }
-  factory ImportSteamFriendsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ImportSteamFriendsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ImportSteamFriendsRequest clone() =>
-      ImportSteamFriendsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ImportSteamFriendsRequest._();
+
+  factory ImportSteamFriendsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ImportSteamFriendsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ImportSteamFriendsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountSteam>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountSteam.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'reset',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ImportSteamFriendsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ImportSteamFriendsRequest copyWith(
           void Function(ImportSteamFriendsRequest) updates) =>
       super.copyWith((message) => updates(message as ImportSteamFriendsRequest))
-          as ImportSteamFriendsRequest; // ignore: deprecated_member_use
+          as ImportSteamFriendsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ImportSteamFriendsRequest create() => ImportSteamFriendsRequest._();
+  @$core.override
   ImportSteamFriendsRequest createEmptyInstance() => create();
   static $pb.PbList<ImportSteamFriendsRequest> createRepeated() =>
       $pb.PbList<ImportSteamFriendsRequest>();
@@ -5101,81 +4148,70 @@ class ImportSteamFriendsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ImportSteamFriendsRequest>(create);
   static ImportSteamFriendsRequest? _defaultInstance;
 
+  /// The Facebook account details.
   @$pb.TagNumber(1)
   AccountSteam get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountSteam v) {
-    setField(1, v);
-  }
-
+  set account(AccountSteam value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountSteam ensureAccount() => $_ensure(0);
 
+  /// Reset the current user's friends list.
   @$pb.TagNumber(2)
   $1.BoolValue get reset => $_getN(1);
   @$pb.TagNumber(2)
-  set reset($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set reset($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasReset() => $_has(1);
   @$pb.TagNumber(2)
-  void clearReset() => clearField(2);
+  void clearReset() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureReset() => $_ensure(1);
 }
 
+/// Immediately join an open group, or request to join a closed one.
 class JoinGroupRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'JoinGroupRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..hasRequiredFields = false;
-
-  JoinGroupRequest._() : super();
   factory JoinGroupRequest({
     $core.String? groupId,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    return result;
   }
-  factory JoinGroupRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory JoinGroupRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  JoinGroupRequest clone() => JoinGroupRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  JoinGroupRequest._();
+
+  factory JoinGroupRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory JoinGroupRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'JoinGroupRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  JoinGroupRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   JoinGroupRequest copyWith(void Function(JoinGroupRequest) updates) =>
       super.copyWith((message) => updates(message as JoinGroupRequest))
-          as JoinGroupRequest; // ignore: deprecated_member_use
+          as JoinGroupRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static JoinGroupRequest create() => JoinGroupRequest._();
+  @$core.override
   JoinGroupRequest createEmptyInstance() => create();
   static $pb.PbList<JoinGroupRequest> createRepeated() =>
       $pb.PbList<JoinGroupRequest>();
@@ -5184,67 +4220,57 @@ class JoinGroupRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<JoinGroupRequest>(create);
   static JoinGroupRequest? _defaultInstance;
 
+  /// The group ID to join. The group must already exist.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 }
 
+/// The request to join a tournament.
 class JoinTournamentRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'JoinTournamentRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'tournamentId')
-    ..hasRequiredFields = false;
-
-  JoinTournamentRequest._() : super();
   factory JoinTournamentRequest({
     $core.String? tournamentId,
   }) {
-    final _result = create();
-    if (tournamentId != null) {
-      _result.tournamentId = tournamentId;
-    }
-    return _result;
+    final result = create();
+    if (tournamentId != null) result.tournamentId = tournamentId;
+    return result;
   }
-  factory JoinTournamentRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory JoinTournamentRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  JoinTournamentRequest clone() =>
-      JoinTournamentRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  JoinTournamentRequest._();
+
+  factory JoinTournamentRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory JoinTournamentRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'JoinTournamentRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'tournamentId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  JoinTournamentRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   JoinTournamentRequest copyWith(
           void Function(JoinTournamentRequest) updates) =>
       super.copyWith((message) => updates(message as JoinTournamentRequest))
-          as JoinTournamentRequest; // ignore: deprecated_member_use
+          as JoinTournamentRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static JoinTournamentRequest create() => JoinTournamentRequest._();
+  @$core.override
   JoinTournamentRequest createEmptyInstance() => create();
   static $pb.PbList<JoinTournamentRequest> createRepeated() =>
       $pb.PbList<JoinTournamentRequest>();
@@ -5253,76 +4279,60 @@ class JoinTournamentRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<JoinTournamentRequest>(create);
   static JoinTournamentRequest? _defaultInstance;
 
+  /// The ID of the tournament to join. The tournament must already exist.
   @$pb.TagNumber(1)
   $core.String get tournamentId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set tournamentId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set tournamentId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTournamentId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTournamentId() => clearField(1);
+  void clearTournamentId() => $_clearField(1);
 }
 
+/// Kick a set of users from a group.
 class KickGroupUsersRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'KickGroupUsersRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIds')
-    ..hasRequiredFields = false;
-
-  KickGroupUsersRequest._() : super();
   factory KickGroupUsersRequest({
     $core.String? groupId,
     $core.Iterable<$core.String>? userIds,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIds != null) {
-      _result.userIds.addAll(userIds);
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    if (userIds != null) result.userIds.addAll(userIds);
+    return result;
   }
-  factory KickGroupUsersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory KickGroupUsersRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  KickGroupUsersRequest clone() =>
-      KickGroupUsersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  KickGroupUsersRequest._();
+
+  factory KickGroupUsersRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory KickGroupUsersRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'KickGroupUsersRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..pPS(2, _omitFieldNames ? '' : 'userIds')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  KickGroupUsersRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   KickGroupUsersRequest copyWith(
           void Function(KickGroupUsersRequest) updates) =>
       super.copyWith((message) => updates(message as KickGroupUsersRequest))
-          as KickGroupUsersRequest; // ignore: deprecated_member_use
+          as KickGroupUsersRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static KickGroupUsersRequest create() => KickGroupUsersRequest._();
+  @$core.override
   KickGroupUsersRequest createEmptyInstance() => create();
   static $pb.PbList<KickGroupUsersRequest> createRepeated() =>
       $pb.PbList<KickGroupUsersRequest>();
@@ -5331,83 +4341,23 @@ class KickGroupUsersRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<KickGroupUsersRequest>(create);
   static KickGroupUsersRequest? _defaultInstance;
 
+  /// The group ID to kick from.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 
+  /// The users to kick.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get userIds => $_getList(1);
+  $pb.PbList<$core.String> get userIds => $_getList(1);
 }
 
+/// A leaderboard on the server.
 class Leaderboard extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Leaderboard',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sortOrder',
-        $pb.PbFieldType.OU3)
-    ..e<Operator>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'operator',
-        $pb.PbFieldType.OE,
-        defaultOrMaker: Operator.NO_OVERRIDE,
-        valueOf: Operator.valueOf,
-        enumValues: Operator.values)
-    ..a<$core.int>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'prevReset',
-        $pb.PbFieldType.OU3)
-    ..a<$core.int>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'nextReset',
-        $pb.PbFieldType.OU3)
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'metadata')
-    ..aOM<$0.Timestamp>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOB(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'authoritative')
-    ..hasRequiredFields = false;
-
-  Leaderboard._() : super();
   factory Leaderboard({
     $core.String? id,
     $core.int? sortOrder,
@@ -5418,52 +4368,56 @@ class Leaderboard extends $pb.GeneratedMessage {
     $0.Timestamp? createTime,
     $core.bool? authoritative,
   }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (sortOrder != null) {
-      _result.sortOrder = sortOrder;
-    }
-    if (operator != null) {
-      _result.operator = operator;
-    }
-    if (prevReset != null) {
-      _result.prevReset = prevReset;
-    }
-    if (nextReset != null) {
-      _result.nextReset = nextReset;
-    }
-    if (metadata != null) {
-      _result.metadata = metadata;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (authoritative != null) {
-      _result.authoritative = authoritative;
-    }
-    return _result;
+    final result = create();
+    if (id != null) result.id = id;
+    if (sortOrder != null) result.sortOrder = sortOrder;
+    if (operator != null) result.operator = operator;
+    if (prevReset != null) result.prevReset = prevReset;
+    if (nextReset != null) result.nextReset = nextReset;
+    if (metadata != null) result.metadata = metadata;
+    if (createTime != null) result.createTime = createTime;
+    if (authoritative != null) result.authoritative = authoritative;
+    return result;
   }
-  factory Leaderboard.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Leaderboard.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Leaderboard clone() => Leaderboard()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Leaderboard._();
+
+  factory Leaderboard.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Leaderboard.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Leaderboard',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..aI(2, _omitFieldNames ? '' : 'sortOrder', fieldType: $pb.PbFieldType.OU3)
+    ..aE<Operator>(3, _omitFieldNames ? '' : 'operator',
+        enumValues: Operator.values)
+    ..aI(4, _omitFieldNames ? '' : 'prevReset', fieldType: $pb.PbFieldType.OU3)
+    ..aI(5, _omitFieldNames ? '' : 'nextReset', fieldType: $pb.PbFieldType.OU3)
+    ..aOS(6, _omitFieldNames ? '' : 'metadata')
+    ..aOM<$0.Timestamp>(7, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOB(8, _omitFieldNames ? '' : 'authoritative')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Leaderboard clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Leaderboard copyWith(void Function(Leaderboard) updates) =>
       super.copyWith((message) => updates(message as Leaderboard))
-          as Leaderboard; // ignore: deprecated_member_use
+          as Leaderboard;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Leaderboard create() => Leaderboard._();
+  @$core.override
   Leaderboard createEmptyInstance() => create();
   static $pb.PbList<Leaderboard> createRepeated() => $pb.PbList<Leaderboard>();
   @$core.pragma('dart2js:noInline')
@@ -5471,162 +4425,132 @@ class Leaderboard extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<Leaderboard>(create);
   static Leaderboard? _defaultInstance;
 
+  /// The ID of the leaderboard.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// ASC(0) or DESC(1) sort mode of scores in the leaderboard.
   @$pb.TagNumber(2)
   $core.int get sortOrder => $_getIZ(1);
   @$pb.TagNumber(2)
-  set sortOrder($core.int v) {
-    $_setUnsignedInt32(1, v);
-  }
-
+  set sortOrder($core.int value) => $_setUnsignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasSortOrder() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSortOrder() => clearField(2);
+  void clearSortOrder() => $_clearField(2);
 
+  /// BEST, SET, INCREMENT or DECREMENT operator mode of the leaderboard.
   @$pb.TagNumber(3)
   Operator get operator => $_getN(2);
   @$pb.TagNumber(3)
-  set operator(Operator v) {
-    setField(3, v);
-  }
-
+  set operator(Operator value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasOperator() => $_has(2);
   @$pb.TagNumber(3)
-  void clearOperator() => clearField(3);
+  void clearOperator() => $_clearField(3);
 
+  /// The UNIX time when the leaderboard was previously reset. A computed value.
   @$pb.TagNumber(4)
   $core.int get prevReset => $_getIZ(3);
   @$pb.TagNumber(4)
-  set prevReset($core.int v) {
-    $_setUnsignedInt32(3, v);
-  }
-
+  set prevReset($core.int value) => $_setUnsignedInt32(3, value);
   @$pb.TagNumber(4)
   $core.bool hasPrevReset() => $_has(3);
   @$pb.TagNumber(4)
-  void clearPrevReset() => clearField(4);
+  void clearPrevReset() => $_clearField(4);
 
+  /// The UNIX time when the leaderboard is next playable. A computed value.
   @$pb.TagNumber(5)
   $core.int get nextReset => $_getIZ(4);
   @$pb.TagNumber(5)
-  set nextReset($core.int v) {
-    $_setUnsignedInt32(4, v);
-  }
-
+  set nextReset($core.int value) => $_setUnsignedInt32(4, value);
   @$pb.TagNumber(5)
   $core.bool hasNextReset() => $_has(4);
   @$pb.TagNumber(5)
-  void clearNextReset() => clearField(5);
+  void clearNextReset() => $_clearField(5);
 
+  /// Additional information stored as a JSON object.
   @$pb.TagNumber(6)
   $core.String get metadata => $_getSZ(5);
   @$pb.TagNumber(6)
-  set metadata($core.String v) {
-    $_setString(5, v);
-  }
-
+  set metadata($core.String value) => $_setString(5, value);
   @$pb.TagNumber(6)
   $core.bool hasMetadata() => $_has(5);
   @$pb.TagNumber(6)
-  void clearMetadata() => clearField(6);
+  void clearMetadata() => $_clearField(6);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the leaderboard was created.
   @$pb.TagNumber(7)
   $0.Timestamp get createTime => $_getN(6);
   @$pb.TagNumber(7)
-  set createTime($0.Timestamp v) {
-    setField(7, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasCreateTime() => $_has(6);
   @$pb.TagNumber(7)
-  void clearCreateTime() => clearField(7);
+  void clearCreateTime() => $_clearField(7);
   @$pb.TagNumber(7)
   $0.Timestamp ensureCreateTime() => $_ensure(6);
 
+  /// Whether the leaderboard was created authoritatively or not.
   @$pb.TagNumber(8)
   $core.bool get authoritative => $_getBF(7);
   @$pb.TagNumber(8)
-  set authoritative($core.bool v) {
-    $_setBool(7, v);
-  }
-
+  set authoritative($core.bool value) => $_setBool(7, value);
   @$pb.TagNumber(8)
   $core.bool hasAuthoritative() => $_has(7);
   @$pb.TagNumber(8)
-  void clearAuthoritative() => clearField(8);
+  void clearAuthoritative() => $_clearField(8);
 }
 
+/// A list of leaderboards
 class LeaderboardList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'LeaderboardList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<Leaderboard>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaderboards',
-        $pb.PbFieldType.PM,
-        subBuilder: Leaderboard.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  LeaderboardList._() : super();
   factory LeaderboardList({
     $core.Iterable<Leaderboard>? leaderboards,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (leaderboards != null) {
-      _result.leaderboards.addAll(leaderboards);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (leaderboards != null) result.leaderboards.addAll(leaderboards);
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory LeaderboardList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LeaderboardList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  LeaderboardList clone() => LeaderboardList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  LeaderboardList._();
+
+  factory LeaderboardList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory LeaderboardList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'LeaderboardList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<Leaderboard>(1, _omitFieldNames ? '' : 'leaderboards',
+        subBuilder: Leaderboard.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  LeaderboardList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LeaderboardList copyWith(void Function(LeaderboardList) updates) =>
       super.copyWith((message) => updates(message as LeaderboardList))
-          as LeaderboardList; // ignore: deprecated_member_use
+          as LeaderboardList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static LeaderboardList create() => LeaderboardList._();
+  @$core.override
   LeaderboardList createEmptyInstance() => create();
   static $pb.PbList<LeaderboardList> createRepeated() =>
       $pb.PbList<LeaderboardList>();
@@ -5635,101 +4559,23 @@ class LeaderboardList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<LeaderboardList>(create);
   static LeaderboardList? _defaultInstance;
 
+  /// The list of leaderboards returned.
   @$pb.TagNumber(1)
-  $core.List<Leaderboard> get leaderboards => $_getList(0);
+  $pb.PbList<Leaderboard> get leaderboards => $_getList(0);
 
+  /// A pagination cursor (optional).
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 }
 
+/// Represents a complete leaderboard record with all scores and associated metadata.
 class LeaderboardRecord extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'LeaderboardRecord',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaderboardId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ownerId')
-    ..aOM<$1.StringValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username',
-        subBuilder: $1.StringValue.create)
-    ..aInt64(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'score')
-    ..aInt64(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'subscore')
-    ..a<$core.int>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'numScore',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'metadata')
-    ..aOM<$0.Timestamp>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'expiryTime',
-        subBuilder: $0.Timestamp.create)
-    ..aInt64(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'rank')
-    ..a<$core.int>(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxNumScore',
-        $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false;
-
-  LeaderboardRecord._() : super();
   factory LeaderboardRecord({
     $core.String? leaderboardId,
     $core.String? ownerId,
@@ -5744,64 +4590,67 @@ class LeaderboardRecord extends $pb.GeneratedMessage {
     $fixnum.Int64? rank,
     $core.int? maxNumScore,
   }) {
-    final _result = create();
-    if (leaderboardId != null) {
-      _result.leaderboardId = leaderboardId;
-    }
-    if (ownerId != null) {
-      _result.ownerId = ownerId;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    if (score != null) {
-      _result.score = score;
-    }
-    if (subscore != null) {
-      _result.subscore = subscore;
-    }
-    if (numScore != null) {
-      _result.numScore = numScore;
-    }
-    if (metadata != null) {
-      _result.metadata = metadata;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    if (expiryTime != null) {
-      _result.expiryTime = expiryTime;
-    }
-    if (rank != null) {
-      _result.rank = rank;
-    }
-    if (maxNumScore != null) {
-      _result.maxNumScore = maxNumScore;
-    }
-    return _result;
+    final result = create();
+    if (leaderboardId != null) result.leaderboardId = leaderboardId;
+    if (ownerId != null) result.ownerId = ownerId;
+    if (username != null) result.username = username;
+    if (score != null) result.score = score;
+    if (subscore != null) result.subscore = subscore;
+    if (numScore != null) result.numScore = numScore;
+    if (metadata != null) result.metadata = metadata;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    if (expiryTime != null) result.expiryTime = expiryTime;
+    if (rank != null) result.rank = rank;
+    if (maxNumScore != null) result.maxNumScore = maxNumScore;
+    return result;
   }
-  factory LeaderboardRecord.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LeaderboardRecord.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  LeaderboardRecord clone() => LeaderboardRecord()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  LeaderboardRecord._();
+
+  factory LeaderboardRecord.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory LeaderboardRecord.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'LeaderboardRecord',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'leaderboardId')
+    ..aOS(2, _omitFieldNames ? '' : 'ownerId')
+    ..aOM<$1.StringValue>(3, _omitFieldNames ? '' : 'username',
+        subBuilder: $1.StringValue.create)
+    ..aInt64(4, _omitFieldNames ? '' : 'score')
+    ..aInt64(5, _omitFieldNames ? '' : 'subscore')
+    ..aI(6, _omitFieldNames ? '' : 'numScore')
+    ..aOS(7, _omitFieldNames ? '' : 'metadata')
+    ..aOM<$0.Timestamp>(8, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(9, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(10, _omitFieldNames ? '' : 'expiryTime',
+        subBuilder: $0.Timestamp.create)
+    ..aInt64(11, _omitFieldNames ? '' : 'rank')
+    ..aI(12, _omitFieldNames ? '' : 'maxNumScore',
+        fieldType: $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  LeaderboardRecord clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LeaderboardRecord copyWith(void Function(LeaderboardRecord) updates) =>
       super.copyWith((message) => updates(message as LeaderboardRecord))
-          as LeaderboardRecord; // ignore: deprecated_member_use
+          as LeaderboardRecord;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static LeaderboardRecord create() => LeaderboardRecord._();
+  @$core.override
   LeaderboardRecord createEmptyInstance() => create();
   static $pb.PbList<LeaderboardRecord> createRepeated() =>
       $pb.PbList<LeaderboardRecord>();
@@ -5810,238 +4659,189 @@ class LeaderboardRecord extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<LeaderboardRecord>(create);
   static LeaderboardRecord? _defaultInstance;
 
+  /// The ID of the leaderboard this score belongs to.
   @$pb.TagNumber(1)
   $core.String get leaderboardId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set leaderboardId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set leaderboardId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasLeaderboardId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLeaderboardId() => clearField(1);
+  void clearLeaderboardId() => $_clearField(1);
 
+  /// The ID of the score owner, usually a user or group.
   @$pb.TagNumber(2)
   $core.String get ownerId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set ownerId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set ownerId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasOwnerId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearOwnerId() => clearField(2);
+  void clearOwnerId() => $_clearField(2);
 
+  /// The username of the score owner, if the owner is a user.
   @$pb.TagNumber(3)
   $1.StringValue get username => $_getN(2);
   @$pb.TagNumber(3)
-  set username($1.StringValue v) {
-    setField(3, v);
-  }
-
+  set username($1.StringValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.StringValue ensureUsername() => $_ensure(2);
 
+  /// The score value.
   @$pb.TagNumber(4)
   $fixnum.Int64 get score => $_getI64(3);
   @$pb.TagNumber(4)
-  set score($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set score($fixnum.Int64 value) => $_setInt64(3, value);
   @$pb.TagNumber(4)
   $core.bool hasScore() => $_has(3);
   @$pb.TagNumber(4)
-  void clearScore() => clearField(4);
+  void clearScore() => $_clearField(4);
 
+  /// An optional subscore value.
   @$pb.TagNumber(5)
   $fixnum.Int64 get subscore => $_getI64(4);
   @$pb.TagNumber(5)
-  set subscore($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set subscore($fixnum.Int64 value) => $_setInt64(4, value);
   @$pb.TagNumber(5)
   $core.bool hasSubscore() => $_has(4);
   @$pb.TagNumber(5)
-  void clearSubscore() => clearField(5);
+  void clearSubscore() => $_clearField(5);
 
+  /// The number of submissions to this score record.
   @$pb.TagNumber(6)
   $core.int get numScore => $_getIZ(5);
   @$pb.TagNumber(6)
-  set numScore($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set numScore($core.int value) => $_setSignedInt32(5, value);
   @$pb.TagNumber(6)
   $core.bool hasNumScore() => $_has(5);
   @$pb.TagNumber(6)
-  void clearNumScore() => clearField(6);
+  void clearNumScore() => $_clearField(6);
 
+  /// Metadata.
   @$pb.TagNumber(7)
   $core.String get metadata => $_getSZ(6);
   @$pb.TagNumber(7)
-  set metadata($core.String v) {
-    $_setString(6, v);
-  }
-
+  set metadata($core.String value) => $_setString(6, value);
   @$pb.TagNumber(7)
   $core.bool hasMetadata() => $_has(6);
   @$pb.TagNumber(7)
-  void clearMetadata() => clearField(7);
+  void clearMetadata() => $_clearField(7);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the leaderboard record was created.
   @$pb.TagNumber(8)
   $0.Timestamp get createTime => $_getN(7);
   @$pb.TagNumber(8)
-  set createTime($0.Timestamp v) {
-    setField(8, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(8, value);
   @$pb.TagNumber(8)
   $core.bool hasCreateTime() => $_has(7);
   @$pb.TagNumber(8)
-  void clearCreateTime() => clearField(8);
+  void clearCreateTime() => $_clearField(8);
   @$pb.TagNumber(8)
   $0.Timestamp ensureCreateTime() => $_ensure(7);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the leaderboard record was updated.
   @$pb.TagNumber(9)
   $0.Timestamp get updateTime => $_getN(8);
   @$pb.TagNumber(9)
-  set updateTime($0.Timestamp v) {
-    setField(9, v);
-  }
-
+  set updateTime($0.Timestamp value) => $_setField(9, value);
   @$pb.TagNumber(9)
   $core.bool hasUpdateTime() => $_has(8);
   @$pb.TagNumber(9)
-  void clearUpdateTime() => clearField(9);
+  void clearUpdateTime() => $_clearField(9);
   @$pb.TagNumber(9)
   $0.Timestamp ensureUpdateTime() => $_ensure(8);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the leaderboard record expires.
   @$pb.TagNumber(10)
   $0.Timestamp get expiryTime => $_getN(9);
   @$pb.TagNumber(10)
-  set expiryTime($0.Timestamp v) {
-    setField(10, v);
-  }
-
+  set expiryTime($0.Timestamp value) => $_setField(10, value);
   @$pb.TagNumber(10)
   $core.bool hasExpiryTime() => $_has(9);
   @$pb.TagNumber(10)
-  void clearExpiryTime() => clearField(10);
+  void clearExpiryTime() => $_clearField(10);
   @$pb.TagNumber(10)
   $0.Timestamp ensureExpiryTime() => $_ensure(9);
 
+  /// The rank of this record.
   @$pb.TagNumber(11)
   $fixnum.Int64 get rank => $_getI64(10);
   @$pb.TagNumber(11)
-  set rank($fixnum.Int64 v) {
-    $_setInt64(10, v);
-  }
-
+  set rank($fixnum.Int64 value) => $_setInt64(10, value);
   @$pb.TagNumber(11)
   $core.bool hasRank() => $_has(10);
   @$pb.TagNumber(11)
-  void clearRank() => clearField(11);
+  void clearRank() => $_clearField(11);
 
+  /// The maximum number of score updates allowed by the owner.
   @$pb.TagNumber(12)
   $core.int get maxNumScore => $_getIZ(11);
   @$pb.TagNumber(12)
-  set maxNumScore($core.int v) {
-    $_setUnsignedInt32(11, v);
-  }
-
+  set maxNumScore($core.int value) => $_setUnsignedInt32(11, value);
   @$pb.TagNumber(12)
   $core.bool hasMaxNumScore() => $_has(11);
   @$pb.TagNumber(12)
-  void clearMaxNumScore() => clearField(12);
+  void clearMaxNumScore() => $_clearField(12);
 }
 
+/// A set of leaderboard records, may be part of a leaderboard records page or a batch of individual records.
 class LeaderboardRecordList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'LeaderboardRecordList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<LeaderboardRecord>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'records',
-        $pb.PbFieldType.PM,
-        subBuilder: LeaderboardRecord.create)
-    ..pc<LeaderboardRecord>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ownerRecords',
-        $pb.PbFieldType.PM,
-        subBuilder: LeaderboardRecord.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'nextCursor')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'prevCursor')
-    ..hasRequiredFields = false;
-
-  LeaderboardRecordList._() : super();
   factory LeaderboardRecordList({
     $core.Iterable<LeaderboardRecord>? records,
     $core.Iterable<LeaderboardRecord>? ownerRecords,
     $core.String? nextCursor,
     $core.String? prevCursor,
+    $fixnum.Int64? rankCount,
   }) {
-    final _result = create();
-    if (records != null) {
-      _result.records.addAll(records);
-    }
-    if (ownerRecords != null) {
-      _result.ownerRecords.addAll(ownerRecords);
-    }
-    if (nextCursor != null) {
-      _result.nextCursor = nextCursor;
-    }
-    if (prevCursor != null) {
-      _result.prevCursor = prevCursor;
-    }
-    return _result;
+    final result = create();
+    if (records != null) result.records.addAll(records);
+    if (ownerRecords != null) result.ownerRecords.addAll(ownerRecords);
+    if (nextCursor != null) result.nextCursor = nextCursor;
+    if (prevCursor != null) result.prevCursor = prevCursor;
+    if (rankCount != null) result.rankCount = rankCount;
+    return result;
   }
-  factory LeaderboardRecordList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LeaderboardRecordList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  LeaderboardRecordList clone() =>
-      LeaderboardRecordList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  LeaderboardRecordList._();
+
+  factory LeaderboardRecordList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory LeaderboardRecordList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'LeaderboardRecordList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<LeaderboardRecord>(1, _omitFieldNames ? '' : 'records',
+        subBuilder: LeaderboardRecord.create)
+    ..pPM<LeaderboardRecord>(2, _omitFieldNames ? '' : 'ownerRecords',
+        subBuilder: LeaderboardRecord.create)
+    ..aOS(3, _omitFieldNames ? '' : 'nextCursor')
+    ..aOS(4, _omitFieldNames ? '' : 'prevCursor')
+    ..aInt64(5, _omitFieldNames ? '' : 'rankCount')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  LeaderboardRecordList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LeaderboardRecordList copyWith(
           void Function(LeaderboardRecordList) updates) =>
       super.copyWith((message) => updates(message as LeaderboardRecordList))
-          as LeaderboardRecordList; // ignore: deprecated_member_use
+          as LeaderboardRecordList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static LeaderboardRecordList create() => LeaderboardRecordList._();
+  @$core.override
   LeaderboardRecordList createEmptyInstance() => create();
   static $pb.PbList<LeaderboardRecordList> createRepeated() =>
       $pb.PbList<LeaderboardRecordList>();
@@ -6050,83 +4850,84 @@ class LeaderboardRecordList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<LeaderboardRecordList>(create);
   static LeaderboardRecordList? _defaultInstance;
 
+  /// A list of leaderboard records.
   @$pb.TagNumber(1)
-  $core.List<LeaderboardRecord> get records => $_getList(0);
+  $pb.PbList<LeaderboardRecord> get records => $_getList(0);
 
+  /// A batched set of leaderboard records belonging to specified owners.
   @$pb.TagNumber(2)
-  $core.List<LeaderboardRecord> get ownerRecords => $_getList(1);
+  $pb.PbList<LeaderboardRecord> get ownerRecords => $_getList(1);
 
+  /// The cursor to send when retrieving the next page, if any.
   @$pb.TagNumber(3)
   $core.String get nextCursor => $_getSZ(2);
   @$pb.TagNumber(3)
-  set nextCursor($core.String v) {
-    $_setString(2, v);
-  }
-
+  set nextCursor($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasNextCursor() => $_has(2);
   @$pb.TagNumber(3)
-  void clearNextCursor() => clearField(3);
+  void clearNextCursor() => $_clearField(3);
 
+  /// The cursor to send when retrieving the previous page, if any.
   @$pb.TagNumber(4)
   $core.String get prevCursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set prevCursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set prevCursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasPrevCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearPrevCursor() => clearField(4);
+  void clearPrevCursor() => $_clearField(4);
+
+  /// The total number of ranks available.
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get rankCount => $_getI64(4);
+  @$pb.TagNumber(5)
+  set rankCount($fixnum.Int64 value) => $_setInt64(4, value);
+  @$pb.TagNumber(5)
+  $core.bool hasRankCount() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearRankCount() => $_clearField(5);
 }
 
+/// Leave a group.
 class LeaveGroupRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'LeaveGroupRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..hasRequiredFields = false;
-
-  LeaveGroupRequest._() : super();
   factory LeaveGroupRequest({
     $core.String? groupId,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    return result;
   }
-  factory LeaveGroupRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LeaveGroupRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  LeaveGroupRequest clone() => LeaveGroupRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  LeaveGroupRequest._();
+
+  factory LeaveGroupRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory LeaveGroupRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'LeaveGroupRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  LeaveGroupRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LeaveGroupRequest copyWith(void Function(LeaveGroupRequest) updates) =>
       super.copyWith((message) => updates(message as LeaveGroupRequest))
-          as LeaveGroupRequest; // ignore: deprecated_member_use
+          as LeaveGroupRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static LeaveGroupRequest create() => LeaveGroupRequest._();
+  @$core.override
   LeaveGroupRequest createEmptyInstance() => create();
   static $pb.PbList<LeaveGroupRequest> createRepeated() =>
       $pb.PbList<LeaveGroupRequest>();
@@ -6135,76 +4936,61 @@ class LeaveGroupRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<LeaveGroupRequest>(create);
   static LeaveGroupRequest? _defaultInstance;
 
+  /// The group ID to leave.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 }
 
+/// Link Facebook to the current user's account.
 class LinkFacebookRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'LinkFacebookRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountFacebook>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountFacebook.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sync',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  LinkFacebookRequest._() : super();
   factory LinkFacebookRequest({
     AccountFacebook? account,
     $1.BoolValue? sync,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (sync != null) {
-      _result.sync = sync;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (sync != null) result.sync = sync;
+    return result;
   }
-  factory LinkFacebookRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LinkFacebookRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  LinkFacebookRequest clone() => LinkFacebookRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  LinkFacebookRequest._();
+
+  factory LinkFacebookRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory LinkFacebookRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'LinkFacebookRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountFacebook>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountFacebook.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'sync',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  LinkFacebookRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LinkFacebookRequest copyWith(void Function(LinkFacebookRequest) updates) =>
       super.copyWith((message) => updates(message as LinkFacebookRequest))
-          as LinkFacebookRequest; // ignore: deprecated_member_use
+          as LinkFacebookRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static LinkFacebookRequest create() => LinkFacebookRequest._();
+  @$core.override
   LinkFacebookRequest createEmptyInstance() => create();
   static $pb.PbList<LinkFacebookRequest> createRepeated() =>
       $pb.PbList<LinkFacebookRequest>();
@@ -6213,92 +4999,75 @@ class LinkFacebookRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<LinkFacebookRequest>(create);
   static LinkFacebookRequest? _defaultInstance;
 
+  /// The Facebook account details.
   @$pb.TagNumber(1)
   AccountFacebook get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountFacebook v) {
-    setField(1, v);
-  }
-
+  set account(AccountFacebook value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountFacebook ensureAccount() => $_ensure(0);
 
+  /// Import Facebook friends for the user.
   @$pb.TagNumber(2)
   $1.BoolValue get sync => $_getN(1);
   @$pb.TagNumber(2)
-  set sync($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set sync($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasSync() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSync() => clearField(2);
+  void clearSync() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureSync() => $_ensure(1);
 }
 
+/// Link Steam to the current user's account.
 class LinkSteamRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'LinkSteamRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<AccountSteam>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'account',
-        subBuilder: AccountSteam.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sync',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  LinkSteamRequest._() : super();
   factory LinkSteamRequest({
     AccountSteam? account,
     $1.BoolValue? sync,
   }) {
-    final _result = create();
-    if (account != null) {
-      _result.account = account;
-    }
-    if (sync != null) {
-      _result.sync = sync;
-    }
-    return _result;
+    final result = create();
+    if (account != null) result.account = account;
+    if (sync != null) result.sync = sync;
+    return result;
   }
-  factory LinkSteamRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LinkSteamRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  LinkSteamRequest clone() => LinkSteamRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  LinkSteamRequest._();
+
+  factory LinkSteamRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory LinkSteamRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'LinkSteamRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<AccountSteam>(1, _omitFieldNames ? '' : 'account',
+        subBuilder: AccountSteam.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'sync',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  LinkSteamRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   LinkSteamRequest copyWith(void Function(LinkSteamRequest) updates) =>
       super.copyWith((message) => updates(message as LinkSteamRequest))
-          as LinkSteamRequest; // ignore: deprecated_member_use
+          as LinkSteamRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static LinkSteamRequest create() => LinkSteamRequest._();
+  @$core.override
   LinkSteamRequest createEmptyInstance() => create();
   static $pb.PbList<LinkSteamRequest> createRepeated() =>
       $pb.PbList<LinkSteamRequest>();
@@ -6307,113 +5076,83 @@ class LinkSteamRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<LinkSteamRequest>(create);
   static LinkSteamRequest? _defaultInstance;
 
+  /// The Facebook account details.
   @$pb.TagNumber(1)
   AccountSteam get account => $_getN(0);
   @$pb.TagNumber(1)
-  set account(AccountSteam v) {
-    setField(1, v);
-  }
-
+  set account(AccountSteam value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasAccount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearAccount() => clearField(1);
+  void clearAccount() => $_clearField(1);
   @$pb.TagNumber(1)
   AccountSteam ensureAccount() => $_ensure(0);
 
+  /// Import Steam friends for the user.
   @$pb.TagNumber(2)
   $1.BoolValue get sync => $_getN(1);
   @$pb.TagNumber(2)
-  set sync($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set sync($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasSync() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSync() => clearField(2);
+  void clearSync() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureSync() => $_ensure(1);
 }
 
+/// List a channel's message history.
 class ListChannelMessagesRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListChannelMessagesRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelId')
-    ..aOM<$1.Int32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.BoolValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'forward',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListChannelMessagesRequest._() : super();
   factory ListChannelMessagesRequest({
     $core.String? channelId,
     $1.Int32Value? limit,
     $1.BoolValue? forward,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (channelId != null) {
-      _result.channelId = channelId;
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (forward != null) {
-      _result.forward = forward;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (channelId != null) result.channelId = channelId;
+    if (limit != null) result.limit = limit;
+    if (forward != null) result.forward = forward;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory ListChannelMessagesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListChannelMessagesRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListChannelMessagesRequest clone() =>
-      ListChannelMessagesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListChannelMessagesRequest._();
+
+  factory ListChannelMessagesRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListChannelMessagesRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListChannelMessagesRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'channelId')
+    ..aOM<$1.Int32Value>(2, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.BoolValue>(3, _omitFieldNames ? '' : 'forward',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(4, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListChannelMessagesRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListChannelMessagesRequest copyWith(
           void Function(ListChannelMessagesRequest) updates) =>
       super.copyWith(
               (message) => updates(message as ListChannelMessagesRequest))
-          as ListChannelMessagesRequest; // ignore: deprecated_member_use
+          as ListChannelMessagesRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListChannelMessagesRequest create() => ListChannelMessagesRequest._();
+  @$core.override
   ListChannelMessagesRequest createEmptyInstance() => create();
   static $pb.PbList<ListChannelMessagesRequest> createRepeated() =>
       $pb.PbList<ListChannelMessagesRequest>();
@@ -6422,125 +5161,98 @@ class ListChannelMessagesRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListChannelMessagesRequest>(create);
   static ListChannelMessagesRequest? _defaultInstance;
 
+  /// The channel ID to list from.
   @$pb.TagNumber(1)
   $core.String get channelId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set channelId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set channelId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasChannelId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearChannelId() => clearField(1);
+  void clearChannelId() => $_clearField(1);
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(2)
   $1.Int32Value get limit => $_getN(1);
   @$pb.TagNumber(2)
-  set limit($1.Int32Value v) {
-    setField(2, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasLimit() => $_has(1);
   @$pb.TagNumber(2)
-  void clearLimit() => clearField(2);
+  void clearLimit() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.Int32Value ensureLimit() => $_ensure(1);
 
+  /// True if listing should be older messages to newer, false if reverse.
   @$pb.TagNumber(3)
   $1.BoolValue get forward => $_getN(2);
   @$pb.TagNumber(3)
-  set forward($1.BoolValue v) {
-    setField(3, v);
-  }
-
+  set forward($1.BoolValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasForward() => $_has(2);
   @$pb.TagNumber(3)
-  void clearForward() => clearField(3);
+  void clearForward() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.BoolValue ensureForward() => $_ensure(2);
 
+  /// A pagination cursor, if any.
   @$pb.TagNumber(4)
   $core.String get cursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set cursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set cursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCursor() => clearField(4);
+  void clearCursor() => $_clearField(4);
 }
 
+/// List friends for a user.
 class ListFriendsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListFriendsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<$1.Int32Value>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.Int32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'state',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListFriendsRequest._() : super();
   factory ListFriendsRequest({
     $1.Int32Value? limit,
     $1.Int32Value? state,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (state != null) {
-      _result.state = state;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (limit != null) result.limit = limit;
+    if (state != null) result.state = state;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory ListFriendsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListFriendsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListFriendsRequest clone() => ListFriendsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListFriendsRequest._();
+
+  factory ListFriendsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListFriendsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListFriendsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<$1.Int32Value>(1, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.Int32Value>(2, _omitFieldNames ? '' : 'state',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(3, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListFriendsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListFriendsRequest copyWith(void Function(ListFriendsRequest) updates) =>
       super.copyWith((message) => updates(message as ListFriendsRequest))
-          as ListFriendsRequest; // ignore: deprecated_member_use
+          as ListFriendsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListFriendsRequest create() => ListFriendsRequest._();
+  @$core.override
   ListFriendsRequest createEmptyInstance() => create();
   static $pb.PbList<ListFriendsRequest> createRepeated() =>
       $pb.PbList<ListFriendsRequest>();
@@ -6549,93 +5261,119 @@ class ListFriendsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListFriendsRequest>(create);
   static ListFriendsRequest? _defaultInstance;
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(1)
   $1.Int32Value get limit => $_getN(0);
   @$pb.TagNumber(1)
-  set limit($1.Int32Value v) {
-    setField(1, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasLimit() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLimit() => clearField(1);
+  void clearLimit() => $_clearField(1);
   @$pb.TagNumber(1)
   $1.Int32Value ensureLimit() => $_ensure(0);
 
+  /// The friend state to list.
   @$pb.TagNumber(2)
   $1.Int32Value get state => $_getN(1);
   @$pb.TagNumber(2)
-  set state($1.Int32Value v) {
-    setField(2, v);
-  }
-
+  set state($1.Int32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasState() => $_has(1);
   @$pb.TagNumber(2)
-  void clearState() => clearField(2);
+  void clearState() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.Int32Value ensureState() => $_ensure(1);
 
+  /// An optional next page cursor.
   @$pb.TagNumber(3)
   $core.String get cursor => $_getSZ(2);
   @$pb.TagNumber(3)
-  set cursor($core.String v) {
-    $_setString(2, v);
-  }
-
+  set cursor($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasCursor() => $_has(2);
   @$pb.TagNumber(3)
-  void clearCursor() => clearField(3);
+  void clearCursor() => $_clearField(3);
 }
 
-class ListGroupsRequest extends $pb.GeneratedMessage {
+class ListFriendsOfFriendsRequest extends $pb.GeneratedMessage {
+  factory ListFriendsOfFriendsRequest({
+    $1.Int32Value? limit,
+    $core.String? cursor,
+  }) {
+    final result = create();
+    if (limit != null) result.limit = limit;
+    if (cursor != null) result.cursor = cursor;
+    return result;
+  }
+
+  ListFriendsOfFriendsRequest._();
+
+  factory ListFriendsOfFriendsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListFriendsOfFriendsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListGroupsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'ListFriendsOfFriendsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..aOM<$1.Int32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
+    ..aOM<$1.Int32Value>(1, _omitFieldNames ? '' : 'limit',
         subBuilder: $1.Int32Value.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'langTag')
-    ..aOM<$1.Int32Value>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'members',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.BoolValue>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'open',
-        subBuilder: $1.BoolValue.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
     ..hasRequiredFields = false;
 
-  ListGroupsRequest._() : super();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListFriendsOfFriendsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListFriendsOfFriendsRequest copyWith(
+          void Function(ListFriendsOfFriendsRequest) updates) =>
+      super.copyWith(
+              (message) => updates(message as ListFriendsOfFriendsRequest))
+          as ListFriendsOfFriendsRequest;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ListFriendsOfFriendsRequest create() =>
+      ListFriendsOfFriendsRequest._();
+  @$core.override
+  ListFriendsOfFriendsRequest createEmptyInstance() => create();
+  static $pb.PbList<ListFriendsOfFriendsRequest> createRepeated() =>
+      $pb.PbList<ListFriendsOfFriendsRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ListFriendsOfFriendsRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ListFriendsOfFriendsRequest>(create);
+  static ListFriendsOfFriendsRequest? _defaultInstance;
+
+  /// Max number of records to return. Between 1 and 100.
+  @$pb.TagNumber(1)
+  $1.Int32Value get limit => $_getN(0);
+  @$pb.TagNumber(1)
+  set limit($1.Int32Value value) => $_setField(1, value);
+  @$pb.TagNumber(1)
+  $core.bool hasLimit() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearLimit() => $_clearField(1);
+  @$pb.TagNumber(1)
+  $1.Int32Value ensureLimit() => $_ensure(0);
+
+  /// An optional next page cursor.
+  @$pb.TagNumber(2)
+  $core.String get cursor => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set cursor($core.String value) => $_setString(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasCursor() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCursor() => $_clearField(2);
+}
+
+/// List groups based on given filters.
+class ListGroupsRequest extends $pb.GeneratedMessage {
   factory ListGroupsRequest({
     $core.String? name,
     $core.String? cursor,
@@ -6644,46 +5382,53 @@ class ListGroupsRequest extends $pb.GeneratedMessage {
     $1.Int32Value? members,
     $1.BoolValue? open,
   }) {
-    final _result = create();
-    if (name != null) {
-      _result.name = name;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (langTag != null) {
-      _result.langTag = langTag;
-    }
-    if (members != null) {
-      _result.members = members;
-    }
-    if (open != null) {
-      _result.open = open;
-    }
-    return _result;
+    final result = create();
+    if (name != null) result.name = name;
+    if (cursor != null) result.cursor = cursor;
+    if (limit != null) result.limit = limit;
+    if (langTag != null) result.langTag = langTag;
+    if (members != null) result.members = members;
+    if (open != null) result.open = open;
+    return result;
   }
-  factory ListGroupsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListGroupsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListGroupsRequest clone() => ListGroupsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListGroupsRequest._();
+
+  factory ListGroupsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListGroupsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListGroupsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..aOM<$1.Int32Value>(3, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(4, _omitFieldNames ? '' : 'langTag')
+    ..aOM<$1.Int32Value>(5, _omitFieldNames ? '' : 'members',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.BoolValue>(6, _omitFieldNames ? '' : 'open',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListGroupsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListGroupsRequest copyWith(void Function(ListGroupsRequest) updates) =>
       super.copyWith((message) => updates(message as ListGroupsRequest))
-          as ListGroupsRequest; // ignore: deprecated_member_use
+          as ListGroupsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListGroupsRequest create() => ListGroupsRequest._();
+  @$core.override
   ListGroupsRequest createEmptyInstance() => create();
   static $pb.PbList<ListGroupsRequest> createRepeated() =>
       $pb.PbList<ListGroupsRequest>();
@@ -6692,162 +5437,124 @@ class ListGroupsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListGroupsRequest>(create);
   static ListGroupsRequest? _defaultInstance;
 
+  /// List groups that contain this value in their names.
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
-  void clearName() => clearField(1);
+  void clearName() => $_clearField(1);
 
+  /// Optional pagination cursor.
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 
+  /// Max number of groups to return. Between 1 and 100.
   @$pb.TagNumber(3)
   $1.Int32Value get limit => $_getN(2);
   @$pb.TagNumber(3)
-  set limit($1.Int32Value v) {
-    setField(3, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasLimit() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLimit() => clearField(3);
+  void clearLimit() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.Int32Value ensureLimit() => $_ensure(2);
 
+  /// Language tag filter
   @$pb.TagNumber(4)
   $core.String get langTag => $_getSZ(3);
   @$pb.TagNumber(4)
-  set langTag($core.String v) {
-    $_setString(3, v);
-  }
-
+  set langTag($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasLangTag() => $_has(3);
   @$pb.TagNumber(4)
-  void clearLangTag() => clearField(4);
+  void clearLangTag() => $_clearField(4);
 
+  /// Number of group members
   @$pb.TagNumber(5)
   $1.Int32Value get members => $_getN(4);
   @$pb.TagNumber(5)
-  set members($1.Int32Value v) {
-    setField(5, v);
-  }
-
+  set members($1.Int32Value value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasMembers() => $_has(4);
   @$pb.TagNumber(5)
-  void clearMembers() => clearField(5);
+  void clearMembers() => $_clearField(5);
   @$pb.TagNumber(5)
   $1.Int32Value ensureMembers() => $_ensure(4);
 
+  /// Optional Open/Closed filter.
   @$pb.TagNumber(6)
   $1.BoolValue get open => $_getN(5);
   @$pb.TagNumber(6)
-  set open($1.BoolValue v) {
-    setField(6, v);
-  }
-
+  set open($1.BoolValue value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasOpen() => $_has(5);
   @$pb.TagNumber(6)
-  void clearOpen() => clearField(6);
+  void clearOpen() => $_clearField(6);
   @$pb.TagNumber(6)
   $1.BoolValue ensureOpen() => $_ensure(5);
 }
 
+/// List all users that are part of a group.
 class ListGroupUsersRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListGroupUsersRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..aOM<$1.Int32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.Int32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'state',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListGroupUsersRequest._() : super();
   factory ListGroupUsersRequest({
     $core.String? groupId,
     $1.Int32Value? limit,
     $1.Int32Value? state,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (state != null) {
-      _result.state = state;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    if (limit != null) result.limit = limit;
+    if (state != null) result.state = state;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory ListGroupUsersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListGroupUsersRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListGroupUsersRequest clone() =>
-      ListGroupUsersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListGroupUsersRequest._();
+
+  factory ListGroupUsersRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListGroupUsersRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListGroupUsersRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..aOM<$1.Int32Value>(2, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.Int32Value>(3, _omitFieldNames ? '' : 'state',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(4, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListGroupUsersRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListGroupUsersRequest copyWith(
           void Function(ListGroupUsersRequest) updates) =>
       super.copyWith((message) => updates(message as ListGroupUsersRequest))
-          as ListGroupUsersRequest; // ignore: deprecated_member_use
+          as ListGroupUsersRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListGroupUsersRequest create() => ListGroupUsersRequest._();
+  @$core.override
   ListGroupUsersRequest createEmptyInstance() => create();
   static $pb.PbList<ListGroupUsersRequest> createRepeated() =>
       $pb.PbList<ListGroupUsersRequest>();
@@ -6856,99 +5563,53 @@ class ListGroupUsersRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListGroupUsersRequest>(create);
   static ListGroupUsersRequest? _defaultInstance;
 
+  /// The group ID to list from.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(2)
   $1.Int32Value get limit => $_getN(1);
   @$pb.TagNumber(2)
-  set limit($1.Int32Value v) {
-    setField(2, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasLimit() => $_has(1);
   @$pb.TagNumber(2)
-  void clearLimit() => clearField(2);
+  void clearLimit() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.Int32Value ensureLimit() => $_ensure(1);
 
+  /// The group user state to list.
   @$pb.TagNumber(3)
   $1.Int32Value get state => $_getN(2);
   @$pb.TagNumber(3)
-  set state($1.Int32Value v) {
-    setField(3, v);
-  }
-
+  set state($1.Int32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasState() => $_has(2);
   @$pb.TagNumber(3)
-  void clearState() => clearField(3);
+  void clearState() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.Int32Value ensureState() => $_ensure(2);
 
+  /// An optional next page cursor.
   @$pb.TagNumber(4)
   $core.String get cursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set cursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set cursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCursor() => clearField(4);
+  void clearCursor() => $_clearField(4);
 }
 
+/// List leaerboard records from a given leaderboard around the owner.
 class ListLeaderboardRecordsAroundOwnerRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListLeaderboardRecordsAroundOwnerRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaderboardId')
-    ..aOM<$1.UInt32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.UInt32Value.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ownerId')
-    ..aOM<$1.Int64Value>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'expiry',
-        subBuilder: $1.Int64Value.create)
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListLeaderboardRecordsAroundOwnerRequest._() : super();
   factory ListLeaderboardRecordsAroundOwnerRequest({
     $core.String? leaderboardId,
     $1.UInt32Value? limit,
@@ -6956,48 +5617,54 @@ class ListLeaderboardRecordsAroundOwnerRequest extends $pb.GeneratedMessage {
     $1.Int64Value? expiry,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (leaderboardId != null) {
-      _result.leaderboardId = leaderboardId;
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (ownerId != null) {
-      _result.ownerId = ownerId;
-    }
-    if (expiry != null) {
-      _result.expiry = expiry;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (leaderboardId != null) result.leaderboardId = leaderboardId;
+    if (limit != null) result.limit = limit;
+    if (ownerId != null) result.ownerId = ownerId;
+    if (expiry != null) result.expiry = expiry;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
+
+  ListLeaderboardRecordsAroundOwnerRequest._();
+
   factory ListLeaderboardRecordsAroundOwnerRequest.fromBuffer(
-          $core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListLeaderboardRecordsAroundOwnerRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListLeaderboardRecordsAroundOwnerRequest clone() =>
-      ListLeaderboardRecordsAroundOwnerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListLeaderboardRecordsAroundOwnerRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListLeaderboardRecordsAroundOwnerRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'leaderboardId')
+    ..aOM<$1.UInt32Value>(2, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.UInt32Value.create)
+    ..aOS(3, _omitFieldNames ? '' : 'ownerId')
+    ..aOM<$1.Int64Value>(4, _omitFieldNames ? '' : 'expiry',
+        subBuilder: $1.Int64Value.create)
+    ..aOS(5, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListLeaderboardRecordsAroundOwnerRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListLeaderboardRecordsAroundOwnerRequest copyWith(
           void Function(ListLeaderboardRecordsAroundOwnerRequest) updates) =>
       super.copyWith((message) =>
               updates(message as ListLeaderboardRecordsAroundOwnerRequest))
-          as ListLeaderboardRecordsAroundOwnerRequest; // ignore: deprecated_member_use
+          as ListLeaderboardRecordsAroundOwnerRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListLeaderboardRecordsAroundOwnerRequest create() =>
       ListLeaderboardRecordsAroundOwnerRequest._();
+  @$core.override
   ListLeaderboardRecordsAroundOwnerRequest createEmptyInstance() => create();
   static $pb.PbList<ListLeaderboardRecordsAroundOwnerRequest>
       createRepeated() =>
@@ -7008,111 +5675,63 @@ class ListLeaderboardRecordsAroundOwnerRequest extends $pb.GeneratedMessage {
           ListLeaderboardRecordsAroundOwnerRequest>(create);
   static ListLeaderboardRecordsAroundOwnerRequest? _defaultInstance;
 
+  /// The ID of the tournament to list for.
   @$pb.TagNumber(1)
   $core.String get leaderboardId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set leaderboardId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set leaderboardId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasLeaderboardId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLeaderboardId() => clearField(1);
+  void clearLeaderboardId() => $_clearField(1);
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(2)
   $1.UInt32Value get limit => $_getN(1);
   @$pb.TagNumber(2)
-  set limit($1.UInt32Value v) {
-    setField(2, v);
-  }
-
+  set limit($1.UInt32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasLimit() => $_has(1);
   @$pb.TagNumber(2)
-  void clearLimit() => clearField(2);
+  void clearLimit() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.UInt32Value ensureLimit() => $_ensure(1);
 
+  /// The owner to retrieve records around.
   @$pb.TagNumber(3)
   $core.String get ownerId => $_getSZ(2);
   @$pb.TagNumber(3)
-  set ownerId($core.String v) {
-    $_setString(2, v);
-  }
-
+  set ownerId($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasOwnerId() => $_has(2);
   @$pb.TagNumber(3)
-  void clearOwnerId() => clearField(3);
+  void clearOwnerId() => $_clearField(3);
 
+  /// Expiry in seconds (since epoch) to begin fetching records from.
   @$pb.TagNumber(4)
   $1.Int64Value get expiry => $_getN(3);
   @$pb.TagNumber(4)
-  set expiry($1.Int64Value v) {
-    setField(4, v);
-  }
-
+  set expiry($1.Int64Value value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasExpiry() => $_has(3);
   @$pb.TagNumber(4)
-  void clearExpiry() => clearField(4);
+  void clearExpiry() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.Int64Value ensureExpiry() => $_ensure(3);
 
+  /// A next or previous page cursor.
   @$pb.TagNumber(5)
   $core.String get cursor => $_getSZ(4);
   @$pb.TagNumber(5)
-  set cursor($core.String v) {
-    $_setString(4, v);
-  }
-
+  set cursor($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasCursor() => $_has(4);
   @$pb.TagNumber(5)
-  void clearCursor() => clearField(5);
+  void clearCursor() => $_clearField(5);
 }
 
+/// List leaderboard records from a given leaderboard.
 class ListLeaderboardRecordsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListLeaderboardRecordsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaderboardId')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ownerIds')
-    ..aOM<$1.Int32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..aOM<$1.Int64Value>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'expiry',
-        subBuilder: $1.Int64Value.create)
-    ..hasRequiredFields = false;
-
-  ListLeaderboardRecordsRequest._() : super();
   factory ListLeaderboardRecordsRequest({
     $core.String? leaderboardId,
     $core.Iterable<$core.String>? ownerIds,
@@ -7120,47 +5739,53 @@ class ListLeaderboardRecordsRequest extends $pb.GeneratedMessage {
     $core.String? cursor,
     $1.Int64Value? expiry,
   }) {
-    final _result = create();
-    if (leaderboardId != null) {
-      _result.leaderboardId = leaderboardId;
-    }
-    if (ownerIds != null) {
-      _result.ownerIds.addAll(ownerIds);
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    if (expiry != null) {
-      _result.expiry = expiry;
-    }
-    return _result;
+    final result = create();
+    if (leaderboardId != null) result.leaderboardId = leaderboardId;
+    if (ownerIds != null) result.ownerIds.addAll(ownerIds);
+    if (limit != null) result.limit = limit;
+    if (cursor != null) result.cursor = cursor;
+    if (expiry != null) result.expiry = expiry;
+    return result;
   }
-  factory ListLeaderboardRecordsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListLeaderboardRecordsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListLeaderboardRecordsRequest clone() =>
-      ListLeaderboardRecordsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListLeaderboardRecordsRequest._();
+
+  factory ListLeaderboardRecordsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListLeaderboardRecordsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListLeaderboardRecordsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'leaderboardId')
+    ..pPS(2, _omitFieldNames ? '' : 'ownerIds')
+    ..aOM<$1.Int32Value>(3, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(4, _omitFieldNames ? '' : 'cursor')
+    ..aOM<$1.Int64Value>(5, _omitFieldNames ? '' : 'expiry',
+        subBuilder: $1.Int64Value.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListLeaderboardRecordsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListLeaderboardRecordsRequest copyWith(
           void Function(ListLeaderboardRecordsRequest) updates) =>
       super.copyWith(
               (message) => updates(message as ListLeaderboardRecordsRequest))
-          as ListLeaderboardRecordsRequest; // ignore: deprecated_member_use
+          as ListLeaderboardRecordsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListLeaderboardRecordsRequest create() =>
       ListLeaderboardRecordsRequest._();
+  @$core.override
   ListLeaderboardRecordsRequest createEmptyInstance() => create();
   static $pb.PbList<ListLeaderboardRecordsRequest> createRepeated() =>
       $pb.PbList<ListLeaderboardRecordsRequest>();
@@ -7169,111 +5794,57 @@ class ListLeaderboardRecordsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListLeaderboardRecordsRequest>(create);
   static ListLeaderboardRecordsRequest? _defaultInstance;
 
+  /// The ID of the leaderboard to list for.
   @$pb.TagNumber(1)
   $core.String get leaderboardId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set leaderboardId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set leaderboardId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasLeaderboardId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLeaderboardId() => clearField(1);
+  void clearLeaderboardId() => $_clearField(1);
 
+  /// One or more owners to retrieve records for.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get ownerIds => $_getList(1);
+  $pb.PbList<$core.String> get ownerIds => $_getList(1);
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(3)
   $1.Int32Value get limit => $_getN(2);
   @$pb.TagNumber(3)
-  set limit($1.Int32Value v) {
-    setField(3, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasLimit() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLimit() => clearField(3);
+  void clearLimit() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.Int32Value ensureLimit() => $_ensure(2);
 
+  /// A next or previous page cursor.
   @$pb.TagNumber(4)
   $core.String get cursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set cursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set cursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCursor() => clearField(4);
+  void clearCursor() => $_clearField(4);
 
+  /// Expiry in seconds (since epoch) to begin fetching records from. Optional. 0 means from current time.
   @$pb.TagNumber(5)
   $1.Int64Value get expiry => $_getN(4);
   @$pb.TagNumber(5)
-  set expiry($1.Int64Value v) {
-    setField(5, v);
-  }
-
+  set expiry($1.Int64Value value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasExpiry() => $_has(4);
   @$pb.TagNumber(5)
-  void clearExpiry() => clearField(5);
+  void clearExpiry() => $_clearField(5);
   @$pb.TagNumber(5)
   $1.Int64Value ensureExpiry() => $_ensure(4);
 }
 
+/// List realtime matches.
 class ListMatchesRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListMatchesRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<$1.Int32Value>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'authoritative',
-        subBuilder: $1.BoolValue.create)
-    ..aOM<$1.StringValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'label',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.Int32Value>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'minSize',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.Int32Value>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxSize',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.StringValue>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'query',
-        subBuilder: $1.StringValue.create)
-    ..hasRequiredFields = false;
-
-  ListMatchesRequest._() : super();
   factory ListMatchesRequest({
     $1.Int32Value? limit,
     $1.BoolValue? authoritative,
@@ -7282,46 +5853,56 @@ class ListMatchesRequest extends $pb.GeneratedMessage {
     $1.Int32Value? maxSize,
     $1.StringValue? query,
   }) {
-    final _result = create();
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (authoritative != null) {
-      _result.authoritative = authoritative;
-    }
-    if (label != null) {
-      _result.label = label;
-    }
-    if (minSize != null) {
-      _result.minSize = minSize;
-    }
-    if (maxSize != null) {
-      _result.maxSize = maxSize;
-    }
-    if (query != null) {
-      _result.query = query;
-    }
-    return _result;
+    final result = create();
+    if (limit != null) result.limit = limit;
+    if (authoritative != null) result.authoritative = authoritative;
+    if (label != null) result.label = label;
+    if (minSize != null) result.minSize = minSize;
+    if (maxSize != null) result.maxSize = maxSize;
+    if (query != null) result.query = query;
+    return result;
   }
-  factory ListMatchesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListMatchesRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListMatchesRequest clone() => ListMatchesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListMatchesRequest._();
+
+  factory ListMatchesRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListMatchesRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListMatchesRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<$1.Int32Value>(1, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'authoritative',
+        subBuilder: $1.BoolValue.create)
+    ..aOM<$1.StringValue>(3, _omitFieldNames ? '' : 'label',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.Int32Value>(4, _omitFieldNames ? '' : 'minSize',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.Int32Value>(5, _omitFieldNames ? '' : 'maxSize',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.StringValue>(6, _omitFieldNames ? '' : 'query',
+        subBuilder: $1.StringValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListMatchesRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListMatchesRequest copyWith(void Function(ListMatchesRequest) updates) =>
       super.copyWith((message) => updates(message as ListMatchesRequest))
-          as ListMatchesRequest; // ignore: deprecated_member_use
+          as ListMatchesRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListMatchesRequest create() => ListMatchesRequest._();
+  @$core.override
   ListMatchesRequest createEmptyInstance() => create();
   static $pb.PbList<ListMatchesRequest> createRepeated() =>
       $pb.PbList<ListMatchesRequest>();
@@ -7330,149 +5911,123 @@ class ListMatchesRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListMatchesRequest>(create);
   static ListMatchesRequest? _defaultInstance;
 
+  /// Limit the number of returned matches.
   @$pb.TagNumber(1)
   $1.Int32Value get limit => $_getN(0);
   @$pb.TagNumber(1)
-  set limit($1.Int32Value v) {
-    setField(1, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasLimit() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLimit() => clearField(1);
+  void clearLimit() => $_clearField(1);
   @$pb.TagNumber(1)
   $1.Int32Value ensureLimit() => $_ensure(0);
 
+  /// Authoritative or relayed matches.
   @$pb.TagNumber(2)
   $1.BoolValue get authoritative => $_getN(1);
   @$pb.TagNumber(2)
-  set authoritative($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set authoritative($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasAuthoritative() => $_has(1);
   @$pb.TagNumber(2)
-  void clearAuthoritative() => clearField(2);
+  void clearAuthoritative() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensureAuthoritative() => $_ensure(1);
 
+  /// Label filter.
   @$pb.TagNumber(3)
   $1.StringValue get label => $_getN(2);
   @$pb.TagNumber(3)
-  set label($1.StringValue v) {
-    setField(3, v);
-  }
-
+  set label($1.StringValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasLabel() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLabel() => clearField(3);
+  void clearLabel() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.StringValue ensureLabel() => $_ensure(2);
 
+  /// Minimum user count.
   @$pb.TagNumber(4)
   $1.Int32Value get minSize => $_getN(3);
   @$pb.TagNumber(4)
-  set minSize($1.Int32Value v) {
-    setField(4, v);
-  }
-
+  set minSize($1.Int32Value value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasMinSize() => $_has(3);
   @$pb.TagNumber(4)
-  void clearMinSize() => clearField(4);
+  void clearMinSize() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.Int32Value ensureMinSize() => $_ensure(3);
 
+  /// Maximum user count.
   @$pb.TagNumber(5)
   $1.Int32Value get maxSize => $_getN(4);
   @$pb.TagNumber(5)
-  set maxSize($1.Int32Value v) {
-    setField(5, v);
-  }
-
+  set maxSize($1.Int32Value value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasMaxSize() => $_has(4);
   @$pb.TagNumber(5)
-  void clearMaxSize() => clearField(5);
+  void clearMaxSize() => $_clearField(5);
   @$pb.TagNumber(5)
   $1.Int32Value ensureMaxSize() => $_ensure(4);
 
+  /// Arbitrary label query.
   @$pb.TagNumber(6)
   $1.StringValue get query => $_getN(5);
   @$pb.TagNumber(6)
-  set query($1.StringValue v) {
-    setField(6, v);
-  }
-
+  set query($1.StringValue value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasQuery() => $_has(5);
   @$pb.TagNumber(6)
-  void clearQuery() => clearField(6);
+  void clearQuery() => $_clearField(6);
   @$pb.TagNumber(6)
   $1.StringValue ensureQuery() => $_ensure(5);
 }
 
+/// Get a list of unexpired notifications.
 class ListNotificationsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListNotificationsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<$1.Int32Value>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cacheableCursor')
-    ..hasRequiredFields = false;
-
-  ListNotificationsRequest._() : super();
   factory ListNotificationsRequest({
     $1.Int32Value? limit,
     $core.String? cacheableCursor,
   }) {
-    final _result = create();
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (cacheableCursor != null) {
-      _result.cacheableCursor = cacheableCursor;
-    }
-    return _result;
+    final result = create();
+    if (limit != null) result.limit = limit;
+    if (cacheableCursor != null) result.cacheableCursor = cacheableCursor;
+    return result;
   }
-  factory ListNotificationsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListNotificationsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListNotificationsRequest clone() =>
-      ListNotificationsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListNotificationsRequest._();
+
+  factory ListNotificationsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListNotificationsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListNotificationsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<$1.Int32Value>(1, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cacheableCursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListNotificationsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListNotificationsRequest copyWith(
           void Function(ListNotificationsRequest) updates) =>
       super.copyWith((message) => updates(message as ListNotificationsRequest))
-          as ListNotificationsRequest; // ignore: deprecated_member_use
+          as ListNotificationsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListNotificationsRequest create() => ListNotificationsRequest._();
+  @$core.override
   ListNotificationsRequest createEmptyInstance() => create();
   static $pb.PbList<ListNotificationsRequest> createRepeated() =>
       $pb.PbList<ListNotificationsRequest>();
@@ -7481,109 +6036,79 @@ class ListNotificationsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListNotificationsRequest>(create);
   static ListNotificationsRequest? _defaultInstance;
 
+  /// The number of notifications to get. Between 1 and 100.
   @$pb.TagNumber(1)
   $1.Int32Value get limit => $_getN(0);
   @$pb.TagNumber(1)
-  set limit($1.Int32Value v) {
-    setField(1, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasLimit() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLimit() => clearField(1);
+  void clearLimit() => $_clearField(1);
   @$pb.TagNumber(1)
   $1.Int32Value ensureLimit() => $_ensure(0);
 
+  /// A cursor to page through notifications. May be cached by clients to get from point in time forwards.
   @$pb.TagNumber(2)
   $core.String get cacheableCursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cacheableCursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cacheableCursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCacheableCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCacheableCursor() => clearField(2);
+  void clearCacheableCursor() => $_clearField(2);
 }
 
+/// List publicly readable storage objects in a given collection.
 class ListStorageObjectsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListStorageObjectsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'collection')
-    ..aOM<$1.Int32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListStorageObjectsRequest._() : super();
   factory ListStorageObjectsRequest({
     $core.String? userId,
     $core.String? collection,
     $1.Int32Value? limit,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (userId != null) {
-      _result.userId = userId;
-    }
-    if (collection != null) {
-      _result.collection = collection;
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (userId != null) result.userId = userId;
+    if (collection != null) result.collection = collection;
+    if (limit != null) result.limit = limit;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory ListStorageObjectsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListStorageObjectsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListStorageObjectsRequest clone() =>
-      ListStorageObjectsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListStorageObjectsRequest._();
+
+  factory ListStorageObjectsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListStorageObjectsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListStorageObjectsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'userId')
+    ..aOS(2, _omitFieldNames ? '' : 'collection')
+    ..aOM<$1.Int32Value>(3, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(4, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListStorageObjectsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListStorageObjectsRequest copyWith(
           void Function(ListStorageObjectsRequest) updates) =>
       super.copyWith((message) => updates(message as ListStorageObjectsRequest))
-          as ListStorageObjectsRequest; // ignore: deprecated_member_use
+          as ListStorageObjectsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListStorageObjectsRequest create() => ListStorageObjectsRequest._();
+  @$core.override
   ListStorageObjectsRequest createEmptyInstance() => create();
   static $pb.PbList<ListStorageObjectsRequest> createRepeated() =>
       $pb.PbList<ListStorageObjectsRequest>();
@@ -7592,115 +6117,93 @@ class ListStorageObjectsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListStorageObjectsRequest>(create);
   static ListStorageObjectsRequest? _defaultInstance;
 
+  /// ID of the user.
   @$pb.TagNumber(1)
   $core.String get userId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set userId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set userId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasUserId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUserId() => clearField(1);
+  void clearUserId() => $_clearField(1);
 
+  /// The collection which stores the object.
   @$pb.TagNumber(2)
   $core.String get collection => $_getSZ(1);
   @$pb.TagNumber(2)
-  set collection($core.String v) {
-    $_setString(1, v);
-  }
-
+  set collection($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCollection() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCollection() => clearField(2);
+  void clearCollection() => $_clearField(2);
 
+  /// The number of storage objects to list. Between 1 and 100.
   @$pb.TagNumber(3)
   $1.Int32Value get limit => $_getN(2);
   @$pb.TagNumber(3)
-  set limit($1.Int32Value v) {
-    setField(3, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasLimit() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLimit() => clearField(3);
+  void clearLimit() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.Int32Value ensureLimit() => $_ensure(2);
 
+  /// The cursor to page through results from.
   @$pb.TagNumber(4)
   $core.String get cursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set cursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set cursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCursor() => clearField(4);
+  void clearCursor() => $_clearField(4);
 }
 
+/// List user subscriptions.
 class ListSubscriptionsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListSubscriptionsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<$1.Int32Value>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListSubscriptionsRequest._() : super();
   factory ListSubscriptionsRequest({
     $1.Int32Value? limit,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (limit != null) result.limit = limit;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory ListSubscriptionsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListSubscriptionsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListSubscriptionsRequest clone() =>
-      ListSubscriptionsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListSubscriptionsRequest._();
+
+  factory ListSubscriptionsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListSubscriptionsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListSubscriptionsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<$1.Int32Value>(1, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListSubscriptionsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListSubscriptionsRequest copyWith(
           void Function(ListSubscriptionsRequest) updates) =>
       super.copyWith((message) => updates(message as ListSubscriptionsRequest))
-          as ListSubscriptionsRequest; // ignore: deprecated_member_use
+          as ListSubscriptionsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListSubscriptionsRequest create() => ListSubscriptionsRequest._();
+  @$core.override
   ListSubscriptionsRequest createEmptyInstance() => create();
   static $pb.PbList<ListSubscriptionsRequest> createRepeated() =>
       $pb.PbList<ListSubscriptionsRequest>();
@@ -7709,73 +6212,31 @@ class ListSubscriptionsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListSubscriptionsRequest>(create);
   static ListSubscriptionsRequest? _defaultInstance;
 
+  /// Max number of results per page
   @$pb.TagNumber(1)
   $1.Int32Value get limit => $_getN(0);
   @$pb.TagNumber(1)
-  set limit($1.Int32Value v) {
-    setField(1, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasLimit() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLimit() => clearField(1);
+  void clearLimit() => $_clearField(1);
   @$pb.TagNumber(1)
   $1.Int32Value ensureLimit() => $_ensure(0);
 
+  /// Cursor to retrieve a page of records from
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 }
 
+/// List tournament records from a given tournament around the owner.
 class ListTournamentRecordsAroundOwnerRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListTournamentRecordsAroundOwnerRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'tournamentId')
-    ..aOM<$1.UInt32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.UInt32Value.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ownerId')
-    ..aOM<$1.Int64Value>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'expiry',
-        subBuilder: $1.Int64Value.create)
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListTournamentRecordsAroundOwnerRequest._() : super();
   factory ListTournamentRecordsAroundOwnerRequest({
     $core.String? tournamentId,
     $1.UInt32Value? limit,
@@ -7783,48 +6244,54 @@ class ListTournamentRecordsAroundOwnerRequest extends $pb.GeneratedMessage {
     $1.Int64Value? expiry,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (tournamentId != null) {
-      _result.tournamentId = tournamentId;
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (ownerId != null) {
-      _result.ownerId = ownerId;
-    }
-    if (expiry != null) {
-      _result.expiry = expiry;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (tournamentId != null) result.tournamentId = tournamentId;
+    if (limit != null) result.limit = limit;
+    if (ownerId != null) result.ownerId = ownerId;
+    if (expiry != null) result.expiry = expiry;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
+
+  ListTournamentRecordsAroundOwnerRequest._();
+
   factory ListTournamentRecordsAroundOwnerRequest.fromBuffer(
-          $core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListTournamentRecordsAroundOwnerRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListTournamentRecordsAroundOwnerRequest clone() =>
-      ListTournamentRecordsAroundOwnerRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListTournamentRecordsAroundOwnerRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListTournamentRecordsAroundOwnerRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'tournamentId')
+    ..aOM<$1.UInt32Value>(2, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.UInt32Value.create)
+    ..aOS(3, _omitFieldNames ? '' : 'ownerId')
+    ..aOM<$1.Int64Value>(4, _omitFieldNames ? '' : 'expiry',
+        subBuilder: $1.Int64Value.create)
+    ..aOS(5, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListTournamentRecordsAroundOwnerRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListTournamentRecordsAroundOwnerRequest copyWith(
           void Function(ListTournamentRecordsAroundOwnerRequest) updates) =>
       super.copyWith((message) =>
               updates(message as ListTournamentRecordsAroundOwnerRequest))
-          as ListTournamentRecordsAroundOwnerRequest; // ignore: deprecated_member_use
+          as ListTournamentRecordsAroundOwnerRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListTournamentRecordsAroundOwnerRequest create() =>
       ListTournamentRecordsAroundOwnerRequest._();
+  @$core.override
   ListTournamentRecordsAroundOwnerRequest createEmptyInstance() => create();
   static $pb.PbList<ListTournamentRecordsAroundOwnerRequest> createRepeated() =>
       $pb.PbList<ListTournamentRecordsAroundOwnerRequest>();
@@ -7834,111 +6301,63 @@ class ListTournamentRecordsAroundOwnerRequest extends $pb.GeneratedMessage {
           ListTournamentRecordsAroundOwnerRequest>(create);
   static ListTournamentRecordsAroundOwnerRequest? _defaultInstance;
 
+  /// The ID of the tournament to list for.
   @$pb.TagNumber(1)
   $core.String get tournamentId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set tournamentId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set tournamentId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTournamentId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTournamentId() => clearField(1);
+  void clearTournamentId() => $_clearField(1);
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(2)
   $1.UInt32Value get limit => $_getN(1);
   @$pb.TagNumber(2)
-  set limit($1.UInt32Value v) {
-    setField(2, v);
-  }
-
+  set limit($1.UInt32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasLimit() => $_has(1);
   @$pb.TagNumber(2)
-  void clearLimit() => clearField(2);
+  void clearLimit() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.UInt32Value ensureLimit() => $_ensure(1);
 
+  /// The owner to retrieve records around.
   @$pb.TagNumber(3)
   $core.String get ownerId => $_getSZ(2);
   @$pb.TagNumber(3)
-  set ownerId($core.String v) {
-    $_setString(2, v);
-  }
-
+  set ownerId($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasOwnerId() => $_has(2);
   @$pb.TagNumber(3)
-  void clearOwnerId() => clearField(3);
+  void clearOwnerId() => $_clearField(3);
 
+  /// Expiry in seconds (since epoch) to begin fetching records from.
   @$pb.TagNumber(4)
   $1.Int64Value get expiry => $_getN(3);
   @$pb.TagNumber(4)
-  set expiry($1.Int64Value v) {
-    setField(4, v);
-  }
-
+  set expiry($1.Int64Value value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasExpiry() => $_has(3);
   @$pb.TagNumber(4)
-  void clearExpiry() => clearField(4);
+  void clearExpiry() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.Int64Value ensureExpiry() => $_ensure(3);
 
+  /// A next or previous page cursor.
   @$pb.TagNumber(5)
   $core.String get cursor => $_getSZ(4);
   @$pb.TagNumber(5)
-  set cursor($core.String v) {
-    $_setString(4, v);
-  }
-
+  set cursor($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasCursor() => $_has(4);
   @$pb.TagNumber(5)
-  void clearCursor() => clearField(5);
+  void clearCursor() => $_clearField(5);
 }
 
+/// List tournament records from a given tournament.
 class ListTournamentRecordsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListTournamentRecordsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'tournamentId')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ownerIds')
-    ..aOM<$1.Int32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..aOM<$1.Int64Value>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'expiry',
-        subBuilder: $1.Int64Value.create)
-    ..hasRequiredFields = false;
-
-  ListTournamentRecordsRequest._() : super();
   factory ListTournamentRecordsRequest({
     $core.String? tournamentId,
     $core.Iterable<$core.String>? ownerIds,
@@ -7946,47 +6365,53 @@ class ListTournamentRecordsRequest extends $pb.GeneratedMessage {
     $core.String? cursor,
     $1.Int64Value? expiry,
   }) {
-    final _result = create();
-    if (tournamentId != null) {
-      _result.tournamentId = tournamentId;
-    }
-    if (ownerIds != null) {
-      _result.ownerIds.addAll(ownerIds);
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    if (expiry != null) {
-      _result.expiry = expiry;
-    }
-    return _result;
+    final result = create();
+    if (tournamentId != null) result.tournamentId = tournamentId;
+    if (ownerIds != null) result.ownerIds.addAll(ownerIds);
+    if (limit != null) result.limit = limit;
+    if (cursor != null) result.cursor = cursor;
+    if (expiry != null) result.expiry = expiry;
+    return result;
   }
-  factory ListTournamentRecordsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListTournamentRecordsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListTournamentRecordsRequest clone() =>
-      ListTournamentRecordsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListTournamentRecordsRequest._();
+
+  factory ListTournamentRecordsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListTournamentRecordsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListTournamentRecordsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'tournamentId')
+    ..pPS(2, _omitFieldNames ? '' : 'ownerIds')
+    ..aOM<$1.Int32Value>(3, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(4, _omitFieldNames ? '' : 'cursor')
+    ..aOM<$1.Int64Value>(5, _omitFieldNames ? '' : 'expiry',
+        subBuilder: $1.Int64Value.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListTournamentRecordsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListTournamentRecordsRequest copyWith(
           void Function(ListTournamentRecordsRequest) updates) =>
       super.copyWith(
               (message) => updates(message as ListTournamentRecordsRequest))
-          as ListTournamentRecordsRequest; // ignore: deprecated_member_use
+          as ListTournamentRecordsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListTournamentRecordsRequest create() =>
       ListTournamentRecordsRequest._();
+  @$core.override
   ListTournamentRecordsRequest createEmptyInstance() => create();
   static $pb.PbList<ListTournamentRecordsRequest> createRepeated() =>
       $pb.PbList<ListTournamentRecordsRequest>();
@@ -7995,110 +6420,57 @@ class ListTournamentRecordsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListTournamentRecordsRequest>(create);
   static ListTournamentRecordsRequest? _defaultInstance;
 
+  /// The ID of the tournament to list for.
   @$pb.TagNumber(1)
   $core.String get tournamentId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set tournamentId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set tournamentId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTournamentId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTournamentId() => clearField(1);
+  void clearTournamentId() => $_clearField(1);
 
+  /// One or more owners to retrieve records for.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get ownerIds => $_getList(1);
+  $pb.PbList<$core.String> get ownerIds => $_getList(1);
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(3)
   $1.Int32Value get limit => $_getN(2);
   @$pb.TagNumber(3)
-  set limit($1.Int32Value v) {
-    setField(3, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasLimit() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLimit() => clearField(3);
+  void clearLimit() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.Int32Value ensureLimit() => $_ensure(2);
 
+  /// A next or previous page cursor.
   @$pb.TagNumber(4)
   $core.String get cursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set cursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set cursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCursor() => clearField(4);
+  void clearCursor() => $_clearField(4);
 
+  /// Expiry in seconds (since epoch) to begin fetching records from.
   @$pb.TagNumber(5)
   $1.Int64Value get expiry => $_getN(4);
   @$pb.TagNumber(5)
-  set expiry($1.Int64Value v) {
-    setField(5, v);
-  }
-
+  set expiry($1.Int64Value value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasExpiry() => $_has(4);
   @$pb.TagNumber(5)
-  void clearExpiry() => clearField(5);
+  void clearExpiry() => $_clearField(5);
   @$pb.TagNumber(5)
   $1.Int64Value ensureExpiry() => $_ensure(4);
 }
 
+/// List active/upcoming tournaments based on given filters.
 class ListTournamentsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListTournamentsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<$1.UInt32Value>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'categoryStart',
-        subBuilder: $1.UInt32Value.create)
-    ..aOM<$1.UInt32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'categoryEnd',
-        subBuilder: $1.UInt32Value.create)
-    ..aOM<$1.UInt32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'startTime',
-        subBuilder: $1.UInt32Value.create)
-    ..aOM<$1.UInt32Value>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'endTime',
-        subBuilder: $1.UInt32Value.create)
-    ..aOM<$1.Int32Value>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListTournamentsRequest._() : super();
   factory ListTournamentsRequest({
     $1.UInt32Value? categoryStart,
     $1.UInt32Value? categoryEnd,
@@ -8107,48 +6479,56 @@ class ListTournamentsRequest extends $pb.GeneratedMessage {
     $1.Int32Value? limit,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (categoryStart != null) {
-      _result.categoryStart = categoryStart;
-    }
-    if (categoryEnd != null) {
-      _result.categoryEnd = categoryEnd;
-    }
-    if (startTime != null) {
-      _result.startTime = startTime;
-    }
-    if (endTime != null) {
-      _result.endTime = endTime;
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (categoryStart != null) result.categoryStart = categoryStart;
+    if (categoryEnd != null) result.categoryEnd = categoryEnd;
+    if (startTime != null) result.startTime = startTime;
+    if (endTime != null) result.endTime = endTime;
+    if (limit != null) result.limit = limit;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory ListTournamentsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListTournamentsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListTournamentsRequest clone() =>
-      ListTournamentsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListTournamentsRequest._();
+
+  factory ListTournamentsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListTournamentsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListTournamentsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<$1.UInt32Value>(1, _omitFieldNames ? '' : 'categoryStart',
+        subBuilder: $1.UInt32Value.create)
+    ..aOM<$1.UInt32Value>(2, _omitFieldNames ? '' : 'categoryEnd',
+        subBuilder: $1.UInt32Value.create)
+    ..aOM<$1.UInt32Value>(3, _omitFieldNames ? '' : 'startTime',
+        subBuilder: $1.UInt32Value.create)
+    ..aOM<$1.UInt32Value>(4, _omitFieldNames ? '' : 'endTime',
+        subBuilder: $1.UInt32Value.create)
+    ..aOM<$1.Int32Value>(6, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(8, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListTournamentsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListTournamentsRequest copyWith(
           void Function(ListTournamentsRequest) updates) =>
       super.copyWith((message) => updates(message as ListTournamentsRequest))
-          as ListTournamentsRequest; // ignore: deprecated_member_use
+          as ListTournamentsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListTournamentsRequest create() => ListTournamentsRequest._();
+  @$core.override
   ListTournamentsRequest createEmptyInstance() => create();
   static $pb.PbList<ListTournamentsRequest> createRepeated() =>
       $pb.PbList<ListTournamentsRequest>();
@@ -8157,166 +6537,128 @@ class ListTournamentsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListTournamentsRequest>(create);
   static ListTournamentsRequest? _defaultInstance;
 
+  /// The start of the categories to include. Defaults to 0.
   @$pb.TagNumber(1)
   $1.UInt32Value get categoryStart => $_getN(0);
   @$pb.TagNumber(1)
-  set categoryStart($1.UInt32Value v) {
-    setField(1, v);
-  }
-
+  set categoryStart($1.UInt32Value value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasCategoryStart() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCategoryStart() => clearField(1);
+  void clearCategoryStart() => $_clearField(1);
   @$pb.TagNumber(1)
   $1.UInt32Value ensureCategoryStart() => $_ensure(0);
 
+  /// The end of the categories to include. Defaults to 128.
   @$pb.TagNumber(2)
   $1.UInt32Value get categoryEnd => $_getN(1);
   @$pb.TagNumber(2)
-  set categoryEnd($1.UInt32Value v) {
-    setField(2, v);
-  }
-
+  set categoryEnd($1.UInt32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasCategoryEnd() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCategoryEnd() => clearField(2);
+  void clearCategoryEnd() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.UInt32Value ensureCategoryEnd() => $_ensure(1);
 
+  /// The start time for tournaments. Defaults to epoch.
   @$pb.TagNumber(3)
   $1.UInt32Value get startTime => $_getN(2);
   @$pb.TagNumber(3)
-  set startTime($1.UInt32Value v) {
-    setField(3, v);
-  }
-
+  set startTime($1.UInt32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasStartTime() => $_has(2);
   @$pb.TagNumber(3)
-  void clearStartTime() => clearField(3);
+  void clearStartTime() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.UInt32Value ensureStartTime() => $_ensure(2);
 
+  /// The end time for tournaments. Defaults to +1 year from current Unix time.
   @$pb.TagNumber(4)
   $1.UInt32Value get endTime => $_getN(3);
   @$pb.TagNumber(4)
-  set endTime($1.UInt32Value v) {
-    setField(4, v);
-  }
-
+  set endTime($1.UInt32Value value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasEndTime() => $_has(3);
   @$pb.TagNumber(4)
-  void clearEndTime() => clearField(4);
+  void clearEndTime() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.UInt32Value ensureEndTime() => $_ensure(3);
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(6)
   $1.Int32Value get limit => $_getN(4);
   @$pb.TagNumber(6)
-  set limit($1.Int32Value v) {
-    setField(6, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasLimit() => $_has(4);
   @$pb.TagNumber(6)
-  void clearLimit() => clearField(6);
+  void clearLimit() => $_clearField(6);
   @$pb.TagNumber(6)
   $1.Int32Value ensureLimit() => $_ensure(4);
 
+  /// A next page cursor for listings (optional).
   @$pb.TagNumber(8)
   $core.String get cursor => $_getSZ(5);
   @$pb.TagNumber(8)
-  set cursor($core.String v) {
-    $_setString(5, v);
-  }
-
+  set cursor($core.String value) => $_setString(5, value);
   @$pb.TagNumber(8)
   $core.bool hasCursor() => $_has(5);
   @$pb.TagNumber(8)
-  void clearCursor() => clearField(8);
+  void clearCursor() => $_clearField(8);
 }
 
+/// List the groups a user is part of, and their relationship to each.
 class ListUserGroupsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ListUserGroupsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userId')
-    ..aOM<$1.Int32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'limit',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.Int32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'state',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  ListUserGroupsRequest._() : super();
   factory ListUserGroupsRequest({
     $core.String? userId,
     $1.Int32Value? limit,
     $1.Int32Value? state,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (userId != null) {
-      _result.userId = userId;
-    }
-    if (limit != null) {
-      _result.limit = limit;
-    }
-    if (state != null) {
-      _result.state = state;
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (userId != null) result.userId = userId;
+    if (limit != null) result.limit = limit;
+    if (state != null) result.state = state;
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory ListUserGroupsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListUserGroupsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ListUserGroupsRequest clone() =>
-      ListUserGroupsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ListUserGroupsRequest._();
+
+  factory ListUserGroupsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListUserGroupsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListUserGroupsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'userId')
+    ..aOM<$1.Int32Value>(2, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.Int32Value>(3, _omitFieldNames ? '' : 'state',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(4, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListUserGroupsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ListUserGroupsRequest copyWith(
           void Function(ListUserGroupsRequest) updates) =>
       super.copyWith((message) => updates(message as ListUserGroupsRequest))
-          as ListUserGroupsRequest; // ignore: deprecated_member_use
+          as ListUserGroupsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ListUserGroupsRequest create() => ListUserGroupsRequest._();
+  @$core.override
   ListUserGroupsRequest createEmptyInstance() => create();
   static $pb.PbList<ListUserGroupsRequest> createRepeated() =>
       $pb.PbList<ListUserGroupsRequest>();
@@ -8325,105 +6667,53 @@ class ListUserGroupsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ListUserGroupsRequest>(create);
   static ListUserGroupsRequest? _defaultInstance;
 
+  /// ID of the user.
   @$pb.TagNumber(1)
   $core.String get userId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set userId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set userId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasUserId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUserId() => clearField(1);
+  void clearUserId() => $_clearField(1);
 
+  /// Max number of records to return. Between 1 and 100.
   @$pb.TagNumber(2)
   $1.Int32Value get limit => $_getN(1);
   @$pb.TagNumber(2)
-  set limit($1.Int32Value v) {
-    setField(2, v);
-  }
-
+  set limit($1.Int32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasLimit() => $_has(1);
   @$pb.TagNumber(2)
-  void clearLimit() => clearField(2);
+  void clearLimit() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.Int32Value ensureLimit() => $_ensure(1);
 
+  /// The user group state to list.
   @$pb.TagNumber(3)
   $1.Int32Value get state => $_getN(2);
   @$pb.TagNumber(3)
-  set state($1.Int32Value v) {
-    setField(3, v);
-  }
-
+  set state($1.Int32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasState() => $_has(2);
   @$pb.TagNumber(3)
-  void clearState() => clearField(3);
+  void clearState() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.Int32Value ensureState() => $_ensure(2);
 
+  /// An optional next page cursor.
   @$pb.TagNumber(4)
   $core.String get cursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set cursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set cursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCursor() => clearField(4);
+  void clearCursor() => $_clearField(4);
 }
 
+/// Represents a realtime match.
 class Match extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Match',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchId')
-    ..aOB(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'authoritative')
-    ..aOM<$1.StringValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'label',
-        subBuilder: $1.StringValue.create)
-    ..a<$core.int>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'size',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'tickRate',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'handlerName')
-    ..hasRequiredFields = false;
-
-  Match._() : super();
   factory Match({
     $core.String? matchId,
     $core.bool? authoritative,
@@ -8432,46 +6722,50 @@ class Match extends $pb.GeneratedMessage {
     $core.int? tickRate,
     $core.String? handlerName,
   }) {
-    final _result = create();
-    if (matchId != null) {
-      _result.matchId = matchId;
-    }
-    if (authoritative != null) {
-      _result.authoritative = authoritative;
-    }
-    if (label != null) {
-      _result.label = label;
-    }
-    if (size != null) {
-      _result.size = size;
-    }
-    if (tickRate != null) {
-      _result.tickRate = tickRate;
-    }
-    if (handlerName != null) {
-      _result.handlerName = handlerName;
-    }
-    return _result;
+    final result = create();
+    if (matchId != null) result.matchId = matchId;
+    if (authoritative != null) result.authoritative = authoritative;
+    if (label != null) result.label = label;
+    if (size != null) result.size = size;
+    if (tickRate != null) result.tickRate = tickRate;
+    if (handlerName != null) result.handlerName = handlerName;
+    return result;
   }
-  factory Match.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Match.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Match clone() => Match()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Match._();
+
+  factory Match.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Match.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Match',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'matchId')
+    ..aOB(2, _omitFieldNames ? '' : 'authoritative')
+    ..aOM<$1.StringValue>(3, _omitFieldNames ? '' : 'label',
+        subBuilder: $1.StringValue.create)
+    ..aI(4, _omitFieldNames ? '' : 'size')
+    ..aI(5, _omitFieldNames ? '' : 'tickRate')
+    ..aOS(6, _omitFieldNames ? '' : 'handlerName')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Match clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Match copyWith(void Function(Match) updates) =>
-      super.copyWith((message) => updates(message as Match))
-          as Match; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Match)) as Match;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Match create() => Match._();
+  @$core.override
   Match createEmptyInstance() => create();
   static $pb.PbList<Match> createRepeated() => $pb.PbList<Match>();
   @$core.pragma('dart2js:noInline')
@@ -8479,129 +6773,107 @@ class Match extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Match>(create);
   static Match? _defaultInstance;
 
+  /// The ID of the match, can be used to join.
   @$pb.TagNumber(1)
   $core.String get matchId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set matchId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set matchId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMatchId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMatchId() => clearField(1);
+  void clearMatchId() => $_clearField(1);
 
+  /// True if it's an server-managed authoritative match, false otherwise.
   @$pb.TagNumber(2)
   $core.bool get authoritative => $_getBF(1);
   @$pb.TagNumber(2)
-  set authoritative($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set authoritative($core.bool value) => $_setBool(1, value);
   @$pb.TagNumber(2)
   $core.bool hasAuthoritative() => $_has(1);
   @$pb.TagNumber(2)
-  void clearAuthoritative() => clearField(2);
+  void clearAuthoritative() => $_clearField(2);
 
+  /// Match label, if any.
   @$pb.TagNumber(3)
   $1.StringValue get label => $_getN(2);
   @$pb.TagNumber(3)
-  set label($1.StringValue v) {
-    setField(3, v);
-  }
-
+  set label($1.StringValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasLabel() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLabel() => clearField(3);
+  void clearLabel() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.StringValue ensureLabel() => $_ensure(2);
 
+  /// Current number of users in the match.
   @$pb.TagNumber(4)
   $core.int get size => $_getIZ(3);
   @$pb.TagNumber(4)
-  set size($core.int v) {
-    $_setSignedInt32(3, v);
-  }
-
+  set size($core.int value) => $_setSignedInt32(3, value);
   @$pb.TagNumber(4)
   $core.bool hasSize() => $_has(3);
   @$pb.TagNumber(4)
-  void clearSize() => clearField(4);
+  void clearSize() => $_clearField(4);
 
+  /// Tick Rate
   @$pb.TagNumber(5)
   $core.int get tickRate => $_getIZ(4);
   @$pb.TagNumber(5)
-  set tickRate($core.int v) {
-    $_setSignedInt32(4, v);
-  }
-
+  set tickRate($core.int value) => $_setSignedInt32(4, value);
   @$pb.TagNumber(5)
   $core.bool hasTickRate() => $_has(4);
   @$pb.TagNumber(5)
-  void clearTickRate() => clearField(5);
+  void clearTickRate() => $_clearField(5);
 
+  /// Handler name
   @$pb.TagNumber(6)
   $core.String get handlerName => $_getSZ(5);
   @$pb.TagNumber(6)
-  set handlerName($core.String v) {
-    $_setString(5, v);
-  }
-
+  set handlerName($core.String value) => $_setString(5, value);
   @$pb.TagNumber(6)
   $core.bool hasHandlerName() => $_has(5);
   @$pb.TagNumber(6)
-  void clearHandlerName() => clearField(6);
+  void clearHandlerName() => $_clearField(6);
 }
 
+/// A list of realtime matches.
 class MatchList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<Match>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matches',
-        $pb.PbFieldType.PM,
-        subBuilder: Match.create)
-    ..hasRequiredFields = false;
-
-  MatchList._() : super();
   factory MatchList({
     $core.Iterable<Match>? matches,
   }) {
-    final _result = create();
-    if (matches != null) {
-      _result.matches.addAll(matches);
-    }
-    return _result;
+    final result = create();
+    if (matches != null) result.matches.addAll(matches);
+    return result;
   }
-  factory MatchList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchList clone() => MatchList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchList._();
+
+  factory MatchList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<Match>(1, _omitFieldNames ? '' : 'matches', subBuilder: Match.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchList copyWith(void Function(MatchList) updates) =>
-      super.copyWith((message) => updates(message as MatchList))
-          as MatchList; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MatchList)) as MatchList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchList create() => MatchList._();
+  @$core.override
   MatchList createEmptyInstance() => create();
   static $pb.PbList<MatchList> createRepeated() => $pb.PbList<MatchList>();
   @$core.pragma('dart2js:noInline')
@@ -8609,60 +6881,169 @@ class MatchList extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MatchList>(create);
   static MatchList? _defaultInstance;
 
+  /// A number of matches corresponding to a list operation.
   @$pb.TagNumber(1)
-  $core.List<Match> get matches => $_getList(0);
+  $pb.PbList<Match> get matches => $_getList(0);
 }
 
-class Notification extends $pb.GeneratedMessage {
+/// Matchmaker ticket completion stats
+class MatchmakerCompletionStats extends $pb.GeneratedMessage {
+  factory MatchmakerCompletionStats({
+    $0.Timestamp? createTime,
+    $0.Timestamp? completeTime,
+  }) {
+    final result = create();
+    if (createTime != null) result.createTime = createTime;
+    if (completeTime != null) result.completeTime = completeTime;
+    return result;
+  }
+
+  MatchmakerCompletionStats._();
+
+  factory MatchmakerCompletionStats.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchmakerCompletionStats.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Notification',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'MatchmakerCompletionStats',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'subject')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'content')
-    ..a<$core.int>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'code',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'senderId')
-    ..aOM<$0.Timestamp>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
+    ..aOM<$0.Timestamp>(1, _omitFieldNames ? '' : 'createTime',
         subBuilder: $0.Timestamp.create)
-    ..aOB(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persistent')
+    ..aOM<$0.Timestamp>(2, _omitFieldNames ? '' : 'completeTime',
+        subBuilder: $0.Timestamp.create)
     ..hasRequiredFields = false;
 
-  Notification._() : super();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerCompletionStats clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerCompletionStats copyWith(
+          void Function(MatchmakerCompletionStats) updates) =>
+      super.copyWith((message) => updates(message as MatchmakerCompletionStats))
+          as MatchmakerCompletionStats;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MatchmakerCompletionStats create() => MatchmakerCompletionStats._();
+  @$core.override
+  MatchmakerCompletionStats createEmptyInstance() => create();
+  static $pb.PbList<MatchmakerCompletionStats> createRepeated() =>
+      $pb.PbList<MatchmakerCompletionStats>();
+  @$core.pragma('dart2js:noInline')
+  static MatchmakerCompletionStats getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<MatchmakerCompletionStats>(create);
+  static MatchmakerCompletionStats? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $0.Timestamp get createTime => $_getN(0);
+  @$pb.TagNumber(1)
+  set createTime($0.Timestamp value) => $_setField(1, value);
+  @$pb.TagNumber(1)
+  $core.bool hasCreateTime() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCreateTime() => $_clearField(1);
+  @$pb.TagNumber(1)
+  $0.Timestamp ensureCreateTime() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $0.Timestamp get completeTime => $_getN(1);
+  @$pb.TagNumber(2)
+  set completeTime($0.Timestamp value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasCompleteTime() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCompleteTime() => $_clearField(2);
+  @$pb.TagNumber(2)
+  $0.Timestamp ensureCompleteTime() => $_ensure(1);
+}
+
+/// Matchmaker stats
+class MatchmakerStats extends $pb.GeneratedMessage {
+  factory MatchmakerStats({
+    $core.int? ticketCount,
+    $0.Timestamp? oldestTicketCreateTime,
+    $core.Iterable<MatchmakerCompletionStats>? completions,
+  }) {
+    final result = create();
+    if (ticketCount != null) result.ticketCount = ticketCount;
+    if (oldestTicketCreateTime != null)
+      result.oldestTicketCreateTime = oldestTicketCreateTime;
+    if (completions != null) result.completions.addAll(completions);
+    return result;
+  }
+
+  MatchmakerStats._();
+
+  factory MatchmakerStats.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchmakerStats.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchmakerStats',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aI(1, _omitFieldNames ? '' : 'ticketCount')
+    ..aOM<$0.Timestamp>(2, _omitFieldNames ? '' : 'oldestTicketCreateTime',
+        subBuilder: $0.Timestamp.create)
+    ..pPM<MatchmakerCompletionStats>(3, _omitFieldNames ? '' : 'completions',
+        subBuilder: MatchmakerCompletionStats.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerStats clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerStats copyWith(void Function(MatchmakerStats) updates) =>
+      super.copyWith((message) => updates(message as MatchmakerStats))
+          as MatchmakerStats;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MatchmakerStats create() => MatchmakerStats._();
+  @$core.override
+  MatchmakerStats createEmptyInstance() => create();
+  static $pb.PbList<MatchmakerStats> createRepeated() =>
+      $pb.PbList<MatchmakerStats>();
+  @$core.pragma('dart2js:noInline')
+  static MatchmakerStats getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<MatchmakerStats>(create);
+  static MatchmakerStats? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get ticketCount => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set ticketCount($core.int value) => $_setSignedInt32(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasTicketCount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTicketCount() => $_clearField(1);
+
+  @$pb.TagNumber(2)
+  $0.Timestamp get oldestTicketCreateTime => $_getN(1);
+  @$pb.TagNumber(2)
+  set oldestTicketCreateTime($0.Timestamp value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasOldestTicketCreateTime() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearOldestTicketCreateTime() => $_clearField(2);
+  @$pb.TagNumber(2)
+  $0.Timestamp ensureOldestTicketCreateTime() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  $pb.PbList<MatchmakerCompletionStats> get completions => $_getList(2);
+}
+
+/// A notification in the server.
+class Notification extends $pb.GeneratedMessage {
   factory Notification({
     $core.String? id,
     $core.String? subject,
@@ -8672,49 +7053,53 @@ class Notification extends $pb.GeneratedMessage {
     $0.Timestamp? createTime,
     $core.bool? persistent,
   }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (subject != null) {
-      _result.subject = subject;
-    }
-    if (content != null) {
-      _result.content = content;
-    }
-    if (code != null) {
-      _result.code = code;
-    }
-    if (senderId != null) {
-      _result.senderId = senderId;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (persistent != null) {
-      _result.persistent = persistent;
-    }
-    return _result;
+    final result = create();
+    if (id != null) result.id = id;
+    if (subject != null) result.subject = subject;
+    if (content != null) result.content = content;
+    if (code != null) result.code = code;
+    if (senderId != null) result.senderId = senderId;
+    if (createTime != null) result.createTime = createTime;
+    if (persistent != null) result.persistent = persistent;
+    return result;
   }
-  factory Notification.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Notification.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Notification clone() => Notification()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Notification._();
+
+  factory Notification.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Notification.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Notification',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..aOS(2, _omitFieldNames ? '' : 'subject')
+    ..aOS(3, _omitFieldNames ? '' : 'content')
+    ..aI(4, _omitFieldNames ? '' : 'code')
+    ..aOS(5, _omitFieldNames ? '' : 'senderId')
+    ..aOM<$0.Timestamp>(6, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOB(7, _omitFieldNames ? '' : 'persistent')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Notification clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Notification copyWith(void Function(Notification) updates) =>
       super.copyWith((message) => updates(message as Notification))
-          as Notification; // ignore: deprecated_member_use
+          as Notification;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Notification create() => Notification._();
+  @$core.override
   Notification createEmptyInstance() => create();
   static $pb.PbList<Notification> createRepeated() =>
       $pb.PbList<Notification>();
@@ -8723,150 +7108,122 @@ class Notification extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<Notification>(create);
   static Notification? _defaultInstance;
 
+  /// ID of the Notification.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// Subject of the notification.
   @$pb.TagNumber(2)
   $core.String get subject => $_getSZ(1);
   @$pb.TagNumber(2)
-  set subject($core.String v) {
-    $_setString(1, v);
-  }
-
+  set subject($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasSubject() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSubject() => clearField(2);
+  void clearSubject() => $_clearField(2);
 
+  /// Content of the notification in JSON.
   @$pb.TagNumber(3)
   $core.String get content => $_getSZ(2);
   @$pb.TagNumber(3)
-  set content($core.String v) {
-    $_setString(2, v);
-  }
-
+  set content($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasContent() => $_has(2);
   @$pb.TagNumber(3)
-  void clearContent() => clearField(3);
+  void clearContent() => $_clearField(3);
 
+  /// Category code for this notification.
   @$pb.TagNumber(4)
   $core.int get code => $_getIZ(3);
   @$pb.TagNumber(4)
-  set code($core.int v) {
-    $_setSignedInt32(3, v);
-  }
-
+  set code($core.int value) => $_setSignedInt32(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCode() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCode() => clearField(4);
+  void clearCode() => $_clearField(4);
 
+  /// ID of the sender, if a user. Otherwise 'null'.
   @$pb.TagNumber(5)
   $core.String get senderId => $_getSZ(4);
   @$pb.TagNumber(5)
-  set senderId($core.String v) {
-    $_setString(4, v);
-  }
-
+  set senderId($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasSenderId() => $_has(4);
   @$pb.TagNumber(5)
-  void clearSenderId() => clearField(5);
+  void clearSenderId() => $_clearField(5);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the notification was created.
   @$pb.TagNumber(6)
   $0.Timestamp get createTime => $_getN(5);
   @$pb.TagNumber(6)
-  set createTime($0.Timestamp v) {
-    setField(6, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasCreateTime() => $_has(5);
   @$pb.TagNumber(6)
-  void clearCreateTime() => clearField(6);
+  void clearCreateTime() => $_clearField(6);
   @$pb.TagNumber(6)
   $0.Timestamp ensureCreateTime() => $_ensure(5);
 
+  /// True if this notification was persisted to the database.
   @$pb.TagNumber(7)
   $core.bool get persistent => $_getBF(6);
   @$pb.TagNumber(7)
-  set persistent($core.bool v) {
-    $_setBool(6, v);
-  }
-
+  set persistent($core.bool value) => $_setBool(6, value);
   @$pb.TagNumber(7)
   $core.bool hasPersistent() => $_has(6);
   @$pb.TagNumber(7)
-  void clearPersistent() => clearField(7);
+  void clearPersistent() => $_clearField(7);
 }
 
+/// A collection of zero or more notifications.
 class NotificationList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'NotificationList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<Notification>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'notifications',
-        $pb.PbFieldType.PM,
-        subBuilder: Notification.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cacheableCursor')
-    ..hasRequiredFields = false;
-
-  NotificationList._() : super();
   factory NotificationList({
     $core.Iterable<Notification>? notifications,
     $core.String? cacheableCursor,
   }) {
-    final _result = create();
-    if (notifications != null) {
-      _result.notifications.addAll(notifications);
-    }
-    if (cacheableCursor != null) {
-      _result.cacheableCursor = cacheableCursor;
-    }
-    return _result;
+    final result = create();
+    if (notifications != null) result.notifications.addAll(notifications);
+    if (cacheableCursor != null) result.cacheableCursor = cacheableCursor;
+    return result;
   }
-  factory NotificationList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory NotificationList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  NotificationList clone() => NotificationList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  NotificationList._();
+
+  factory NotificationList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory NotificationList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'NotificationList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<Notification>(1, _omitFieldNames ? '' : 'notifications',
+        subBuilder: Notification.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cacheableCursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  NotificationList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   NotificationList copyWith(void Function(NotificationList) updates) =>
       super.copyWith((message) => updates(message as NotificationList))
-          as NotificationList; // ignore: deprecated_member_use
+          as NotificationList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static NotificationList create() => NotificationList._();
+  @$core.override
   NotificationList createEmptyInstance() => create();
   static $pb.PbList<NotificationList> createRepeated() =>
       $pb.PbList<NotificationList>();
@@ -8875,79 +7232,64 @@ class NotificationList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<NotificationList>(create);
   static NotificationList? _defaultInstance;
 
+  /// Collection of notifications.
   @$pb.TagNumber(1)
-  $core.List<Notification> get notifications => $_getList(0);
+  $pb.PbList<Notification> get notifications => $_getList(0);
 
+  /// Use this cursor to paginate notifications. Cache this to catch up to new notifications.
   @$pb.TagNumber(2)
   $core.String get cacheableCursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cacheableCursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cacheableCursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCacheableCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCacheableCursor() => clearField(2);
+  void clearCacheableCursor() => $_clearField(2);
 }
 
+/// Promote a set of users in a group to the next role up.
 class PromoteGroupUsersRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PromoteGroupUsersRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIds')
-    ..hasRequiredFields = false;
-
-  PromoteGroupUsersRequest._() : super();
   factory PromoteGroupUsersRequest({
     $core.String? groupId,
     $core.Iterable<$core.String>? userIds,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIds != null) {
-      _result.userIds.addAll(userIds);
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    if (userIds != null) result.userIds.addAll(userIds);
+    return result;
   }
-  factory PromoteGroupUsersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PromoteGroupUsersRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PromoteGroupUsersRequest clone() =>
-      PromoteGroupUsersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PromoteGroupUsersRequest._();
+
+  factory PromoteGroupUsersRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PromoteGroupUsersRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PromoteGroupUsersRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..pPS(2, _omitFieldNames ? '' : 'userIds')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PromoteGroupUsersRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PromoteGroupUsersRequest copyWith(
           void Function(PromoteGroupUsersRequest) updates) =>
       super.copyWith((message) => updates(message as PromoteGroupUsersRequest))
-          as PromoteGroupUsersRequest; // ignore: deprecated_member_use
+          as PromoteGroupUsersRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PromoteGroupUsersRequest create() => PromoteGroupUsersRequest._();
+  @$core.override
   PromoteGroupUsersRequest createEmptyInstance() => create();
   static $pb.PbList<PromoteGroupUsersRequest> createRepeated() =>
       $pb.PbList<PromoteGroupUsersRequest>();
@@ -8956,79 +7298,64 @@ class PromoteGroupUsersRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PromoteGroupUsersRequest>(create);
   static PromoteGroupUsersRequest? _defaultInstance;
 
+  /// The group ID to promote in.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 
+  /// The users to promote.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get userIds => $_getList(1);
+  $pb.PbList<$core.String> get userIds => $_getList(1);
 }
 
+/// Demote a set of users in a group to the next role down.
 class DemoteGroupUsersRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DemoteGroupUsersRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIds')
-    ..hasRequiredFields = false;
-
-  DemoteGroupUsersRequest._() : super();
   factory DemoteGroupUsersRequest({
     $core.String? groupId,
     $core.Iterable<$core.String>? userIds,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIds != null) {
-      _result.userIds.addAll(userIds);
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    if (userIds != null) result.userIds.addAll(userIds);
+    return result;
   }
-  factory DemoteGroupUsersRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DemoteGroupUsersRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DemoteGroupUsersRequest clone() =>
-      DemoteGroupUsersRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DemoteGroupUsersRequest._();
+
+  factory DemoteGroupUsersRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DemoteGroupUsersRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DemoteGroupUsersRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..pPS(2, _omitFieldNames ? '' : 'userIds')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DemoteGroupUsersRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DemoteGroupUsersRequest copyWith(
           void Function(DemoteGroupUsersRequest) updates) =>
       super.copyWith((message) => updates(message as DemoteGroupUsersRequest))
-          as DemoteGroupUsersRequest; // ignore: deprecated_member_use
+          as DemoteGroupUsersRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DemoteGroupUsersRequest create() => DemoteGroupUsersRequest._();
+  @$core.override
   DemoteGroupUsersRequest createEmptyInstance() => create();
   static $pb.PbList<DemoteGroupUsersRequest> createRepeated() =>
       $pb.PbList<DemoteGroupUsersRequest>();
@@ -9037,86 +7364,66 @@ class DemoteGroupUsersRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<DemoteGroupUsersRequest>(create);
   static DemoteGroupUsersRequest? _defaultInstance;
 
+  /// The group ID to demote in.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 
+  /// The users to demote.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get userIds => $_getList(1);
+  $pb.PbList<$core.String> get userIds => $_getList(1);
 }
 
+/// Storage objects to get.
 class ReadStorageObjectId extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ReadStorageObjectId',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'collection')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'key')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userId')
-    ..hasRequiredFields = false;
-
-  ReadStorageObjectId._() : super();
   factory ReadStorageObjectId({
     $core.String? collection,
     $core.String? key,
     $core.String? userId,
   }) {
-    final _result = create();
-    if (collection != null) {
-      _result.collection = collection;
-    }
-    if (key != null) {
-      _result.key = key;
-    }
-    if (userId != null) {
-      _result.userId = userId;
-    }
-    return _result;
+    final result = create();
+    if (collection != null) result.collection = collection;
+    if (key != null) result.key = key;
+    if (userId != null) result.userId = userId;
+    return result;
   }
-  factory ReadStorageObjectId.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReadStorageObjectId.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ReadStorageObjectId clone() => ReadStorageObjectId()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ReadStorageObjectId._();
+
+  factory ReadStorageObjectId.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ReadStorageObjectId.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ReadStorageObjectId',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'collection')
+    ..aOS(2, _omitFieldNames ? '' : 'key')
+    ..aOS(3, _omitFieldNames ? '' : 'userId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ReadStorageObjectId clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ReadStorageObjectId copyWith(void Function(ReadStorageObjectId) updates) =>
       super.copyWith((message) => updates(message as ReadStorageObjectId))
-          as ReadStorageObjectId; // ignore: deprecated_member_use
+          as ReadStorageObjectId;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ReadStorageObjectId create() => ReadStorageObjectId._();
+  @$core.override
   ReadStorageObjectId createEmptyInstance() => create();
   static $pb.PbList<ReadStorageObjectId> createRepeated() =>
       $pb.PbList<ReadStorageObjectId>();
@@ -9125,93 +7432,78 @@ class ReadStorageObjectId extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ReadStorageObjectId>(create);
   static ReadStorageObjectId? _defaultInstance;
 
+  /// The collection which stores the object.
   @$pb.TagNumber(1)
   $core.String get collection => $_getSZ(0);
   @$pb.TagNumber(1)
-  set collection($core.String v) {
-    $_setString(0, v);
-  }
-
+  set collection($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCollection() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCollection() => clearField(1);
+  void clearCollection() => $_clearField(1);
 
+  /// The key of the object within the collection.
   @$pb.TagNumber(2)
   $core.String get key => $_getSZ(1);
   @$pb.TagNumber(2)
-  set key($core.String v) {
-    $_setString(1, v);
-  }
-
+  set key($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasKey() => $_has(1);
   @$pb.TagNumber(2)
-  void clearKey() => clearField(2);
+  void clearKey() => $_clearField(2);
 
+  /// The user owner of the object.
   @$pb.TagNumber(3)
   $core.String get userId => $_getSZ(2);
   @$pb.TagNumber(3)
-  set userId($core.String v) {
-    $_setString(2, v);
-  }
-
+  set userId($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUserId() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUserId() => clearField(3);
+  void clearUserId() => $_clearField(3);
 }
 
+/// Batch get storage objects.
 class ReadStorageObjectsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ReadStorageObjectsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<ReadStorageObjectId>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'objectIds',
-        $pb.PbFieldType.PM,
-        subBuilder: ReadStorageObjectId.create)
-    ..hasRequiredFields = false;
-
-  ReadStorageObjectsRequest._() : super();
   factory ReadStorageObjectsRequest({
     $core.Iterable<ReadStorageObjectId>? objectIds,
   }) {
-    final _result = create();
-    if (objectIds != null) {
-      _result.objectIds.addAll(objectIds);
-    }
-    return _result;
+    final result = create();
+    if (objectIds != null) result.objectIds.addAll(objectIds);
+    return result;
   }
-  factory ReadStorageObjectsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReadStorageObjectsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ReadStorageObjectsRequest clone() =>
-      ReadStorageObjectsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ReadStorageObjectsRequest._();
+
+  factory ReadStorageObjectsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ReadStorageObjectsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ReadStorageObjectsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<ReadStorageObjectId>(1, _omitFieldNames ? '' : 'objectIds',
+        subBuilder: ReadStorageObjectId.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ReadStorageObjectsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ReadStorageObjectsRequest copyWith(
           void Function(ReadStorageObjectsRequest) updates) =>
       super.copyWith((message) => updates(message as ReadStorageObjectsRequest))
-          as ReadStorageObjectsRequest; // ignore: deprecated_member_use
+          as ReadStorageObjectsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ReadStorageObjectsRequest create() => ReadStorageObjectsRequest._();
+  @$core.override
   ReadStorageObjectsRequest createEmptyInstance() => create();
   static $pb.PbList<ReadStorageObjectsRequest> createRepeated() =>
       $pb.PbList<ReadStorageObjectsRequest>();
@@ -9220,74 +7512,55 @@ class ReadStorageObjectsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ReadStorageObjectsRequest>(create);
   static ReadStorageObjectsRequest? _defaultInstance;
 
+  /// Batch of storage objects.
   @$pb.TagNumber(1)
-  $core.List<ReadStorageObjectId> get objectIds => $_getList(0);
+  $pb.PbList<ReadStorageObjectId> get objectIds => $_getList(0);
 }
 
+/// Execute an Lua function on the server.
 class Rpc extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Rpc',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'payload')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'httpKey')
-    ..hasRequiredFields = false;
-
-  Rpc._() : super();
   factory Rpc({
     $core.String? id,
     $core.String? payload,
     $core.String? httpKey,
   }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (payload != null) {
-      _result.payload = payload;
-    }
-    if (httpKey != null) {
-      _result.httpKey = httpKey;
-    }
-    return _result;
+    final result = create();
+    if (id != null) result.id = id;
+    if (payload != null) result.payload = payload;
+    if (httpKey != null) result.httpKey = httpKey;
+    return result;
   }
-  factory Rpc.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Rpc.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Rpc clone() => Rpc()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Rpc._();
+
+  factory Rpc.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Rpc.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Rpc',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..aOS(2, _omitFieldNames ? '' : 'payload')
+    ..aOS(3, _omitFieldNames ? '' : 'httpKey')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Rpc clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Rpc copyWith(void Function(Rpc) updates) =>
-      super.copyWith((message) => updates(message as Rpc))
-          as Rpc; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Rpc)) as Rpc;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Rpc create() => Rpc._();
+  @$core.override
   Rpc createEmptyInstance() => create();
   static $pb.PbList<Rpc> createRepeated() => $pb.PbList<Rpc>();
   @$core.pragma('dart2js:noInline')
@@ -9295,107 +7568,81 @@ class Rpc extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Rpc>(create);
   static Rpc? _defaultInstance;
 
+  /// The identifier of the function.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// The payload of the function which must be a JSON object.
   @$pb.TagNumber(2)
   $core.String get payload => $_getSZ(1);
   @$pb.TagNumber(2)
-  set payload($core.String v) {
-    $_setString(1, v);
-  }
-
+  set payload($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasPayload() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPayload() => clearField(2);
+  void clearPayload() => $_clearField(2);
 
+  /// The authentication key used when executed as a non-client HTTP request.
   @$pb.TagNumber(3)
   $core.String get httpKey => $_getSZ(2);
   @$pb.TagNumber(3)
-  set httpKey($core.String v) {
-    $_setString(2, v);
-  }
-
+  set httpKey($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasHttpKey() => $_has(2);
   @$pb.TagNumber(3)
-  void clearHttpKey() => clearField(3);
+  void clearHttpKey() => $_clearField(3);
 }
 
+/// A user's session used to authenticate messages.
 class Session extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Session',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOB(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'created')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'refreshToken')
-    ..hasRequiredFields = false;
-
-  Session._() : super();
   factory Session({
     $core.bool? created,
     $core.String? token,
     $core.String? refreshToken,
   }) {
-    final _result = create();
-    if (created != null) {
-      _result.created = created;
-    }
-    if (token != null) {
-      _result.token = token;
-    }
-    if (refreshToken != null) {
-      _result.refreshToken = refreshToken;
-    }
-    return _result;
+    final result = create();
+    if (created != null) result.created = created;
+    if (token != null) result.token = token;
+    if (refreshToken != null) result.refreshToken = refreshToken;
+    return result;
   }
-  factory Session.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Session.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Session clone() => Session()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Session._();
+
+  factory Session.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Session.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Session',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'created')
+    ..aOS(2, _omitFieldNames ? '' : 'token')
+    ..aOS(3, _omitFieldNames ? '' : 'refreshToken')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Session clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Session copyWith(void Function(Session) updates) =>
-      super.copyWith((message) => updates(message as Session))
-          as Session; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Session)) as Session;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Session create() => Session._();
+  @$core.override
   Session createEmptyInstance() => create();
   static $pb.PbList<Session> createRepeated() => $pb.PbList<Session>();
   @$core.pragma('dart2js:noInline')
@@ -9403,105 +7650,39 @@ class Session extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Session>(create);
   static Session? _defaultInstance;
 
+  /// True if the corresponding account was just created, false otherwise.
   @$pb.TagNumber(1)
   $core.bool get created => $_getBF(0);
   @$pb.TagNumber(1)
-  set created($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set created($core.bool value) => $_setBool(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCreated() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCreated() => clearField(1);
+  void clearCreated() => $_clearField(1);
 
+  /// Authentication credentials.
   @$pb.TagNumber(2)
   $core.String get token => $_getSZ(1);
   @$pb.TagNumber(2)
-  set token($core.String v) {
-    $_setString(1, v);
-  }
-
+  set token($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasToken() => $_has(1);
   @$pb.TagNumber(2)
-  void clearToken() => clearField(2);
+  void clearToken() => $_clearField(2);
 
+  /// Refresh token that can be used for session token renewal.
   @$pb.TagNumber(3)
   $core.String get refreshToken => $_getSZ(2);
   @$pb.TagNumber(3)
-  set refreshToken($core.String v) {
-    $_setString(2, v);
-  }
-
+  set refreshToken($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasRefreshToken() => $_has(2);
   @$pb.TagNumber(3)
-  void clearRefreshToken() => clearField(3);
+  void clearRefreshToken() => $_clearField(3);
 }
 
+/// An object within the storage engine.
 class StorageObject extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StorageObject',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'collection')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'key')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userId')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value')
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'version')
-    ..a<$core.int>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'permissionRead',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'permissionWrite',
-        $pb.PbFieldType.O3)
-    ..aOM<$0.Timestamp>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..hasRequiredFields = false;
-
-  StorageObject._() : super();
   factory StorageObject({
     $core.String? collection,
     $core.String? key,
@@ -9513,55 +7694,58 @@ class StorageObject extends $pb.GeneratedMessage {
     $0.Timestamp? createTime,
     $0.Timestamp? updateTime,
   }) {
-    final _result = create();
-    if (collection != null) {
-      _result.collection = collection;
-    }
-    if (key != null) {
-      _result.key = key;
-    }
-    if (userId != null) {
-      _result.userId = userId;
-    }
-    if (value != null) {
-      _result.value = value;
-    }
-    if (version != null) {
-      _result.version = version;
-    }
-    if (permissionRead != null) {
-      _result.permissionRead = permissionRead;
-    }
-    if (permissionWrite != null) {
-      _result.permissionWrite = permissionWrite;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    return _result;
+    final result = create();
+    if (collection != null) result.collection = collection;
+    if (key != null) result.key = key;
+    if (userId != null) result.userId = userId;
+    if (value != null) result.value = value;
+    if (version != null) result.version = version;
+    if (permissionRead != null) result.permissionRead = permissionRead;
+    if (permissionWrite != null) result.permissionWrite = permissionWrite;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    return result;
   }
-  factory StorageObject.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StorageObject.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StorageObject clone() => StorageObject()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StorageObject._();
+
+  factory StorageObject.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StorageObject.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StorageObject',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'collection')
+    ..aOS(2, _omitFieldNames ? '' : 'key')
+    ..aOS(3, _omitFieldNames ? '' : 'userId')
+    ..aOS(4, _omitFieldNames ? '' : 'value')
+    ..aOS(5, _omitFieldNames ? '' : 'version')
+    ..aI(6, _omitFieldNames ? '' : 'permissionRead')
+    ..aI(7, _omitFieldNames ? '' : 'permissionWrite')
+    ..aOM<$0.Timestamp>(8, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(9, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StorageObject clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StorageObject copyWith(void Function(StorageObject) updates) =>
       super.copyWith((message) => updates(message as StorageObject))
-          as StorageObject; // ignore: deprecated_member_use
+          as StorageObject;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StorageObject create() => StorageObject._();
+  @$core.override
   StorageObject createEmptyInstance() => create();
   static $pb.PbList<StorageObject> createRepeated() =>
       $pb.PbList<StorageObject>();
@@ -9570,192 +7754,157 @@ class StorageObject extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StorageObject>(create);
   static StorageObject? _defaultInstance;
 
+  /// The collection which stores the object.
   @$pb.TagNumber(1)
   $core.String get collection => $_getSZ(0);
   @$pb.TagNumber(1)
-  set collection($core.String v) {
-    $_setString(0, v);
-  }
-
+  set collection($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCollection() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCollection() => clearField(1);
+  void clearCollection() => $_clearField(1);
 
+  /// The key of the object within the collection.
   @$pb.TagNumber(2)
   $core.String get key => $_getSZ(1);
   @$pb.TagNumber(2)
-  set key($core.String v) {
-    $_setString(1, v);
-  }
-
+  set key($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasKey() => $_has(1);
   @$pb.TagNumber(2)
-  void clearKey() => clearField(2);
+  void clearKey() => $_clearField(2);
 
+  /// The user owner of the object.
   @$pb.TagNumber(3)
   $core.String get userId => $_getSZ(2);
   @$pb.TagNumber(3)
-  set userId($core.String v) {
-    $_setString(2, v);
-  }
-
+  set userId($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUserId() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUserId() => clearField(3);
+  void clearUserId() => $_clearField(3);
 
+  /// The value of the object.
   @$pb.TagNumber(4)
   $core.String get value => $_getSZ(3);
   @$pb.TagNumber(4)
-  set value($core.String v) {
-    $_setString(3, v);
-  }
-
+  set value($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasValue() => $_has(3);
   @$pb.TagNumber(4)
-  void clearValue() => clearField(4);
+  void clearValue() => $_clearField(4);
 
+  /// The version hash of the object.
   @$pb.TagNumber(5)
   $core.String get version => $_getSZ(4);
   @$pb.TagNumber(5)
-  set version($core.String v) {
-    $_setString(4, v);
-  }
-
+  set version($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasVersion() => $_has(4);
   @$pb.TagNumber(5)
-  void clearVersion() => clearField(5);
+  void clearVersion() => $_clearField(5);
 
+  /// The read access permissions for the object.
   @$pb.TagNumber(6)
   $core.int get permissionRead => $_getIZ(5);
   @$pb.TagNumber(6)
-  set permissionRead($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set permissionRead($core.int value) => $_setSignedInt32(5, value);
   @$pb.TagNumber(6)
   $core.bool hasPermissionRead() => $_has(5);
   @$pb.TagNumber(6)
-  void clearPermissionRead() => clearField(6);
+  void clearPermissionRead() => $_clearField(6);
 
+  /// The write access permissions for the object.
   @$pb.TagNumber(7)
   $core.int get permissionWrite => $_getIZ(6);
   @$pb.TagNumber(7)
-  set permissionWrite($core.int v) {
-    $_setSignedInt32(6, v);
-  }
-
+  set permissionWrite($core.int value) => $_setSignedInt32(6, value);
   @$pb.TagNumber(7)
   $core.bool hasPermissionWrite() => $_has(6);
   @$pb.TagNumber(7)
-  void clearPermissionWrite() => clearField(7);
+  void clearPermissionWrite() => $_clearField(7);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the object was created.
   @$pb.TagNumber(8)
   $0.Timestamp get createTime => $_getN(7);
   @$pb.TagNumber(8)
-  set createTime($0.Timestamp v) {
-    setField(8, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(8, value);
   @$pb.TagNumber(8)
   $core.bool hasCreateTime() => $_has(7);
   @$pb.TagNumber(8)
-  void clearCreateTime() => clearField(8);
+  void clearCreateTime() => $_clearField(8);
   @$pb.TagNumber(8)
   $0.Timestamp ensureCreateTime() => $_ensure(7);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the object was last updated.
   @$pb.TagNumber(9)
   $0.Timestamp get updateTime => $_getN(8);
   @$pb.TagNumber(9)
-  set updateTime($0.Timestamp v) {
-    setField(9, v);
-  }
-
+  set updateTime($0.Timestamp value) => $_setField(9, value);
   @$pb.TagNumber(9)
   $core.bool hasUpdateTime() => $_has(8);
   @$pb.TagNumber(9)
-  void clearUpdateTime() => clearField(9);
+  void clearUpdateTime() => $_clearField(9);
   @$pb.TagNumber(9)
   $0.Timestamp ensureUpdateTime() => $_ensure(8);
 }
 
+/// A storage acknowledgement.
 class StorageObjectAck extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StorageObjectAck',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'collection')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'key')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'version')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userId')
-    ..hasRequiredFields = false;
-
-  StorageObjectAck._() : super();
   factory StorageObjectAck({
     $core.String? collection,
     $core.String? key,
     $core.String? version,
     $core.String? userId,
+    $0.Timestamp? createTime,
+    $0.Timestamp? updateTime,
   }) {
-    final _result = create();
-    if (collection != null) {
-      _result.collection = collection;
-    }
-    if (key != null) {
-      _result.key = key;
-    }
-    if (version != null) {
-      _result.version = version;
-    }
-    if (userId != null) {
-      _result.userId = userId;
-    }
-    return _result;
+    final result = create();
+    if (collection != null) result.collection = collection;
+    if (key != null) result.key = key;
+    if (version != null) result.version = version;
+    if (userId != null) result.userId = userId;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    return result;
   }
-  factory StorageObjectAck.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StorageObjectAck.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StorageObjectAck clone() => StorageObjectAck()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StorageObjectAck._();
+
+  factory StorageObjectAck.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StorageObjectAck.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StorageObjectAck',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'collection')
+    ..aOS(2, _omitFieldNames ? '' : 'key')
+    ..aOS(3, _omitFieldNames ? '' : 'version')
+    ..aOS(4, _omitFieldNames ? '' : 'userId')
+    ..aOM<$0.Timestamp>(5, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(6, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StorageObjectAck clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StorageObjectAck copyWith(void Function(StorageObjectAck) updates) =>
       super.copyWith((message) => updates(message as StorageObjectAck))
-          as StorageObjectAck; // ignore: deprecated_member_use
+          as StorageObjectAck;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StorageObjectAck create() => StorageObjectAck._();
+  @$core.override
   StorageObjectAck createEmptyInstance() => create();
   static $pb.PbList<StorageObjectAck> createRepeated() =>
       $pb.PbList<StorageObjectAck>();
@@ -9764,103 +7913,111 @@ class StorageObjectAck extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StorageObjectAck>(create);
   static StorageObjectAck? _defaultInstance;
 
+  /// The collection which stores the object.
   @$pb.TagNumber(1)
   $core.String get collection => $_getSZ(0);
   @$pb.TagNumber(1)
-  set collection($core.String v) {
-    $_setString(0, v);
-  }
-
+  set collection($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCollection() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCollection() => clearField(1);
+  void clearCollection() => $_clearField(1);
 
+  /// The key of the object within the collection.
   @$pb.TagNumber(2)
   $core.String get key => $_getSZ(1);
   @$pb.TagNumber(2)
-  set key($core.String v) {
-    $_setString(1, v);
-  }
-
+  set key($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasKey() => $_has(1);
   @$pb.TagNumber(2)
-  void clearKey() => clearField(2);
+  void clearKey() => $_clearField(2);
 
+  /// The version hash of the object.
   @$pb.TagNumber(3)
   $core.String get version => $_getSZ(2);
   @$pb.TagNumber(3)
-  set version($core.String v) {
-    $_setString(2, v);
-  }
-
+  set version($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasVersion() => $_has(2);
   @$pb.TagNumber(3)
-  void clearVersion() => clearField(3);
+  void clearVersion() => $_clearField(3);
 
+  /// The owner of the object.
   @$pb.TagNumber(4)
   $core.String get userId => $_getSZ(3);
   @$pb.TagNumber(4)
-  set userId($core.String v) {
-    $_setString(3, v);
-  }
-
+  set userId($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasUserId() => $_has(3);
   @$pb.TagNumber(4)
-  void clearUserId() => clearField(4);
+  void clearUserId() => $_clearField(4);
+
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the object was created.
+  @$pb.TagNumber(5)
+  $0.Timestamp get createTime => $_getN(4);
+  @$pb.TagNumber(5)
+  set createTime($0.Timestamp value) => $_setField(5, value);
+  @$pb.TagNumber(5)
+  $core.bool hasCreateTime() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearCreateTime() => $_clearField(5);
+  @$pb.TagNumber(5)
+  $0.Timestamp ensureCreateTime() => $_ensure(4);
+
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the object was last updated.
+  @$pb.TagNumber(6)
+  $0.Timestamp get updateTime => $_getN(5);
+  @$pb.TagNumber(6)
+  set updateTime($0.Timestamp value) => $_setField(6, value);
+  @$pb.TagNumber(6)
+  $core.bool hasUpdateTime() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearUpdateTime() => $_clearField(6);
+  @$pb.TagNumber(6)
+  $0.Timestamp ensureUpdateTime() => $_ensure(5);
 }
 
+/// Batch of acknowledgements for the storage object write.
 class StorageObjectAcks extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StorageObjectAcks',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<StorageObjectAck>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'acks',
-        $pb.PbFieldType.PM,
-        subBuilder: StorageObjectAck.create)
-    ..hasRequiredFields = false;
-
-  StorageObjectAcks._() : super();
   factory StorageObjectAcks({
     $core.Iterable<StorageObjectAck>? acks,
   }) {
-    final _result = create();
-    if (acks != null) {
-      _result.acks.addAll(acks);
-    }
-    return _result;
+    final result = create();
+    if (acks != null) result.acks.addAll(acks);
+    return result;
   }
-  factory StorageObjectAcks.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StorageObjectAcks.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StorageObjectAcks clone() => StorageObjectAcks()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StorageObjectAcks._();
+
+  factory StorageObjectAcks.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StorageObjectAcks.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StorageObjectAcks',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<StorageObjectAck>(1, _omitFieldNames ? '' : 'acks',
+        subBuilder: StorageObjectAck.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StorageObjectAcks clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StorageObjectAcks copyWith(void Function(StorageObjectAcks) updates) =>
       super.copyWith((message) => updates(message as StorageObjectAcks))
-          as StorageObjectAcks; // ignore: deprecated_member_use
+          as StorageObjectAcks;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StorageObjectAcks create() => StorageObjectAcks._();
+  @$core.override
   StorageObjectAcks createEmptyInstance() => create();
   static $pb.PbList<StorageObjectAcks> createRepeated() =>
       $pb.PbList<StorageObjectAcks>();
@@ -9869,58 +8026,51 @@ class StorageObjectAcks extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StorageObjectAcks>(create);
   static StorageObjectAcks? _defaultInstance;
 
+  /// Batch of storage write acknowledgements.
   @$pb.TagNumber(1)
-  $core.List<StorageObjectAck> get acks => $_getList(0);
+  $pb.PbList<StorageObjectAck> get acks => $_getList(0);
 }
 
+/// Batch of storage objects.
 class StorageObjects extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StorageObjects',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<StorageObject>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'objects',
-        $pb.PbFieldType.PM,
-        subBuilder: StorageObject.create)
-    ..hasRequiredFields = false;
-
-  StorageObjects._() : super();
   factory StorageObjects({
     $core.Iterable<StorageObject>? objects,
   }) {
-    final _result = create();
-    if (objects != null) {
-      _result.objects.addAll(objects);
-    }
-    return _result;
+    final result = create();
+    if (objects != null) result.objects.addAll(objects);
+    return result;
   }
-  factory StorageObjects.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StorageObjects.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StorageObjects clone() => StorageObjects()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StorageObjects._();
+
+  factory StorageObjects.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StorageObjects.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StorageObjects',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<StorageObject>(1, _omitFieldNames ? '' : 'objects',
+        subBuilder: StorageObject.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StorageObjects clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StorageObjects copyWith(void Function(StorageObjects) updates) =>
       super.copyWith((message) => updates(message as StorageObjects))
-          as StorageObjects; // ignore: deprecated_member_use
+          as StorageObjects;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StorageObjects create() => StorageObjects._();
+  @$core.override
   StorageObjects createEmptyInstance() => create();
   static $pb.PbList<StorageObjects> createRepeated() =>
       $pb.PbList<StorageObjects>();
@@ -9929,67 +8079,54 @@ class StorageObjects extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StorageObjects>(create);
   static StorageObjects? _defaultInstance;
 
+  /// The batch of storage objects.
   @$pb.TagNumber(1)
-  $core.List<StorageObject> get objects => $_getList(0);
+  $pb.PbList<StorageObject> get objects => $_getList(0);
 }
 
+/// List of storage objects.
 class StorageObjectList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StorageObjectList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<StorageObject>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'objects',
-        $pb.PbFieldType.PM,
-        subBuilder: StorageObject.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  StorageObjectList._() : super();
   factory StorageObjectList({
     $core.Iterable<StorageObject>? objects,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (objects != null) {
-      _result.objects.addAll(objects);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (objects != null) result.objects.addAll(objects);
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory StorageObjectList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StorageObjectList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StorageObjectList clone() => StorageObjectList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StorageObjectList._();
+
+  factory StorageObjectList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StorageObjectList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StorageObjectList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<StorageObject>(1, _omitFieldNames ? '' : 'objects',
+        subBuilder: StorageObject.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StorageObjectList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StorageObjectList copyWith(void Function(StorageObjectList) updates) =>
       super.copyWith((message) => updates(message as StorageObjectList))
-          as StorageObjectList; // ignore: deprecated_member_use
+          as StorageObjectList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StorageObjectList create() => StorageObjectList._();
+  @$core.override
   StorageObjectList createEmptyInstance() => create();
   static $pb.PbList<StorageObjectList> createRepeated() =>
       $pb.PbList<StorageObjectList>();
@@ -9998,152 +8135,23 @@ class StorageObjectList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StorageObjectList>(create);
   static StorageObjectList? _defaultInstance;
 
+  /// The list of storage objects.
   @$pb.TagNumber(1)
-  $core.List<StorageObject> get objects => $_getList(0);
+  $pb.PbList<StorageObject> get objects => $_getList(0);
 
+  /// The cursor for the next page of results, if any.
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 }
 
+/// A tournament on the server.
 class Tournament extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Tournament',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'title')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'description')
-    ..a<$core.int>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'category',
-        $pb.PbFieldType.OU3)
-    ..a<$core.int>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sortOrder',
-        $pb.PbFieldType.OU3)
-    ..a<$core.int>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'size',
-        $pb.PbFieldType.OU3)
-    ..a<$core.int>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxSize',
-        $pb.PbFieldType.OU3)
-    ..a<$core.int>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxNumScore',
-        $pb.PbFieldType.OU3)
-    ..aOB(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'canEnter')
-    ..a<$core.int>(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'endActive',
-        $pb.PbFieldType.OU3)
-    ..a<$core.int>(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'nextReset',
-        $pb.PbFieldType.OU3)
-    ..aOS(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'metadata')
-    ..aOM<$0.Timestamp>(
-        13,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        14,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'startTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        15,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'endTime',
-        subBuilder: $0.Timestamp.create)
-    ..a<$core.int>(
-        16,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'duration',
-        $pb.PbFieldType.OU3)
-    ..a<$core.int>(
-        17,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'startActive',
-        $pb.PbFieldType.OU3)
-    ..a<$core.int>(
-        18,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'prevReset',
-        $pb.PbFieldType.OU3)
-    ..e<Operator>(
-        19,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'operator',
-        $pb.PbFieldType.OE,
-        defaultOrMaker: Operator.NO_OVERRIDE,
-        valueOf: Operator.valueOf,
-        enumValues: Operator.values)
-    ..aOB(
-        20,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'authoritative')
-    ..hasRequiredFields = false;
-
-  Tournament._() : super();
   factory Tournament({
     $core.String? id,
     $core.String? title,
@@ -10165,89 +8173,87 @@ class Tournament extends $pb.GeneratedMessage {
     $core.int? prevReset,
     Operator? operator,
     $core.bool? authoritative,
+    $core.bool? joinRequired,
   }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (title != null) {
-      _result.title = title;
-    }
-    if (description != null) {
-      _result.description = description;
-    }
-    if (category != null) {
-      _result.category = category;
-    }
-    if (sortOrder != null) {
-      _result.sortOrder = sortOrder;
-    }
-    if (size != null) {
-      _result.size = size;
-    }
-    if (maxSize != null) {
-      _result.maxSize = maxSize;
-    }
-    if (maxNumScore != null) {
-      _result.maxNumScore = maxNumScore;
-    }
-    if (canEnter != null) {
-      _result.canEnter = canEnter;
-    }
-    if (endActive != null) {
-      _result.endActive = endActive;
-    }
-    if (nextReset != null) {
-      _result.nextReset = nextReset;
-    }
-    if (metadata != null) {
-      _result.metadata = metadata;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (startTime != null) {
-      _result.startTime = startTime;
-    }
-    if (endTime != null) {
-      _result.endTime = endTime;
-    }
-    if (duration != null) {
-      _result.duration = duration;
-    }
-    if (startActive != null) {
-      _result.startActive = startActive;
-    }
-    if (prevReset != null) {
-      _result.prevReset = prevReset;
-    }
-    if (operator != null) {
-      _result.operator = operator;
-    }
-    if (authoritative != null) {
-      _result.authoritative = authoritative;
-    }
-    return _result;
+    final result = create();
+    if (id != null) result.id = id;
+    if (title != null) result.title = title;
+    if (description != null) result.description = description;
+    if (category != null) result.category = category;
+    if (sortOrder != null) result.sortOrder = sortOrder;
+    if (size != null) result.size = size;
+    if (maxSize != null) result.maxSize = maxSize;
+    if (maxNumScore != null) result.maxNumScore = maxNumScore;
+    if (canEnter != null) result.canEnter = canEnter;
+    if (endActive != null) result.endActive = endActive;
+    if (nextReset != null) result.nextReset = nextReset;
+    if (metadata != null) result.metadata = metadata;
+    if (createTime != null) result.createTime = createTime;
+    if (startTime != null) result.startTime = startTime;
+    if (endTime != null) result.endTime = endTime;
+    if (duration != null) result.duration = duration;
+    if (startActive != null) result.startActive = startActive;
+    if (prevReset != null) result.prevReset = prevReset;
+    if (operator != null) result.operator = operator;
+    if (authoritative != null) result.authoritative = authoritative;
+    if (joinRequired != null) result.joinRequired = joinRequired;
+    return result;
   }
-  factory Tournament.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Tournament.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Tournament clone() => Tournament()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Tournament._();
+
+  factory Tournament.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Tournament.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Tournament',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..aOS(2, _omitFieldNames ? '' : 'title')
+    ..aOS(3, _omitFieldNames ? '' : 'description')
+    ..aI(4, _omitFieldNames ? '' : 'category', fieldType: $pb.PbFieldType.OU3)
+    ..aI(5, _omitFieldNames ? '' : 'sortOrder', fieldType: $pb.PbFieldType.OU3)
+    ..aI(6, _omitFieldNames ? '' : 'size', fieldType: $pb.PbFieldType.OU3)
+    ..aI(7, _omitFieldNames ? '' : 'maxSize', fieldType: $pb.PbFieldType.OU3)
+    ..aI(8, _omitFieldNames ? '' : 'maxNumScore',
+        fieldType: $pb.PbFieldType.OU3)
+    ..aOB(9, _omitFieldNames ? '' : 'canEnter')
+    ..aI(10, _omitFieldNames ? '' : 'endActive', fieldType: $pb.PbFieldType.OU3)
+    ..aI(11, _omitFieldNames ? '' : 'nextReset', fieldType: $pb.PbFieldType.OU3)
+    ..aOS(12, _omitFieldNames ? '' : 'metadata')
+    ..aOM<$0.Timestamp>(13, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(14, _omitFieldNames ? '' : 'startTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(15, _omitFieldNames ? '' : 'endTime',
+        subBuilder: $0.Timestamp.create)
+    ..aI(16, _omitFieldNames ? '' : 'duration', fieldType: $pb.PbFieldType.OU3)
+    ..aI(17, _omitFieldNames ? '' : 'startActive',
+        fieldType: $pb.PbFieldType.OU3)
+    ..aI(18, _omitFieldNames ? '' : 'prevReset', fieldType: $pb.PbFieldType.OU3)
+    ..aE<Operator>(19, _omitFieldNames ? '' : 'operator',
+        enumValues: Operator.values)
+    ..aOB(20, _omitFieldNames ? '' : 'authoritative')
+    ..aOB(21, _omitFieldNames ? '' : 'joinRequired')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Tournament clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Tournament copyWith(void Function(Tournament) updates) =>
-      super.copyWith((message) => updates(message as Tournament))
-          as Tournament; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Tournament)) as Tournament;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Tournament create() => Tournament._();
+  @$core.override
   Tournament createEmptyInstance() => create();
   static $pb.PbList<Tournament> createRepeated() => $pb.PbList<Tournament>();
   @$core.pragma('dart2js:noInline')
@@ -10255,310 +8261,266 @@ class Tournament extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<Tournament>(create);
   static Tournament? _defaultInstance;
 
+  /// The ID of the tournament.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// The title for the tournament.
   @$pb.TagNumber(2)
   $core.String get title => $_getSZ(1);
   @$pb.TagNumber(2)
-  set title($core.String v) {
-    $_setString(1, v);
-  }
-
+  set title($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasTitle() => $_has(1);
   @$pb.TagNumber(2)
-  void clearTitle() => clearField(2);
+  void clearTitle() => $_clearField(2);
 
+  /// The description of the tournament. May be blank.
   @$pb.TagNumber(3)
   $core.String get description => $_getSZ(2);
   @$pb.TagNumber(3)
-  set description($core.String v) {
-    $_setString(2, v);
-  }
-
+  set description($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasDescription() => $_has(2);
   @$pb.TagNumber(3)
-  void clearDescription() => clearField(3);
+  void clearDescription() => $_clearField(3);
 
+  /// The category of the tournament. e.g. "vip" could be category 1.
   @$pb.TagNumber(4)
   $core.int get category => $_getIZ(3);
   @$pb.TagNumber(4)
-  set category($core.int v) {
-    $_setUnsignedInt32(3, v);
-  }
-
+  set category($core.int value) => $_setUnsignedInt32(3, value);
   @$pb.TagNumber(4)
   $core.bool hasCategory() => $_has(3);
   @$pb.TagNumber(4)
-  void clearCategory() => clearField(4);
+  void clearCategory() => $_clearField(4);
 
+  /// ASC (0) or DESC (1) sort mode of scores in the tournament.
   @$pb.TagNumber(5)
   $core.int get sortOrder => $_getIZ(4);
   @$pb.TagNumber(5)
-  set sortOrder($core.int v) {
-    $_setUnsignedInt32(4, v);
-  }
-
+  set sortOrder($core.int value) => $_setUnsignedInt32(4, value);
   @$pb.TagNumber(5)
   $core.bool hasSortOrder() => $_has(4);
   @$pb.TagNumber(5)
-  void clearSortOrder() => clearField(5);
+  void clearSortOrder() => $_clearField(5);
 
+  /// The current number of players in the tournament.
   @$pb.TagNumber(6)
   $core.int get size => $_getIZ(5);
   @$pb.TagNumber(6)
-  set size($core.int v) {
-    $_setUnsignedInt32(5, v);
-  }
-
+  set size($core.int value) => $_setUnsignedInt32(5, value);
   @$pb.TagNumber(6)
   $core.bool hasSize() => $_has(5);
   @$pb.TagNumber(6)
-  void clearSize() => clearField(6);
+  void clearSize() => $_clearField(6);
 
+  /// The maximum number of players for the tournament.
   @$pb.TagNumber(7)
   $core.int get maxSize => $_getIZ(6);
   @$pb.TagNumber(7)
-  set maxSize($core.int v) {
-    $_setUnsignedInt32(6, v);
-  }
-
+  set maxSize($core.int value) => $_setUnsignedInt32(6, value);
   @$pb.TagNumber(7)
   $core.bool hasMaxSize() => $_has(6);
   @$pb.TagNumber(7)
-  void clearMaxSize() => clearField(7);
+  void clearMaxSize() => $_clearField(7);
 
+  /// The maximum score updates allowed per player for the current tournament.
   @$pb.TagNumber(8)
   $core.int get maxNumScore => $_getIZ(7);
   @$pb.TagNumber(8)
-  set maxNumScore($core.int v) {
-    $_setUnsignedInt32(7, v);
-  }
-
+  set maxNumScore($core.int value) => $_setUnsignedInt32(7, value);
   @$pb.TagNumber(8)
   $core.bool hasMaxNumScore() => $_has(7);
   @$pb.TagNumber(8)
-  void clearMaxNumScore() => clearField(8);
+  void clearMaxNumScore() => $_clearField(8);
 
+  /// True if the tournament is active and can enter. A computed value.
   @$pb.TagNumber(9)
   $core.bool get canEnter => $_getBF(8);
   @$pb.TagNumber(9)
-  set canEnter($core.bool v) {
-    $_setBool(8, v);
-  }
-
+  set canEnter($core.bool value) => $_setBool(8, value);
   @$pb.TagNumber(9)
   $core.bool hasCanEnter() => $_has(8);
   @$pb.TagNumber(9)
-  void clearCanEnter() => clearField(9);
+  void clearCanEnter() => $_clearField(9);
 
+  /// The UNIX time when the tournament stops being active until next reset. A computed value.
   @$pb.TagNumber(10)
   $core.int get endActive => $_getIZ(9);
   @$pb.TagNumber(10)
-  set endActive($core.int v) {
-    $_setUnsignedInt32(9, v);
-  }
-
+  set endActive($core.int value) => $_setUnsignedInt32(9, value);
   @$pb.TagNumber(10)
   $core.bool hasEndActive() => $_has(9);
   @$pb.TagNumber(10)
-  void clearEndActive() => clearField(10);
+  void clearEndActive() => $_clearField(10);
 
+  /// The UNIX time when the tournament is next playable. A computed value.
   @$pb.TagNumber(11)
   $core.int get nextReset => $_getIZ(10);
   @$pb.TagNumber(11)
-  set nextReset($core.int v) {
-    $_setUnsignedInt32(10, v);
-  }
-
+  set nextReset($core.int value) => $_setUnsignedInt32(10, value);
   @$pb.TagNumber(11)
   $core.bool hasNextReset() => $_has(10);
   @$pb.TagNumber(11)
-  void clearNextReset() => clearField(11);
+  void clearNextReset() => $_clearField(11);
 
+  /// Additional information stored as a JSON object.
   @$pb.TagNumber(12)
   $core.String get metadata => $_getSZ(11);
   @$pb.TagNumber(12)
-  set metadata($core.String v) {
-    $_setString(11, v);
-  }
-
+  set metadata($core.String value) => $_setString(11, value);
   @$pb.TagNumber(12)
   $core.bool hasMetadata() => $_has(11);
   @$pb.TagNumber(12)
-  void clearMetadata() => clearField(12);
+  void clearMetadata() => $_clearField(12);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the tournament was created.
   @$pb.TagNumber(13)
   $0.Timestamp get createTime => $_getN(12);
   @$pb.TagNumber(13)
-  set createTime($0.Timestamp v) {
-    setField(13, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(13, value);
   @$pb.TagNumber(13)
   $core.bool hasCreateTime() => $_has(12);
   @$pb.TagNumber(13)
-  void clearCreateTime() => clearField(13);
+  void clearCreateTime() => $_clearField(13);
   @$pb.TagNumber(13)
   $0.Timestamp ensureCreateTime() => $_ensure(12);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the tournament will start.
   @$pb.TagNumber(14)
   $0.Timestamp get startTime => $_getN(13);
   @$pb.TagNumber(14)
-  set startTime($0.Timestamp v) {
-    setField(14, v);
-  }
-
+  set startTime($0.Timestamp value) => $_setField(14, value);
   @$pb.TagNumber(14)
   $core.bool hasStartTime() => $_has(13);
   @$pb.TagNumber(14)
-  void clearStartTime() => clearField(14);
+  void clearStartTime() => $_clearField(14);
   @$pb.TagNumber(14)
   $0.Timestamp ensureStartTime() => $_ensure(13);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the tournament will be stopped.
   @$pb.TagNumber(15)
   $0.Timestamp get endTime => $_getN(14);
   @$pb.TagNumber(15)
-  set endTime($0.Timestamp v) {
-    setField(15, v);
-  }
-
+  set endTime($0.Timestamp value) => $_setField(15, value);
   @$pb.TagNumber(15)
   $core.bool hasEndTime() => $_has(14);
   @$pb.TagNumber(15)
-  void clearEndTime() => clearField(15);
+  void clearEndTime() => $_clearField(15);
   @$pb.TagNumber(15)
   $0.Timestamp ensureEndTime() => $_ensure(14);
 
+  /// Duration of the tournament in seconds.
   @$pb.TagNumber(16)
   $core.int get duration => $_getIZ(15);
   @$pb.TagNumber(16)
-  set duration($core.int v) {
-    $_setUnsignedInt32(15, v);
-  }
-
+  set duration($core.int value) => $_setUnsignedInt32(15, value);
   @$pb.TagNumber(16)
   $core.bool hasDuration() => $_has(15);
   @$pb.TagNumber(16)
-  void clearDuration() => clearField(16);
+  void clearDuration() => $_clearField(16);
 
+  /// The UNIX time when the tournament start being active. A computed value.
   @$pb.TagNumber(17)
   $core.int get startActive => $_getIZ(16);
   @$pb.TagNumber(17)
-  set startActive($core.int v) {
-    $_setUnsignedInt32(16, v);
-  }
-
+  set startActive($core.int value) => $_setUnsignedInt32(16, value);
   @$pb.TagNumber(17)
   $core.bool hasStartActive() => $_has(16);
   @$pb.TagNumber(17)
-  void clearStartActive() => clearField(17);
+  void clearStartActive() => $_clearField(17);
 
+  /// The UNIX time when the tournament was last reset. A computed value.
   @$pb.TagNumber(18)
   $core.int get prevReset => $_getIZ(17);
   @$pb.TagNumber(18)
-  set prevReset($core.int v) {
-    $_setUnsignedInt32(17, v);
-  }
-
+  set prevReset($core.int value) => $_setUnsignedInt32(17, value);
   @$pb.TagNumber(18)
   $core.bool hasPrevReset() => $_has(17);
   @$pb.TagNumber(18)
-  void clearPrevReset() => clearField(18);
+  void clearPrevReset() => $_clearField(18);
 
+  /// Operator.
   @$pb.TagNumber(19)
   Operator get operator => $_getN(18);
   @$pb.TagNumber(19)
-  set operator(Operator v) {
-    setField(19, v);
-  }
-
+  set operator(Operator value) => $_setField(19, value);
   @$pb.TagNumber(19)
   $core.bool hasOperator() => $_has(18);
   @$pb.TagNumber(19)
-  void clearOperator() => clearField(19);
+  void clearOperator() => $_clearField(19);
 
+  /// Whether the leaderboard was created authoritatively or not.
   @$pb.TagNumber(20)
   $core.bool get authoritative => $_getBF(19);
   @$pb.TagNumber(20)
-  set authoritative($core.bool v) {
-    $_setBool(19, v);
-  }
-
+  set authoritative($core.bool value) => $_setBool(19, value);
   @$pb.TagNumber(20)
   $core.bool hasAuthoritative() => $_has(19);
   @$pb.TagNumber(20)
-  void clearAuthoritative() => clearField(20);
+  void clearAuthoritative() => $_clearField(20);
+
+  /// Whether the user must join the tournament before being able to submit scores.
+  @$pb.TagNumber(21)
+  $core.bool get joinRequired => $_getBF(20);
+  @$pb.TagNumber(21)
+  set joinRequired($core.bool value) => $_setBool(20, value);
+  @$pb.TagNumber(21)
+  $core.bool hasJoinRequired() => $_has(20);
+  @$pb.TagNumber(21)
+  void clearJoinRequired() => $_clearField(21);
 }
 
+/// A list of tournaments.
 class TournamentList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'TournamentList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<Tournament>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'tournaments',
-        $pb.PbFieldType.PM,
-        subBuilder: Tournament.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  TournamentList._() : super();
   factory TournamentList({
     $core.Iterable<Tournament>? tournaments,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (tournaments != null) {
-      _result.tournaments.addAll(tournaments);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (tournaments != null) result.tournaments.addAll(tournaments);
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory TournamentList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TournamentList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  TournamentList clone() => TournamentList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  TournamentList._();
+
+  factory TournamentList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory TournamentList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'TournamentList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<Tournament>(1, _omitFieldNames ? '' : 'tournaments',
+        subBuilder: Tournament.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  TournamentList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   TournamentList copyWith(void Function(TournamentList) updates) =>
       super.copyWith((message) => updates(message as TournamentList))
-          as TournamentList; // ignore: deprecated_member_use
+          as TournamentList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static TournamentList create() => TournamentList._();
+  @$core.override
   TournamentList createEmptyInstance() => create();
   static $pb.PbList<TournamentList> createRepeated() =>
       $pb.PbList<TournamentList>();
@@ -10567,100 +8529,74 @@ class TournamentList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<TournamentList>(create);
   static TournamentList? _defaultInstance;
 
+  /// The list of tournaments returned.
   @$pb.TagNumber(1)
-  $core.List<Tournament> get tournaments => $_getList(0);
+  $pb.PbList<Tournament> get tournaments => $_getList(0);
 
+  /// A pagination cursor (optional).
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 }
 
+/// A set of tournament records which may be part of a tournament records page or a batch of individual records.
 class TournamentRecordList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'TournamentRecordList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<LeaderboardRecord>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'records',
-        $pb.PbFieldType.PM,
-        subBuilder: LeaderboardRecord.create)
-    ..pc<LeaderboardRecord>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ownerRecords',
-        $pb.PbFieldType.PM,
-        subBuilder: LeaderboardRecord.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'nextCursor')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'prevCursor')
-    ..hasRequiredFields = false;
-
-  TournamentRecordList._() : super();
   factory TournamentRecordList({
     $core.Iterable<LeaderboardRecord>? records,
     $core.Iterable<LeaderboardRecord>? ownerRecords,
     $core.String? nextCursor,
     $core.String? prevCursor,
+    $fixnum.Int64? rankCount,
   }) {
-    final _result = create();
-    if (records != null) {
-      _result.records.addAll(records);
-    }
-    if (ownerRecords != null) {
-      _result.ownerRecords.addAll(ownerRecords);
-    }
-    if (nextCursor != null) {
-      _result.nextCursor = nextCursor;
-    }
-    if (prevCursor != null) {
-      _result.prevCursor = prevCursor;
-    }
-    return _result;
+    final result = create();
+    if (records != null) result.records.addAll(records);
+    if (ownerRecords != null) result.ownerRecords.addAll(ownerRecords);
+    if (nextCursor != null) result.nextCursor = nextCursor;
+    if (prevCursor != null) result.prevCursor = prevCursor;
+    if (rankCount != null) result.rankCount = rankCount;
+    return result;
   }
-  factory TournamentRecordList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory TournamentRecordList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  TournamentRecordList clone() =>
-      TournamentRecordList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  TournamentRecordList._();
+
+  factory TournamentRecordList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory TournamentRecordList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'TournamentRecordList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<LeaderboardRecord>(1, _omitFieldNames ? '' : 'records',
+        subBuilder: LeaderboardRecord.create)
+    ..pPM<LeaderboardRecord>(2, _omitFieldNames ? '' : 'ownerRecords',
+        subBuilder: LeaderboardRecord.create)
+    ..aOS(3, _omitFieldNames ? '' : 'nextCursor')
+    ..aOS(4, _omitFieldNames ? '' : 'prevCursor')
+    ..aInt64(5, _omitFieldNames ? '' : 'rankCount')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  TournamentRecordList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   TournamentRecordList copyWith(void Function(TournamentRecordList) updates) =>
       super.copyWith((message) => updates(message as TournamentRecordList))
-          as TournamentRecordList; // ignore: deprecated_member_use
+          as TournamentRecordList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static TournamentRecordList create() => TournamentRecordList._();
+  @$core.override
   TournamentRecordList createEmptyInstance() => create();
   static $pb.PbList<TournamentRecordList> createRepeated() =>
       $pb.PbList<TournamentRecordList>();
@@ -10669,86 +8605,47 @@ class TournamentRecordList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<TournamentRecordList>(create);
   static TournamentRecordList? _defaultInstance;
 
+  /// A list of tournament records.
   @$pb.TagNumber(1)
-  $core.List<LeaderboardRecord> get records => $_getList(0);
+  $pb.PbList<LeaderboardRecord> get records => $_getList(0);
 
+  /// A batched set of tournament records belonging to specified owners.
   @$pb.TagNumber(2)
-  $core.List<LeaderboardRecord> get ownerRecords => $_getList(1);
+  $pb.PbList<LeaderboardRecord> get ownerRecords => $_getList(1);
 
+  /// The cursor to send when retireving the next page (optional).
   @$pb.TagNumber(3)
   $core.String get nextCursor => $_getSZ(2);
   @$pb.TagNumber(3)
-  set nextCursor($core.String v) {
-    $_setString(2, v);
-  }
-
+  set nextCursor($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasNextCursor() => $_has(2);
   @$pb.TagNumber(3)
-  void clearNextCursor() => clearField(3);
+  void clearNextCursor() => $_clearField(3);
 
+  /// The cursor to send when retrieving the previous page (optional).
   @$pb.TagNumber(4)
   $core.String get prevCursor => $_getSZ(3);
   @$pb.TagNumber(4)
-  set prevCursor($core.String v) {
-    $_setString(3, v);
-  }
-
+  set prevCursor($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasPrevCursor() => $_has(3);
   @$pb.TagNumber(4)
-  void clearPrevCursor() => clearField(4);
+  void clearPrevCursor() => $_clearField(4);
+
+  /// The total number of ranks available.
+  @$pb.TagNumber(5)
+  $fixnum.Int64 get rankCount => $_getI64(4);
+  @$pb.TagNumber(5)
+  set rankCount($fixnum.Int64 value) => $_setInt64(4, value);
+  @$pb.TagNumber(5)
+  $core.bool hasRankCount() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearRankCount() => $_clearField(5);
 }
 
+/// Update a user's account details.
 class UpdateAccountRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UpdateAccountRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<$1.StringValue>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.StringValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'displayName',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.StringValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'avatarUrl',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.StringValue>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'langTag',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.StringValue>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'location',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.StringValue>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'timezone',
-        subBuilder: $1.StringValue.create)
-    ..hasRequiredFields = false;
-
-  UpdateAccountRequest._() : super();
   factory UpdateAccountRequest({
     $1.StringValue? username,
     $1.StringValue? displayName,
@@ -10757,47 +8654,56 @@ class UpdateAccountRequest extends $pb.GeneratedMessage {
     $1.StringValue? location,
     $1.StringValue? timezone,
   }) {
-    final _result = create();
-    if (username != null) {
-      _result.username = username;
-    }
-    if (displayName != null) {
-      _result.displayName = displayName;
-    }
-    if (avatarUrl != null) {
-      _result.avatarUrl = avatarUrl;
-    }
-    if (langTag != null) {
-      _result.langTag = langTag;
-    }
-    if (location != null) {
-      _result.location = location;
-    }
-    if (timezone != null) {
-      _result.timezone = timezone;
-    }
-    return _result;
+    final result = create();
+    if (username != null) result.username = username;
+    if (displayName != null) result.displayName = displayName;
+    if (avatarUrl != null) result.avatarUrl = avatarUrl;
+    if (langTag != null) result.langTag = langTag;
+    if (location != null) result.location = location;
+    if (timezone != null) result.timezone = timezone;
+    return result;
   }
-  factory UpdateAccountRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UpdateAccountRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  UpdateAccountRequest clone() =>
-      UpdateAccountRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  UpdateAccountRequest._();
+
+  factory UpdateAccountRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UpdateAccountRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UpdateAccountRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<$1.StringValue>(1, _omitFieldNames ? '' : 'username',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(2, _omitFieldNames ? '' : 'displayName',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(3, _omitFieldNames ? '' : 'avatarUrl',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(4, _omitFieldNames ? '' : 'langTag',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(5, _omitFieldNames ? '' : 'location',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(6, _omitFieldNames ? '' : 'timezone',
+        subBuilder: $1.StringValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UpdateAccountRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UpdateAccountRequest copyWith(void Function(UpdateAccountRequest) updates) =>
       super.copyWith((message) => updates(message as UpdateAccountRequest))
-          as UpdateAccountRequest; // ignore: deprecated_member_use
+          as UpdateAccountRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UpdateAccountRequest create() => UpdateAccountRequest._();
+  @$core.override
   UpdateAccountRequest createEmptyInstance() => create();
   static $pb.PbList<UpdateAccountRequest> createRepeated() =>
       $pb.PbList<UpdateAccountRequest>();
@@ -10806,139 +8712,81 @@ class UpdateAccountRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<UpdateAccountRequest>(create);
   static UpdateAccountRequest? _defaultInstance;
 
+  /// The username of the user's account.
   @$pb.TagNumber(1)
   $1.StringValue get username => $_getN(0);
   @$pb.TagNumber(1)
-  set username($1.StringValue v) {
-    setField(1, v);
-  }
-
+  set username($1.StringValue value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasUsername() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUsername() => clearField(1);
+  void clearUsername() => $_clearField(1);
   @$pb.TagNumber(1)
   $1.StringValue ensureUsername() => $_ensure(0);
 
+  /// The display name of the user.
   @$pb.TagNumber(2)
   $1.StringValue get displayName => $_getN(1);
   @$pb.TagNumber(2)
-  set displayName($1.StringValue v) {
-    setField(2, v);
-  }
-
+  set displayName($1.StringValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasDisplayName() => $_has(1);
   @$pb.TagNumber(2)
-  void clearDisplayName() => clearField(2);
+  void clearDisplayName() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.StringValue ensureDisplayName() => $_ensure(1);
 
+  /// A URL for an avatar image.
   @$pb.TagNumber(3)
   $1.StringValue get avatarUrl => $_getN(2);
   @$pb.TagNumber(3)
-  set avatarUrl($1.StringValue v) {
-    setField(3, v);
-  }
-
+  set avatarUrl($1.StringValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasAvatarUrl() => $_has(2);
   @$pb.TagNumber(3)
-  void clearAvatarUrl() => clearField(3);
+  void clearAvatarUrl() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.StringValue ensureAvatarUrl() => $_ensure(2);
 
+  /// The language expected to be a tag which follows the BCP-47 spec.
   @$pb.TagNumber(4)
   $1.StringValue get langTag => $_getN(3);
   @$pb.TagNumber(4)
-  set langTag($1.StringValue v) {
-    setField(4, v);
-  }
-
+  set langTag($1.StringValue value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasLangTag() => $_has(3);
   @$pb.TagNumber(4)
-  void clearLangTag() => clearField(4);
+  void clearLangTag() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.StringValue ensureLangTag() => $_ensure(3);
 
+  /// The location set by the user.
   @$pb.TagNumber(5)
   $1.StringValue get location => $_getN(4);
   @$pb.TagNumber(5)
-  set location($1.StringValue v) {
-    setField(5, v);
-  }
-
+  set location($1.StringValue value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasLocation() => $_has(4);
   @$pb.TagNumber(5)
-  void clearLocation() => clearField(5);
+  void clearLocation() => $_clearField(5);
   @$pb.TagNumber(5)
   $1.StringValue ensureLocation() => $_ensure(4);
 
+  /// The timezone set by the user.
   @$pb.TagNumber(6)
   $1.StringValue get timezone => $_getN(5);
   @$pb.TagNumber(6)
-  set timezone($1.StringValue v) {
-    setField(6, v);
-  }
-
+  set timezone($1.StringValue value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasTimezone() => $_has(5);
   @$pb.TagNumber(6)
-  void clearTimezone() => clearField(6);
+  void clearTimezone() => $_clearField(6);
   @$pb.TagNumber(6)
   $1.StringValue ensureTimezone() => $_ensure(5);
 }
 
+/// Update fields in a given group.
 class UpdateGroupRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UpdateGroupRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..aOM<$1.StringValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.StringValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'description',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.StringValue>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'langTag',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.StringValue>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'avatarUrl',
-        subBuilder: $1.StringValue.create)
-    ..aOM<$1.BoolValue>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'open',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  UpdateGroupRequest._() : super();
   factory UpdateGroupRequest({
     $core.String? groupId,
     $1.StringValue? name,
@@ -10947,46 +8795,55 @@ class UpdateGroupRequest extends $pb.GeneratedMessage {
     $1.StringValue? avatarUrl,
     $1.BoolValue? open,
   }) {
-    final _result = create();
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (name != null) {
-      _result.name = name;
-    }
-    if (description != null) {
-      _result.description = description;
-    }
-    if (langTag != null) {
-      _result.langTag = langTag;
-    }
-    if (avatarUrl != null) {
-      _result.avatarUrl = avatarUrl;
-    }
-    if (open != null) {
-      _result.open = open;
-    }
-    return _result;
+    final result = create();
+    if (groupId != null) result.groupId = groupId;
+    if (name != null) result.name = name;
+    if (description != null) result.description = description;
+    if (langTag != null) result.langTag = langTag;
+    if (avatarUrl != null) result.avatarUrl = avatarUrl;
+    if (open != null) result.open = open;
+    return result;
   }
-  factory UpdateGroupRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UpdateGroupRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  UpdateGroupRequest clone() => UpdateGroupRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  UpdateGroupRequest._();
+
+  factory UpdateGroupRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UpdateGroupRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UpdateGroupRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'groupId')
+    ..aOM<$1.StringValue>(2, _omitFieldNames ? '' : 'name',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(3, _omitFieldNames ? '' : 'description',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(4, _omitFieldNames ? '' : 'langTag',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(5, _omitFieldNames ? '' : 'avatarUrl',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.BoolValue>(6, _omitFieldNames ? '' : 'open',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UpdateGroupRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UpdateGroupRequest copyWith(void Function(UpdateGroupRequest) updates) =>
       super.copyWith((message) => updates(message as UpdateGroupRequest))
-          as UpdateGroupRequest; // ignore: deprecated_member_use
+          as UpdateGroupRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UpdateGroupRequest create() => UpdateGroupRequest._();
+  @$core.override
   UpdateGroupRequest createEmptyInstance() => create();
   static $pb.PbList<UpdateGroupRequest> createRepeated() =>
       $pb.PbList<UpdateGroupRequest>();
@@ -10995,195 +8852,79 @@ class UpdateGroupRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<UpdateGroupRequest>(create);
   static UpdateGroupRequest? _defaultInstance;
 
+  /// The ID of the group to update.
   @$pb.TagNumber(1)
   $core.String get groupId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set groupId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set groupId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasGroupId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroupId() => clearField(1);
+  void clearGroupId() => $_clearField(1);
 
+  /// Name.
   @$pb.TagNumber(2)
   $1.StringValue get name => $_getN(1);
   @$pb.TagNumber(2)
-  set name($1.StringValue v) {
-    setField(2, v);
-  }
-
+  set name($1.StringValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasName() => $_has(1);
   @$pb.TagNumber(2)
-  void clearName() => clearField(2);
+  void clearName() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.StringValue ensureName() => $_ensure(1);
 
+  /// Description string.
   @$pb.TagNumber(3)
   $1.StringValue get description => $_getN(2);
   @$pb.TagNumber(3)
-  set description($1.StringValue v) {
-    setField(3, v);
-  }
-
+  set description($1.StringValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasDescription() => $_has(2);
   @$pb.TagNumber(3)
-  void clearDescription() => clearField(3);
+  void clearDescription() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.StringValue ensureDescription() => $_ensure(2);
 
+  /// Lang tag.
   @$pb.TagNumber(4)
   $1.StringValue get langTag => $_getN(3);
   @$pb.TagNumber(4)
-  set langTag($1.StringValue v) {
-    setField(4, v);
-  }
-
+  set langTag($1.StringValue value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasLangTag() => $_has(3);
   @$pb.TagNumber(4)
-  void clearLangTag() => clearField(4);
+  void clearLangTag() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.StringValue ensureLangTag() => $_ensure(3);
 
+  /// Avatar URL.
   @$pb.TagNumber(5)
   $1.StringValue get avatarUrl => $_getN(4);
   @$pb.TagNumber(5)
-  set avatarUrl($1.StringValue v) {
-    setField(5, v);
-  }
-
+  set avatarUrl($1.StringValue value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasAvatarUrl() => $_has(4);
   @$pb.TagNumber(5)
-  void clearAvatarUrl() => clearField(5);
+  void clearAvatarUrl() => $_clearField(5);
   @$pb.TagNumber(5)
   $1.StringValue ensureAvatarUrl() => $_ensure(4);
 
+  /// Open is true if anyone should be allowed to join, or false if joins must be approved by a group admin.
   @$pb.TagNumber(6)
   $1.BoolValue get open => $_getN(5);
   @$pb.TagNumber(6)
-  set open($1.BoolValue v) {
-    setField(6, v);
-  }
-
+  set open($1.BoolValue value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasOpen() => $_has(5);
   @$pb.TagNumber(6)
-  void clearOpen() => clearField(6);
+  void clearOpen() => $_clearField(6);
   @$pb.TagNumber(6)
   $1.BoolValue ensureOpen() => $_ensure(5);
 }
 
+/// A user in the server.
 class User extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'User',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'displayName')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'avatarUrl')
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'langTag')
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'location')
-    ..aOS(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'timezone')
-    ..aOS(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'metadata')
-    ..aOS(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'facebookId')
-    ..aOS(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'googleId')
-    ..aOS(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'gamecenterId')
-    ..aOS(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'steamId')
-    ..aOB(
-        13,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'online')
-    ..a<$core.int>(
-        14,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'edgeCount',
-        $pb.PbFieldType.O3)
-    ..aOM<$0.Timestamp>(
-        15,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        16,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOS(
-        17,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'facebookInstantGameId')
-    ..aOS(
-        18,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'appleId')
-    ..hasRequiredFields = false;
-
-  User._() : super();
   factory User({
     $core.String? id,
     $core.String? username,
@@ -11204,82 +8945,76 @@ class User extends $pb.GeneratedMessage {
     $core.String? facebookInstantGameId,
     $core.String? appleId,
   }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    if (displayName != null) {
-      _result.displayName = displayName;
-    }
-    if (avatarUrl != null) {
-      _result.avatarUrl = avatarUrl;
-    }
-    if (langTag != null) {
-      _result.langTag = langTag;
-    }
-    if (location != null) {
-      _result.location = location;
-    }
-    if (timezone != null) {
-      _result.timezone = timezone;
-    }
-    if (metadata != null) {
-      _result.metadata = metadata;
-    }
-    if (facebookId != null) {
-      _result.facebookId = facebookId;
-    }
-    if (googleId != null) {
-      _result.googleId = googleId;
-    }
-    if (gamecenterId != null) {
-      _result.gamecenterId = gamecenterId;
-    }
-    if (steamId != null) {
-      _result.steamId = steamId;
-    }
-    if (online != null) {
-      _result.online = online;
-    }
-    if (edgeCount != null) {
-      _result.edgeCount = edgeCount;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    if (facebookInstantGameId != null) {
-      _result.facebookInstantGameId = facebookInstantGameId;
-    }
-    if (appleId != null) {
-      _result.appleId = appleId;
-    }
-    return _result;
+    final result = create();
+    if (id != null) result.id = id;
+    if (username != null) result.username = username;
+    if (displayName != null) result.displayName = displayName;
+    if (avatarUrl != null) result.avatarUrl = avatarUrl;
+    if (langTag != null) result.langTag = langTag;
+    if (location != null) result.location = location;
+    if (timezone != null) result.timezone = timezone;
+    if (metadata != null) result.metadata = metadata;
+    if (facebookId != null) result.facebookId = facebookId;
+    if (googleId != null) result.googleId = googleId;
+    if (gamecenterId != null) result.gamecenterId = gamecenterId;
+    if (steamId != null) result.steamId = steamId;
+    if (online != null) result.online = online;
+    if (edgeCount != null) result.edgeCount = edgeCount;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    if (facebookInstantGameId != null)
+      result.facebookInstantGameId = facebookInstantGameId;
+    if (appleId != null) result.appleId = appleId;
+    return result;
   }
-  factory User.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory User.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  User clone() => User()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  User._();
+
+  factory User.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory User.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'User',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..aOS(2, _omitFieldNames ? '' : 'username')
+    ..aOS(3, _omitFieldNames ? '' : 'displayName')
+    ..aOS(4, _omitFieldNames ? '' : 'avatarUrl')
+    ..aOS(5, _omitFieldNames ? '' : 'langTag')
+    ..aOS(6, _omitFieldNames ? '' : 'location')
+    ..aOS(7, _omitFieldNames ? '' : 'timezone')
+    ..aOS(8, _omitFieldNames ? '' : 'metadata')
+    ..aOS(9, _omitFieldNames ? '' : 'facebookId')
+    ..aOS(10, _omitFieldNames ? '' : 'googleId')
+    ..aOS(11, _omitFieldNames ? '' : 'gamecenterId')
+    ..aOS(12, _omitFieldNames ? '' : 'steamId')
+    ..aOB(13, _omitFieldNames ? '' : 'online')
+    ..aI(14, _omitFieldNames ? '' : 'edgeCount')
+    ..aOM<$0.Timestamp>(15, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(16, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOS(17, _omitFieldNames ? '' : 'facebookInstantGameId')
+    ..aOS(18, _omitFieldNames ? '' : 'appleId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  User clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   User copyWith(void Function(User) updates) =>
-      super.copyWith((message) => updates(message as User))
-          as User; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as User)) as User;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static User create() => User._();
+  @$core.override
   User createEmptyInstance() => create();
   static $pb.PbList<User> createRepeated() => $pb.PbList<User>();
   @$core.pragma('dart2js:noInline')
@@ -11287,286 +9022,235 @@ class User extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<User>(create);
   static User? _defaultInstance;
 
+  /// The id of the user's account.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// The username of the user's account.
   @$pb.TagNumber(2)
   $core.String get username => $_getSZ(1);
   @$pb.TagNumber(2)
-  set username($core.String v) {
-    $_setString(1, v);
-  }
-
+  set username($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasUsername() => $_has(1);
   @$pb.TagNumber(2)
-  void clearUsername() => clearField(2);
+  void clearUsername() => $_clearField(2);
 
+  /// The display name of the user.
   @$pb.TagNumber(3)
   $core.String get displayName => $_getSZ(2);
   @$pb.TagNumber(3)
-  set displayName($core.String v) {
-    $_setString(2, v);
-  }
-
+  set displayName($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasDisplayName() => $_has(2);
   @$pb.TagNumber(3)
-  void clearDisplayName() => clearField(3);
+  void clearDisplayName() => $_clearField(3);
 
+  /// A URL for an avatar image.
   @$pb.TagNumber(4)
   $core.String get avatarUrl => $_getSZ(3);
   @$pb.TagNumber(4)
-  set avatarUrl($core.String v) {
-    $_setString(3, v);
-  }
-
+  set avatarUrl($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasAvatarUrl() => $_has(3);
   @$pb.TagNumber(4)
-  void clearAvatarUrl() => clearField(4);
+  void clearAvatarUrl() => $_clearField(4);
 
+  /// The language expected to be a tag which follows the BCP-47 spec.
   @$pb.TagNumber(5)
   $core.String get langTag => $_getSZ(4);
   @$pb.TagNumber(5)
-  set langTag($core.String v) {
-    $_setString(4, v);
-  }
-
+  set langTag($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasLangTag() => $_has(4);
   @$pb.TagNumber(5)
-  void clearLangTag() => clearField(5);
+  void clearLangTag() => $_clearField(5);
 
+  /// The location set by the user.
   @$pb.TagNumber(6)
   $core.String get location => $_getSZ(5);
   @$pb.TagNumber(6)
-  set location($core.String v) {
-    $_setString(5, v);
-  }
-
+  set location($core.String value) => $_setString(5, value);
   @$pb.TagNumber(6)
   $core.bool hasLocation() => $_has(5);
   @$pb.TagNumber(6)
-  void clearLocation() => clearField(6);
+  void clearLocation() => $_clearField(6);
 
+  /// The timezone set by the user.
   @$pb.TagNumber(7)
   $core.String get timezone => $_getSZ(6);
   @$pb.TagNumber(7)
-  set timezone($core.String v) {
-    $_setString(6, v);
-  }
-
+  set timezone($core.String value) => $_setString(6, value);
   @$pb.TagNumber(7)
   $core.bool hasTimezone() => $_has(6);
   @$pb.TagNumber(7)
-  void clearTimezone() => clearField(7);
+  void clearTimezone() => $_clearField(7);
 
+  /// Additional information stored as a JSON object.
   @$pb.TagNumber(8)
   $core.String get metadata => $_getSZ(7);
   @$pb.TagNumber(8)
-  set metadata($core.String v) {
-    $_setString(7, v);
-  }
-
+  set metadata($core.String value) => $_setString(7, value);
   @$pb.TagNumber(8)
   $core.bool hasMetadata() => $_has(7);
   @$pb.TagNumber(8)
-  void clearMetadata() => clearField(8);
+  void clearMetadata() => $_clearField(8);
 
+  /// The Facebook id in the user's account.
   @$pb.TagNumber(9)
   $core.String get facebookId => $_getSZ(8);
   @$pb.TagNumber(9)
-  set facebookId($core.String v) {
-    $_setString(8, v);
-  }
-
+  set facebookId($core.String value) => $_setString(8, value);
   @$pb.TagNumber(9)
   $core.bool hasFacebookId() => $_has(8);
   @$pb.TagNumber(9)
-  void clearFacebookId() => clearField(9);
+  void clearFacebookId() => $_clearField(9);
 
+  /// The Google id in the user's account.
   @$pb.TagNumber(10)
   $core.String get googleId => $_getSZ(9);
   @$pb.TagNumber(10)
-  set googleId($core.String v) {
-    $_setString(9, v);
-  }
-
+  set googleId($core.String value) => $_setString(9, value);
   @$pb.TagNumber(10)
   $core.bool hasGoogleId() => $_has(9);
   @$pb.TagNumber(10)
-  void clearGoogleId() => clearField(10);
+  void clearGoogleId() => $_clearField(10);
 
+  /// The Apple Game Center in of the user's account.
   @$pb.TagNumber(11)
   $core.String get gamecenterId => $_getSZ(10);
   @$pb.TagNumber(11)
-  set gamecenterId($core.String v) {
-    $_setString(10, v);
-  }
-
+  set gamecenterId($core.String value) => $_setString(10, value);
   @$pb.TagNumber(11)
   $core.bool hasGamecenterId() => $_has(10);
   @$pb.TagNumber(11)
-  void clearGamecenterId() => clearField(11);
+  void clearGamecenterId() => $_clearField(11);
 
+  /// The Steam id in the user's account.
   @$pb.TagNumber(12)
   $core.String get steamId => $_getSZ(11);
   @$pb.TagNumber(12)
-  set steamId($core.String v) {
-    $_setString(11, v);
-  }
-
+  set steamId($core.String value) => $_setString(11, value);
   @$pb.TagNumber(12)
   $core.bool hasSteamId() => $_has(11);
   @$pb.TagNumber(12)
-  void clearSteamId() => clearField(12);
+  void clearSteamId() => $_clearField(12);
 
+  /// Indicates whether the user is currently online.
   @$pb.TagNumber(13)
   $core.bool get online => $_getBF(12);
   @$pb.TagNumber(13)
-  set online($core.bool v) {
-    $_setBool(12, v);
-  }
-
+  set online($core.bool value) => $_setBool(12, value);
   @$pb.TagNumber(13)
   $core.bool hasOnline() => $_has(12);
   @$pb.TagNumber(13)
-  void clearOnline() => clearField(13);
+  void clearOnline() => $_clearField(13);
 
+  /// Number of related edges to this user.
   @$pb.TagNumber(14)
   $core.int get edgeCount => $_getIZ(13);
   @$pb.TagNumber(14)
-  set edgeCount($core.int v) {
-    $_setSignedInt32(13, v);
-  }
-
+  set edgeCount($core.int value) => $_setSignedInt32(13, value);
   @$pb.TagNumber(14)
   $core.bool hasEdgeCount() => $_has(13);
   @$pb.TagNumber(14)
-  void clearEdgeCount() => clearField(14);
+  void clearEdgeCount() => $_clearField(14);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the user was created.
   @$pb.TagNumber(15)
   $0.Timestamp get createTime => $_getN(14);
   @$pb.TagNumber(15)
-  set createTime($0.Timestamp v) {
-    setField(15, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(15, value);
   @$pb.TagNumber(15)
   $core.bool hasCreateTime() => $_has(14);
   @$pb.TagNumber(15)
-  void clearCreateTime() => clearField(15);
+  void clearCreateTime() => $_clearField(15);
   @$pb.TagNumber(15)
   $0.Timestamp ensureCreateTime() => $_ensure(14);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the user was last updated.
   @$pb.TagNumber(16)
   $0.Timestamp get updateTime => $_getN(15);
   @$pb.TagNumber(16)
-  set updateTime($0.Timestamp v) {
-    setField(16, v);
-  }
-
+  set updateTime($0.Timestamp value) => $_setField(16, value);
   @$pb.TagNumber(16)
   $core.bool hasUpdateTime() => $_has(15);
   @$pb.TagNumber(16)
-  void clearUpdateTime() => clearField(16);
+  void clearUpdateTime() => $_clearField(16);
   @$pb.TagNumber(16)
   $0.Timestamp ensureUpdateTime() => $_ensure(15);
 
+  /// The Facebook Instant Game ID in the user's account.
   @$pb.TagNumber(17)
   $core.String get facebookInstantGameId => $_getSZ(16);
   @$pb.TagNumber(17)
-  set facebookInstantGameId($core.String v) {
-    $_setString(16, v);
-  }
-
+  set facebookInstantGameId($core.String value) => $_setString(16, value);
   @$pb.TagNumber(17)
   $core.bool hasFacebookInstantGameId() => $_has(16);
   @$pb.TagNumber(17)
-  void clearFacebookInstantGameId() => clearField(17);
+  void clearFacebookInstantGameId() => $_clearField(17);
 
+  /// The Apple Sign In ID in the user's account.
   @$pb.TagNumber(18)
   $core.String get appleId => $_getSZ(17);
   @$pb.TagNumber(18)
-  set appleId($core.String v) {
-    $_setString(17, v);
-  }
-
+  set appleId($core.String value) => $_setString(17, value);
   @$pb.TagNumber(18)
   $core.bool hasAppleId() => $_has(17);
   @$pb.TagNumber(18)
-  void clearAppleId() => clearField(18);
+  void clearAppleId() => $_clearField(18);
 }
 
+/// A single group-role pair.
 class UserGroupList_UserGroup extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UserGroupList.UserGroup',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<Group>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'group',
-        subBuilder: Group.create)
-    ..aOM<$1.Int32Value>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'state',
-        subBuilder: $1.Int32Value.create)
-    ..hasRequiredFields = false;
-
-  UserGroupList_UserGroup._() : super();
   factory UserGroupList_UserGroup({
     Group? group,
     $1.Int32Value? state,
   }) {
-    final _result = create();
-    if (group != null) {
-      _result.group = group;
-    }
-    if (state != null) {
-      _result.state = state;
-    }
-    return _result;
+    final result = create();
+    if (group != null) result.group = group;
+    if (state != null) result.state = state;
+    return result;
   }
-  factory UserGroupList_UserGroup.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UserGroupList_UserGroup.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  UserGroupList_UserGroup clone() =>
-      UserGroupList_UserGroup()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  UserGroupList_UserGroup._();
+
+  factory UserGroupList_UserGroup.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UserGroupList_UserGroup.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UserGroupList.UserGroup',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<Group>(1, _omitFieldNames ? '' : 'group', subBuilder: Group.create)
+    ..aOM<$1.Int32Value>(2, _omitFieldNames ? '' : 'state',
+        subBuilder: $1.Int32Value.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UserGroupList_UserGroup clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UserGroupList_UserGroup copyWith(
           void Function(UserGroupList_UserGroup) updates) =>
       super.copyWith((message) => updates(message as UserGroupList_UserGroup))
-          as UserGroupList_UserGroup; // ignore: deprecated_member_use
+          as UserGroupList_UserGroup;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UserGroupList_UserGroup create() => UserGroupList_UserGroup._();
+  @$core.override
   UserGroupList_UserGroup createEmptyInstance() => create();
   static $pb.PbList<UserGroupList_UserGroup> createRepeated() =>
       $pb.PbList<UserGroupList_UserGroup>();
@@ -11575,92 +9259,74 @@ class UserGroupList_UserGroup extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<UserGroupList_UserGroup>(create);
   static UserGroupList_UserGroup? _defaultInstance;
 
+  /// Group.
   @$pb.TagNumber(1)
   Group get group => $_getN(0);
   @$pb.TagNumber(1)
-  set group(Group v) {
-    setField(1, v);
-  }
-
+  set group(Group value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasGroup() => $_has(0);
   @$pb.TagNumber(1)
-  void clearGroup() => clearField(1);
+  void clearGroup() => $_clearField(1);
   @$pb.TagNumber(1)
   Group ensureGroup() => $_ensure(0);
 
+  /// The user's relationship to the group.
   @$pb.TagNumber(2)
   $1.Int32Value get state => $_getN(1);
   @$pb.TagNumber(2)
-  set state($1.Int32Value v) {
-    setField(2, v);
-  }
-
+  set state($1.Int32Value value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasState() => $_has(1);
   @$pb.TagNumber(2)
-  void clearState() => clearField(2);
+  void clearState() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.Int32Value ensureState() => $_ensure(1);
 }
 
+/// A list of groups belonging to a user, along with the user's role in each group.
 class UserGroupList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UserGroupList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<UserGroupList_UserGroup>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userGroups',
-        $pb.PbFieldType.PM,
-        subBuilder: UserGroupList_UserGroup.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..hasRequiredFields = false;
-
-  UserGroupList._() : super();
   factory UserGroupList({
     $core.Iterable<UserGroupList_UserGroup>? userGroups,
     $core.String? cursor,
   }) {
-    final _result = create();
-    if (userGroups != null) {
-      _result.userGroups.addAll(userGroups);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    return _result;
+    final result = create();
+    if (userGroups != null) result.userGroups.addAll(userGroups);
+    if (cursor != null) result.cursor = cursor;
+    return result;
   }
-  factory UserGroupList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UserGroupList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  UserGroupList clone() => UserGroupList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  UserGroupList._();
+
+  factory UserGroupList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UserGroupList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UserGroupList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<UserGroupList_UserGroup>(1, _omitFieldNames ? '' : 'userGroups',
+        subBuilder: UserGroupList_UserGroup.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UserGroupList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UserGroupList copyWith(void Function(UserGroupList) updates) =>
       super.copyWith((message) => updates(message as UserGroupList))
-          as UserGroupList; // ignore: deprecated_member_use
+          as UserGroupList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UserGroupList create() => UserGroupList._();
+  @$core.override
   UserGroupList createEmptyInstance() => create();
   static $pb.PbList<UserGroupList> createRepeated() =>
       $pb.PbList<UserGroupList>();
@@ -11669,70 +9335,59 @@ class UserGroupList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<UserGroupList>(create);
   static UserGroupList? _defaultInstance;
 
+  /// Group-role pairs for a user.
   @$pb.TagNumber(1)
-  $core.List<UserGroupList_UserGroup> get userGroups => $_getList(0);
+  $pb.PbList<UserGroupList_UserGroup> get userGroups => $_getList(0);
 
+  /// Cursor for the next page of results, if any.
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 }
 
+/// A collection of zero or more users.
 class Users extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Users',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<User>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'users',
-        $pb.PbFieldType.PM,
-        subBuilder: User.create)
-    ..hasRequiredFields = false;
-
-  Users._() : super();
   factory Users({
     $core.Iterable<User>? users,
   }) {
-    final _result = create();
-    if (users != null) {
-      _result.users.addAll(users);
-    }
-    return _result;
+    final result = create();
+    if (users != null) result.users.addAll(users);
+    return result;
   }
-  factory Users.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Users.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Users clone() => Users()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Users._();
+
+  factory Users.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Users.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Users',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<User>(1, _omitFieldNames ? '' : 'users', subBuilder: User.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Users clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Users copyWith(void Function(Users) updates) =>
-      super.copyWith((message) => updates(message as Users))
-          as Users; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Users)) as Users;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Users create() => Users._();
+  @$core.override
   Users createEmptyInstance() => create();
   static $pb.PbList<Users> createRepeated() => $pb.PbList<Users>();
   @$core.pragma('dart2js:noInline')
@@ -11740,70 +9395,57 @@ class Users extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Users>(create);
   static Users? _defaultInstance;
 
+  /// The User objects.
   @$pb.TagNumber(1)
-  $core.List<User> get users => $_getList(0);
+  $pb.PbList<User> get users => $_getList(0);
 }
 
+/// Apple IAP Purchases validation request
 class ValidatePurchaseAppleRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidatePurchaseAppleRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'receipt')
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persist',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  ValidatePurchaseAppleRequest._() : super();
   factory ValidatePurchaseAppleRequest({
     $core.String? receipt,
     $1.BoolValue? persist,
   }) {
-    final _result = create();
-    if (receipt != null) {
-      _result.receipt = receipt;
-    }
-    if (persist != null) {
-      _result.persist = persist;
-    }
-    return _result;
+    final result = create();
+    if (receipt != null) result.receipt = receipt;
+    if (persist != null) result.persist = persist;
+    return result;
   }
-  factory ValidatePurchaseAppleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidatePurchaseAppleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidatePurchaseAppleRequest clone() =>
-      ValidatePurchaseAppleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidatePurchaseAppleRequest._();
+
+  factory ValidatePurchaseAppleRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidatePurchaseAppleRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidatePurchaseAppleRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'receipt')
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'persist',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatePurchaseAppleRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidatePurchaseAppleRequest copyWith(
           void Function(ValidatePurchaseAppleRequest) updates) =>
       super.copyWith(
               (message) => updates(message as ValidatePurchaseAppleRequest))
-          as ValidatePurchaseAppleRequest; // ignore: deprecated_member_use
+          as ValidatePurchaseAppleRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseAppleRequest create() =>
       ValidatePurchaseAppleRequest._();
+  @$core.override
   ValidatePurchaseAppleRequest createEmptyInstance() => create();
   static $pb.PbList<ValidatePurchaseAppleRequest> createRepeated() =>
       $pb.PbList<ValidatePurchaseAppleRequest>();
@@ -11812,93 +9454,76 @@ class ValidatePurchaseAppleRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseAppleRequest>(create);
   static ValidatePurchaseAppleRequest? _defaultInstance;
 
+  /// Base64 encoded Apple receipt data payload.
   @$pb.TagNumber(1)
   $core.String get receipt => $_getSZ(0);
   @$pb.TagNumber(1)
-  set receipt($core.String v) {
-    $_setString(0, v);
-  }
-
+  set receipt($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasReceipt() => $_has(0);
   @$pb.TagNumber(1)
-  void clearReceipt() => clearField(1);
+  void clearReceipt() => $_clearField(1);
 
+  /// Persist the purchase
   @$pb.TagNumber(2)
   $1.BoolValue get persist => $_getN(1);
   @$pb.TagNumber(2)
-  set persist($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set persist($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPersist() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPersist() => clearField(2);
+  void clearPersist() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensurePersist() => $_ensure(1);
 }
 
+/// Apple Subscription validation request
 class ValidateSubscriptionAppleRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidateSubscriptionAppleRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'receipt')
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persist',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  ValidateSubscriptionAppleRequest._() : super();
   factory ValidateSubscriptionAppleRequest({
     $core.String? receipt,
     $1.BoolValue? persist,
   }) {
-    final _result = create();
-    if (receipt != null) {
-      _result.receipt = receipt;
-    }
-    if (persist != null) {
-      _result.persist = persist;
-    }
-    return _result;
+    final result = create();
+    if (receipt != null) result.receipt = receipt;
+    if (persist != null) result.persist = persist;
+    return result;
   }
-  factory ValidateSubscriptionAppleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidateSubscriptionAppleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidateSubscriptionAppleRequest clone() =>
-      ValidateSubscriptionAppleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidateSubscriptionAppleRequest._();
+
+  factory ValidateSubscriptionAppleRequest.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidateSubscriptionAppleRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidateSubscriptionAppleRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'receipt')
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'persist',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidateSubscriptionAppleRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidateSubscriptionAppleRequest copyWith(
           void Function(ValidateSubscriptionAppleRequest) updates) =>
       super.copyWith(
               (message) => updates(message as ValidateSubscriptionAppleRequest))
-          as ValidateSubscriptionAppleRequest; // ignore: deprecated_member_use
+          as ValidateSubscriptionAppleRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidateSubscriptionAppleRequest create() =>
       ValidateSubscriptionAppleRequest._();
+  @$core.override
   ValidateSubscriptionAppleRequest createEmptyInstance() => create();
   static $pb.PbList<ValidateSubscriptionAppleRequest> createRepeated() =>
       $pb.PbList<ValidateSubscriptionAppleRequest>();
@@ -11908,93 +9533,75 @@ class ValidateSubscriptionAppleRequest extends $pb.GeneratedMessage {
           create);
   static ValidateSubscriptionAppleRequest? _defaultInstance;
 
+  /// Base64 encoded Apple receipt data payload.
   @$pb.TagNumber(1)
   $core.String get receipt => $_getSZ(0);
   @$pb.TagNumber(1)
-  set receipt($core.String v) {
-    $_setString(0, v);
-  }
-
+  set receipt($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasReceipt() => $_has(0);
   @$pb.TagNumber(1)
-  void clearReceipt() => clearField(1);
+  void clearReceipt() => $_clearField(1);
 
+  /// Persist the subscription.
   @$pb.TagNumber(2)
   $1.BoolValue get persist => $_getN(1);
   @$pb.TagNumber(2)
-  set persist($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set persist($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPersist() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPersist() => clearField(2);
+  void clearPersist() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensurePersist() => $_ensure(1);
 }
 
+/// Google IAP Purchase validation request
 class ValidatePurchaseGoogleRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidatePurchaseGoogleRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'purchase')
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persist',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  ValidatePurchaseGoogleRequest._() : super();
   factory ValidatePurchaseGoogleRequest({
     $core.String? purchase,
     $1.BoolValue? persist,
   }) {
-    final _result = create();
-    if (purchase != null) {
-      _result.purchase = purchase;
-    }
-    if (persist != null) {
-      _result.persist = persist;
-    }
-    return _result;
+    final result = create();
+    if (purchase != null) result.purchase = purchase;
+    if (persist != null) result.persist = persist;
+    return result;
   }
-  factory ValidatePurchaseGoogleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidatePurchaseGoogleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidatePurchaseGoogleRequest clone() =>
-      ValidatePurchaseGoogleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidatePurchaseGoogleRequest._();
+
+  factory ValidatePurchaseGoogleRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidatePurchaseGoogleRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidatePurchaseGoogleRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'purchase')
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'persist',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatePurchaseGoogleRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidatePurchaseGoogleRequest copyWith(
           void Function(ValidatePurchaseGoogleRequest) updates) =>
       super.copyWith(
               (message) => updates(message as ValidatePurchaseGoogleRequest))
-          as ValidatePurchaseGoogleRequest; // ignore: deprecated_member_use
+          as ValidatePurchaseGoogleRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseGoogleRequest create() =>
       ValidatePurchaseGoogleRequest._();
+  @$core.override
   ValidatePurchaseGoogleRequest createEmptyInstance() => create();
   static $pb.PbList<ValidatePurchaseGoogleRequest> createRepeated() =>
       $pb.PbList<ValidatePurchaseGoogleRequest>();
@@ -12003,93 +9610,76 @@ class ValidatePurchaseGoogleRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseGoogleRequest>(create);
   static ValidatePurchaseGoogleRequest? _defaultInstance;
 
+  /// JSON encoded Google purchase payload.
   @$pb.TagNumber(1)
   $core.String get purchase => $_getSZ(0);
   @$pb.TagNumber(1)
-  set purchase($core.String v) {
-    $_setString(0, v);
-  }
-
+  set purchase($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPurchase() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPurchase() => clearField(1);
+  void clearPurchase() => $_clearField(1);
 
+  /// Persist the purchase
   @$pb.TagNumber(2)
   $1.BoolValue get persist => $_getN(1);
   @$pb.TagNumber(2)
-  set persist($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set persist($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPersist() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPersist() => clearField(2);
+  void clearPersist() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensurePersist() => $_ensure(1);
 }
 
+/// Google Subscription validation request
 class ValidateSubscriptionGoogleRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidateSubscriptionGoogleRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'receipt')
-    ..aOM<$1.BoolValue>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persist',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  ValidateSubscriptionGoogleRequest._() : super();
   factory ValidateSubscriptionGoogleRequest({
     $core.String? receipt,
     $1.BoolValue? persist,
   }) {
-    final _result = create();
-    if (receipt != null) {
-      _result.receipt = receipt;
-    }
-    if (persist != null) {
-      _result.persist = persist;
-    }
-    return _result;
+    final result = create();
+    if (receipt != null) result.receipt = receipt;
+    if (persist != null) result.persist = persist;
+    return result;
   }
-  factory ValidateSubscriptionGoogleRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidateSubscriptionGoogleRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidateSubscriptionGoogleRequest clone() =>
-      ValidateSubscriptionGoogleRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidateSubscriptionGoogleRequest._();
+
+  factory ValidateSubscriptionGoogleRequest.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidateSubscriptionGoogleRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidateSubscriptionGoogleRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'receipt')
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'persist',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidateSubscriptionGoogleRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidateSubscriptionGoogleRequest copyWith(
           void Function(ValidateSubscriptionGoogleRequest) updates) =>
       super.copyWith((message) =>
               updates(message as ValidateSubscriptionGoogleRequest))
-          as ValidateSubscriptionGoogleRequest; // ignore: deprecated_member_use
+          as ValidateSubscriptionGoogleRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidateSubscriptionGoogleRequest create() =>
       ValidateSubscriptionGoogleRequest._();
+  @$core.override
   ValidateSubscriptionGoogleRequest createEmptyInstance() => create();
   static $pb.PbList<ValidateSubscriptionGoogleRequest> createRepeated() =>
       $pb.PbList<ValidateSubscriptionGoogleRequest>();
@@ -12099,102 +9689,78 @@ class ValidateSubscriptionGoogleRequest extends $pb.GeneratedMessage {
           create);
   static ValidateSubscriptionGoogleRequest? _defaultInstance;
 
+  /// JSON encoded Google purchase payload.
   @$pb.TagNumber(1)
   $core.String get receipt => $_getSZ(0);
   @$pb.TagNumber(1)
-  set receipt($core.String v) {
-    $_setString(0, v);
-  }
-
+  set receipt($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasReceipt() => $_has(0);
   @$pb.TagNumber(1)
-  void clearReceipt() => clearField(1);
+  void clearReceipt() => $_clearField(1);
 
+  /// Persist the subscription.
   @$pb.TagNumber(2)
   $1.BoolValue get persist => $_getN(1);
   @$pb.TagNumber(2)
-  set persist($1.BoolValue v) {
-    setField(2, v);
-  }
-
+  set persist($1.BoolValue value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPersist() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPersist() => clearField(2);
+  void clearPersist() => $_clearField(2);
   @$pb.TagNumber(2)
   $1.BoolValue ensurePersist() => $_ensure(1);
 }
 
+/// Huawei IAP Purchase validation request
 class ValidatePurchaseHuaweiRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidatePurchaseHuaweiRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'purchase')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'signature')
-    ..aOM<$1.BoolValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persist',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  ValidatePurchaseHuaweiRequest._() : super();
   factory ValidatePurchaseHuaweiRequest({
     $core.String? purchase,
     $core.String? signature,
     $1.BoolValue? persist,
   }) {
-    final _result = create();
-    if (purchase != null) {
-      _result.purchase = purchase;
-    }
-    if (signature != null) {
-      _result.signature = signature;
-    }
-    if (persist != null) {
-      _result.persist = persist;
-    }
-    return _result;
+    final result = create();
+    if (purchase != null) result.purchase = purchase;
+    if (signature != null) result.signature = signature;
+    if (persist != null) result.persist = persist;
+    return result;
   }
-  factory ValidatePurchaseHuaweiRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidatePurchaseHuaweiRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidatePurchaseHuaweiRequest clone() =>
-      ValidatePurchaseHuaweiRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidatePurchaseHuaweiRequest._();
+
+  factory ValidatePurchaseHuaweiRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidatePurchaseHuaweiRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidatePurchaseHuaweiRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'purchase')
+    ..aOS(2, _omitFieldNames ? '' : 'signature')
+    ..aOM<$1.BoolValue>(3, _omitFieldNames ? '' : 'persist',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatePurchaseHuaweiRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidatePurchaseHuaweiRequest copyWith(
           void Function(ValidatePurchaseHuaweiRequest) updates) =>
       super.copyWith(
               (message) => updates(message as ValidatePurchaseHuaweiRequest))
-          as ValidatePurchaseHuaweiRequest; // ignore: deprecated_member_use
+          as ValidatePurchaseHuaweiRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseHuaweiRequest create() =>
       ValidatePurchaseHuaweiRequest._();
+  @$core.override
   ValidatePurchaseHuaweiRequest createEmptyInstance() => create();
   static $pb.PbList<ValidatePurchaseHuaweiRequest> createRepeated() =>
       $pb.PbList<ValidatePurchaseHuaweiRequest>();
@@ -12203,125 +9769,120 @@ class ValidatePurchaseHuaweiRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseHuaweiRequest>(create);
   static ValidatePurchaseHuaweiRequest? _defaultInstance;
 
+  /// JSON encoded Huawei InAppPurchaseData.
   @$pb.TagNumber(1)
   $core.String get purchase => $_getSZ(0);
   @$pb.TagNumber(1)
-  set purchase($core.String v) {
-    $_setString(0, v);
-  }
-
+  set purchase($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPurchase() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPurchase() => clearField(1);
+  void clearPurchase() => $_clearField(1);
 
+  /// InAppPurchaseData signature.
   @$pb.TagNumber(2)
   $core.String get signature => $_getSZ(1);
   @$pb.TagNumber(2)
-  set signature($core.String v) {
-    $_setString(1, v);
-  }
-
+  set signature($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasSignature() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSignature() => clearField(2);
+  void clearSignature() => $_clearField(2);
 
+  /// Persist the purchase
   @$pb.TagNumber(3)
   $1.BoolValue get persist => $_getN(2);
   @$pb.TagNumber(3)
-  set persist($1.BoolValue v) {
-    setField(3, v);
-  }
-
+  set persist($1.BoolValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasPersist() => $_has(2);
   @$pb.TagNumber(3)
-  void clearPersist() => clearField(3);
+  void clearPersist() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.BoolValue ensurePersist() => $_ensure(2);
 }
 
-class ValidatedPurchase extends $pb.GeneratedMessage {
+/// Facebook Instant IAP Purchase validation request
+class ValidatePurchaseFacebookInstantRequest extends $pb.GeneratedMessage {
+  factory ValidatePurchaseFacebookInstantRequest({
+    $core.String? signedRequest,
+    $1.BoolValue? persist,
+  }) {
+    final result = create();
+    if (signedRequest != null) result.signedRequest = signedRequest;
+    if (persist != null) result.persist = persist;
+    return result;
+  }
+
+  ValidatePurchaseFacebookInstantRequest._();
+
+  factory ValidatePurchaseFacebookInstantRequest.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidatePurchaseFacebookInstantRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidatedPurchase',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
+      _omitMessageNames ? '' : 'ValidatePurchaseFacebookInstantRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'productId')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'transactionId')
-    ..e<StoreProvider>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'store',
-        $pb.PbFieldType.OE,
-        defaultOrMaker: StoreProvider.APPLE_APP_STORE,
-        valueOf: StoreProvider.valueOf,
-        enumValues: StoreProvider.values)
-    ..aOM<$0.Timestamp>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'purchaseTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'refundTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOS(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'providerResponse')
-    ..e<StoreEnvironment>(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'environment',
-        $pb.PbFieldType.OE,
-        defaultOrMaker: StoreEnvironment.UNKNOWN,
-        valueOf: StoreEnvironment.valueOf,
-        enumValues: StoreEnvironment.values)
-    ..aOB(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'seenBefore')
+    ..aOS(1, _omitFieldNames ? '' : 'signedRequest')
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'persist',
+        subBuilder: $1.BoolValue.create)
     ..hasRequiredFields = false;
 
-  ValidatedPurchase._() : super();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatePurchaseFacebookInstantRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatePurchaseFacebookInstantRequest copyWith(
+          void Function(ValidatePurchaseFacebookInstantRequest) updates) =>
+      super.copyWith((message) =>
+              updates(message as ValidatePurchaseFacebookInstantRequest))
+          as ValidatePurchaseFacebookInstantRequest;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ValidatePurchaseFacebookInstantRequest create() =>
+      ValidatePurchaseFacebookInstantRequest._();
+  @$core.override
+  ValidatePurchaseFacebookInstantRequest createEmptyInstance() => create();
+  static $pb.PbList<ValidatePurchaseFacebookInstantRequest> createRepeated() =>
+      $pb.PbList<ValidatePurchaseFacebookInstantRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ValidatePurchaseFacebookInstantRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
+          ValidatePurchaseFacebookInstantRequest>(create);
+  static ValidatePurchaseFacebookInstantRequest? _defaultInstance;
+
+  /// Base64 encoded Facebook Instant signedRequest receipt data payload.
+  @$pb.TagNumber(1)
+  $core.String get signedRequest => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set signedRequest($core.String value) => $_setString(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasSignedRequest() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSignedRequest() => $_clearField(1);
+
+  /// Persist the purchase
+  @$pb.TagNumber(2)
+  $1.BoolValue get persist => $_getN(1);
+  @$pb.TagNumber(2)
+  set persist($1.BoolValue value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasPersist() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPersist() => $_clearField(2);
+  @$pb.TagNumber(2)
+  $1.BoolValue ensurePersist() => $_ensure(1);
+}
+
+/// Validated Purchase stored by Nakama.
+class ValidatedPurchase extends $pb.GeneratedMessage {
   factory ValidatedPurchase({
     $core.String? userId,
     $core.String? productId,
@@ -12335,61 +9896,66 @@ class ValidatedPurchase extends $pb.GeneratedMessage {
     StoreEnvironment? environment,
     $core.bool? seenBefore,
   }) {
-    final _result = create();
-    if (userId != null) {
-      _result.userId = userId;
-    }
-    if (productId != null) {
-      _result.productId = productId;
-    }
-    if (transactionId != null) {
-      _result.transactionId = transactionId;
-    }
-    if (store != null) {
-      _result.store = store;
-    }
-    if (purchaseTime != null) {
-      _result.purchaseTime = purchaseTime;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    if (refundTime != null) {
-      _result.refundTime = refundTime;
-    }
-    if (providerResponse != null) {
-      _result.providerResponse = providerResponse;
-    }
-    if (environment != null) {
-      _result.environment = environment;
-    }
-    if (seenBefore != null) {
-      _result.seenBefore = seenBefore;
-    }
-    return _result;
+    final result = create();
+    if (userId != null) result.userId = userId;
+    if (productId != null) result.productId = productId;
+    if (transactionId != null) result.transactionId = transactionId;
+    if (store != null) result.store = store;
+    if (purchaseTime != null) result.purchaseTime = purchaseTime;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    if (refundTime != null) result.refundTime = refundTime;
+    if (providerResponse != null) result.providerResponse = providerResponse;
+    if (environment != null) result.environment = environment;
+    if (seenBefore != null) result.seenBefore = seenBefore;
+    return result;
   }
-  factory ValidatedPurchase.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidatedPurchase.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidatedPurchase clone() => ValidatedPurchase()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidatedPurchase._();
+
+  factory ValidatedPurchase.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidatedPurchase.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidatedPurchase',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'userId')
+    ..aOS(2, _omitFieldNames ? '' : 'productId')
+    ..aOS(3, _omitFieldNames ? '' : 'transactionId')
+    ..aE<StoreProvider>(4, _omitFieldNames ? '' : 'store',
+        enumValues: StoreProvider.values)
+    ..aOM<$0.Timestamp>(5, _omitFieldNames ? '' : 'purchaseTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(6, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(7, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(8, _omitFieldNames ? '' : 'refundTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOS(9, _omitFieldNames ? '' : 'providerResponse')
+    ..aE<StoreEnvironment>(10, _omitFieldNames ? '' : 'environment',
+        enumValues: StoreEnvironment.values)
+    ..aOB(11, _omitFieldNames ? '' : 'seenBefore')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatedPurchase clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidatedPurchase copyWith(void Function(ValidatedPurchase) updates) =>
       super.copyWith((message) => updates(message as ValidatedPurchase))
-          as ValidatedPurchase; // ignore: deprecated_member_use
+          as ValidatedPurchase;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidatedPurchase create() => ValidatedPurchase._();
+  @$core.override
   ValidatedPurchase createEmptyInstance() => create();
   static $pb.PbList<ValidatedPurchase> createRepeated() =>
       $pb.PbList<ValidatedPurchase>();
@@ -12398,197 +9964,167 @@ class ValidatedPurchase extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ValidatedPurchase>(create);
   static ValidatedPurchase? _defaultInstance;
 
+  /// Purchase User ID.
   @$pb.TagNumber(1)
   $core.String get userId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set userId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set userId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasUserId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUserId() => clearField(1);
+  void clearUserId() => $_clearField(1);
 
+  /// Purchase Product ID.
   @$pb.TagNumber(2)
   $core.String get productId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set productId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set productId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasProductId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearProductId() => clearField(2);
+  void clearProductId() => $_clearField(2);
 
+  /// Purchase Transaction ID.
   @$pb.TagNumber(3)
   $core.String get transactionId => $_getSZ(2);
   @$pb.TagNumber(3)
-  set transactionId($core.String v) {
-    $_setString(2, v);
-  }
-
+  set transactionId($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasTransactionId() => $_has(2);
   @$pb.TagNumber(3)
-  void clearTransactionId() => clearField(3);
+  void clearTransactionId() => $_clearField(3);
 
+  /// Store identifier
   @$pb.TagNumber(4)
   StoreProvider get store => $_getN(3);
   @$pb.TagNumber(4)
-  set store(StoreProvider v) {
-    setField(4, v);
-  }
-
+  set store(StoreProvider value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasStore() => $_has(3);
   @$pb.TagNumber(4)
-  void clearStore() => clearField(4);
+  void clearStore() => $_clearField(4);
 
+  /// Timestamp when the purchase was done.
   @$pb.TagNumber(5)
   $0.Timestamp get purchaseTime => $_getN(4);
   @$pb.TagNumber(5)
-  set purchaseTime($0.Timestamp v) {
-    setField(5, v);
-  }
-
+  set purchaseTime($0.Timestamp value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasPurchaseTime() => $_has(4);
   @$pb.TagNumber(5)
-  void clearPurchaseTime() => clearField(5);
+  void clearPurchaseTime() => $_clearField(5);
   @$pb.TagNumber(5)
   $0.Timestamp ensurePurchaseTime() => $_ensure(4);
 
+  /// Timestamp when the receipt validation was stored in DB.
   @$pb.TagNumber(6)
   $0.Timestamp get createTime => $_getN(5);
   @$pb.TagNumber(6)
-  set createTime($0.Timestamp v) {
-    setField(6, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasCreateTime() => $_has(5);
   @$pb.TagNumber(6)
-  void clearCreateTime() => clearField(6);
+  void clearCreateTime() => $_clearField(6);
   @$pb.TagNumber(6)
   $0.Timestamp ensureCreateTime() => $_ensure(5);
 
+  /// Timestamp when the receipt validation was updated in DB.
   @$pb.TagNumber(7)
   $0.Timestamp get updateTime => $_getN(6);
   @$pb.TagNumber(7)
-  set updateTime($0.Timestamp v) {
-    setField(7, v);
-  }
-
+  set updateTime($0.Timestamp value) => $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasUpdateTime() => $_has(6);
   @$pb.TagNumber(7)
-  void clearUpdateTime() => clearField(7);
+  void clearUpdateTime() => $_clearField(7);
   @$pb.TagNumber(7)
   $0.Timestamp ensureUpdateTime() => $_ensure(6);
 
+  /// Timestamp when the purchase was refunded. Set to UNIX
   @$pb.TagNumber(8)
   $0.Timestamp get refundTime => $_getN(7);
   @$pb.TagNumber(8)
-  set refundTime($0.Timestamp v) {
-    setField(8, v);
-  }
-
+  set refundTime($0.Timestamp value) => $_setField(8, value);
   @$pb.TagNumber(8)
   $core.bool hasRefundTime() => $_has(7);
   @$pb.TagNumber(8)
-  void clearRefundTime() => clearField(8);
+  void clearRefundTime() => $_clearField(8);
   @$pb.TagNumber(8)
   $0.Timestamp ensureRefundTime() => $_ensure(7);
 
+  /// Raw provider validation response.
   @$pb.TagNumber(9)
   $core.String get providerResponse => $_getSZ(8);
   @$pb.TagNumber(9)
-  set providerResponse($core.String v) {
-    $_setString(8, v);
-  }
-
+  set providerResponse($core.String value) => $_setString(8, value);
   @$pb.TagNumber(9)
   $core.bool hasProviderResponse() => $_has(8);
   @$pb.TagNumber(9)
-  void clearProviderResponse() => clearField(9);
+  void clearProviderResponse() => $_clearField(9);
 
+  /// Whether the purchase was done in production or sandbox environment.
   @$pb.TagNumber(10)
   StoreEnvironment get environment => $_getN(9);
   @$pb.TagNumber(10)
-  set environment(StoreEnvironment v) {
-    setField(10, v);
-  }
-
+  set environment(StoreEnvironment value) => $_setField(10, value);
   @$pb.TagNumber(10)
   $core.bool hasEnvironment() => $_has(9);
   @$pb.TagNumber(10)
-  void clearEnvironment() => clearField(10);
+  void clearEnvironment() => $_clearField(10);
 
+  /// Whether the purchase had already been validated by Nakama before.
   @$pb.TagNumber(11)
   $core.bool get seenBefore => $_getBF(10);
   @$pb.TagNumber(11)
-  set seenBefore($core.bool v) {
-    $_setBool(10, v);
-  }
-
+  set seenBefore($core.bool value) => $_setBool(10, value);
   @$pb.TagNumber(11)
   $core.bool hasSeenBefore() => $_has(10);
   @$pb.TagNumber(11)
-  void clearSeenBefore() => clearField(11);
+  void clearSeenBefore() => $_clearField(11);
 }
 
+/// Validate IAP response.
 class ValidatePurchaseResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidatePurchaseResponse',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<ValidatedPurchase>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'validatedPurchases',
-        $pb.PbFieldType.PM,
-        subBuilder: ValidatedPurchase.create)
-    ..hasRequiredFields = false;
-
-  ValidatePurchaseResponse._() : super();
   factory ValidatePurchaseResponse({
     $core.Iterable<ValidatedPurchase>? validatedPurchases,
   }) {
-    final _result = create();
-    if (validatedPurchases != null) {
-      _result.validatedPurchases.addAll(validatedPurchases);
-    }
-    return _result;
+    final result = create();
+    if (validatedPurchases != null)
+      result.validatedPurchases.addAll(validatedPurchases);
+    return result;
   }
-  factory ValidatePurchaseResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidatePurchaseResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidatePurchaseResponse clone() =>
-      ValidatePurchaseResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidatePurchaseResponse._();
+
+  factory ValidatePurchaseResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidatePurchaseResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidatePurchaseResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<ValidatedPurchase>(1, _omitFieldNames ? '' : 'validatedPurchases',
+        subBuilder: ValidatedPurchase.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatePurchaseResponse clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidatePurchaseResponse copyWith(
           void Function(ValidatePurchaseResponse) updates) =>
       super.copyWith((message) => updates(message as ValidatePurchaseResponse))
-          as ValidatePurchaseResponse; // ignore: deprecated_member_use
+          as ValidatePurchaseResponse;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseResponse create() => ValidatePurchaseResponse._();
+  @$core.override
   ValidatePurchaseResponse createEmptyInstance() => create();
   static $pb.PbList<ValidatePurchaseResponse> createRepeated() =>
       $pb.PbList<ValidatePurchaseResponse>();
@@ -12597,61 +10133,56 @@ class ValidatePurchaseResponse extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseResponse>(create);
   static ValidatePurchaseResponse? _defaultInstance;
 
+  /// Newly seen validated purchases.
   @$pb.TagNumber(1)
-  $core.List<ValidatedPurchase> get validatedPurchases => $_getList(0);
+  $pb.PbList<ValidatedPurchase> get validatedPurchases => $_getList(0);
 }
 
+/// Validate Subscription response.
 class ValidateSubscriptionResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidateSubscriptionResponse',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOM<ValidatedSubscription>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'validatedSubscription',
-        subBuilder: ValidatedSubscription.create)
-    ..hasRequiredFields = false;
-
-  ValidateSubscriptionResponse._() : super();
   factory ValidateSubscriptionResponse({
     ValidatedSubscription? validatedSubscription,
   }) {
-    final _result = create();
-    if (validatedSubscription != null) {
-      _result.validatedSubscription = validatedSubscription;
-    }
-    return _result;
+    final result = create();
+    if (validatedSubscription != null)
+      result.validatedSubscription = validatedSubscription;
+    return result;
   }
-  factory ValidateSubscriptionResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidateSubscriptionResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidateSubscriptionResponse clone() =>
-      ValidateSubscriptionResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidateSubscriptionResponse._();
+
+  factory ValidateSubscriptionResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidateSubscriptionResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidateSubscriptionResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<ValidatedSubscription>(
+        1, _omitFieldNames ? '' : 'validatedSubscription',
+        subBuilder: ValidatedSubscription.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidateSubscriptionResponse clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidateSubscriptionResponse copyWith(
           void Function(ValidateSubscriptionResponse) updates) =>
       super.copyWith(
               (message) => updates(message as ValidateSubscriptionResponse))
-          as ValidateSubscriptionResponse; // ignore: deprecated_member_use
+          as ValidateSubscriptionResponse;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidateSubscriptionResponse create() =>
       ValidateSubscriptionResponse._();
+  @$core.override
   ValidateSubscriptionResponse createEmptyInstance() => create();
   static $pb.PbList<ValidateSubscriptionResponse> createRepeated() =>
       $pb.PbList<ValidateSubscriptionResponse>();
@@ -12663,109 +10194,17 @@ class ValidateSubscriptionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   ValidatedSubscription get validatedSubscription => $_getN(0);
   @$pb.TagNumber(1)
-  set validatedSubscription(ValidatedSubscription v) {
-    setField(1, v);
-  }
-
+  set validatedSubscription(ValidatedSubscription value) =>
+      $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasValidatedSubscription() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValidatedSubscription() => clearField(1);
+  void clearValidatedSubscription() => $_clearField(1);
   @$pb.TagNumber(1)
   ValidatedSubscription ensureValidatedSubscription() => $_ensure(0);
 }
 
 class ValidatedSubscription extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ValidatedSubscription',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'productId')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'originalTransactionId')
-    ..e<StoreProvider>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'store',
-        $pb.PbFieldType.OE,
-        defaultOrMaker: StoreProvider.APPLE_APP_STORE,
-        valueOf: StoreProvider.valueOf,
-        enumValues: StoreProvider.values)
-    ..aOM<$0.Timestamp>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'purchaseTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..e<StoreEnvironment>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'environment',
-        $pb.PbFieldType.OE,
-        defaultOrMaker: StoreEnvironment.UNKNOWN,
-        valueOf: StoreEnvironment.valueOf,
-        enumValues: StoreEnvironment.values)
-    ..aOM<$0.Timestamp>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'expiryTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'refundTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOS(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'providerResponse')
-    ..aOS(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'providerNotification')
-    ..aOB(
-        13,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'active')
-    ..hasRequiredFields = false;
-
-  ValidatedSubscription._() : super();
   factory ValidatedSubscription({
     $core.String? userId,
     $core.String? productId,
@@ -12781,69 +10220,74 @@ class ValidatedSubscription extends $pb.GeneratedMessage {
     $core.String? providerNotification,
     $core.bool? active,
   }) {
-    final _result = create();
-    if (userId != null) {
-      _result.userId = userId;
-    }
-    if (productId != null) {
-      _result.productId = productId;
-    }
-    if (originalTransactionId != null) {
-      _result.originalTransactionId = originalTransactionId;
-    }
-    if (store != null) {
-      _result.store = store;
-    }
-    if (purchaseTime != null) {
-      _result.purchaseTime = purchaseTime;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    if (environment != null) {
-      _result.environment = environment;
-    }
-    if (expiryTime != null) {
-      _result.expiryTime = expiryTime;
-    }
-    if (refundTime != null) {
-      _result.refundTime = refundTime;
-    }
-    if (providerResponse != null) {
-      _result.providerResponse = providerResponse;
-    }
-    if (providerNotification != null) {
-      _result.providerNotification = providerNotification;
-    }
-    if (active != null) {
-      _result.active = active;
-    }
-    return _result;
+    final result = create();
+    if (userId != null) result.userId = userId;
+    if (productId != null) result.productId = productId;
+    if (originalTransactionId != null)
+      result.originalTransactionId = originalTransactionId;
+    if (store != null) result.store = store;
+    if (purchaseTime != null) result.purchaseTime = purchaseTime;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    if (environment != null) result.environment = environment;
+    if (expiryTime != null) result.expiryTime = expiryTime;
+    if (refundTime != null) result.refundTime = refundTime;
+    if (providerResponse != null) result.providerResponse = providerResponse;
+    if (providerNotification != null)
+      result.providerNotification = providerNotification;
+    if (active != null) result.active = active;
+    return result;
   }
-  factory ValidatedSubscription.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ValidatedSubscription.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ValidatedSubscription clone() =>
-      ValidatedSubscription()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ValidatedSubscription._();
+
+  factory ValidatedSubscription.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidatedSubscription.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidatedSubscription',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'userId')
+    ..aOS(2, _omitFieldNames ? '' : 'productId')
+    ..aOS(3, _omitFieldNames ? '' : 'originalTransactionId')
+    ..aE<StoreProvider>(4, _omitFieldNames ? '' : 'store',
+        enumValues: StoreProvider.values)
+    ..aOM<$0.Timestamp>(5, _omitFieldNames ? '' : 'purchaseTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(6, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(7, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $0.Timestamp.create)
+    ..aE<StoreEnvironment>(8, _omitFieldNames ? '' : 'environment',
+        enumValues: StoreEnvironment.values)
+    ..aOM<$0.Timestamp>(9, _omitFieldNames ? '' : 'expiryTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(10, _omitFieldNames ? '' : 'refundTime',
+        subBuilder: $0.Timestamp.create)
+    ..aOS(11, _omitFieldNames ? '' : 'providerResponse')
+    ..aOS(12, _omitFieldNames ? '' : 'providerNotification')
+    ..aOB(13, _omitFieldNames ? '' : 'active')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatedSubscription clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ValidatedSubscription copyWith(
           void Function(ValidatedSubscription) updates) =>
       super.copyWith((message) => updates(message as ValidatedSubscription))
-          as ValidatedSubscription; // ignore: deprecated_member_use
+          as ValidatedSubscription;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ValidatedSubscription create() => ValidatedSubscription._();
+  @$core.override
   ValidatedSubscription createEmptyInstance() => create();
   static $pb.PbList<ValidatedSubscription> createRepeated() =>
       $pb.PbList<ValidatedSubscription>();
@@ -12852,239 +10296,194 @@ class ValidatedSubscription extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ValidatedSubscription>(create);
   static ValidatedSubscription? _defaultInstance;
 
+  /// Subscription User ID.
   @$pb.TagNumber(1)
   $core.String get userId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set userId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set userId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasUserId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUserId() => clearField(1);
+  void clearUserId() => $_clearField(1);
 
+  /// Purchase Product ID.
   @$pb.TagNumber(2)
   $core.String get productId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set productId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set productId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasProductId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearProductId() => clearField(2);
+  void clearProductId() => $_clearField(2);
 
+  /// Purchase Original transaction ID (we only keep track of the original subscription, not subsequent renewals).
   @$pb.TagNumber(3)
   $core.String get originalTransactionId => $_getSZ(2);
   @$pb.TagNumber(3)
-  set originalTransactionId($core.String v) {
-    $_setString(2, v);
-  }
-
+  set originalTransactionId($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasOriginalTransactionId() => $_has(2);
   @$pb.TagNumber(3)
-  void clearOriginalTransactionId() => clearField(3);
+  void clearOriginalTransactionId() => $_clearField(3);
 
+  /// Store identifier
   @$pb.TagNumber(4)
   StoreProvider get store => $_getN(3);
   @$pb.TagNumber(4)
-  set store(StoreProvider v) {
-    setField(4, v);
-  }
-
+  set store(StoreProvider value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasStore() => $_has(3);
   @$pb.TagNumber(4)
-  void clearStore() => clearField(4);
+  void clearStore() => $_clearField(4);
 
+  /// UNIX Timestamp when the purchase was done.
   @$pb.TagNumber(5)
   $0.Timestamp get purchaseTime => $_getN(4);
   @$pb.TagNumber(5)
-  set purchaseTime($0.Timestamp v) {
-    setField(5, v);
-  }
-
+  set purchaseTime($0.Timestamp value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasPurchaseTime() => $_has(4);
   @$pb.TagNumber(5)
-  void clearPurchaseTime() => clearField(5);
+  void clearPurchaseTime() => $_clearField(5);
   @$pb.TagNumber(5)
   $0.Timestamp ensurePurchaseTime() => $_ensure(4);
 
+  /// UNIX Timestamp when the receipt validation was stored in DB.
   @$pb.TagNumber(6)
   $0.Timestamp get createTime => $_getN(5);
   @$pb.TagNumber(6)
-  set createTime($0.Timestamp v) {
-    setField(6, v);
-  }
-
+  set createTime($0.Timestamp value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasCreateTime() => $_has(5);
   @$pb.TagNumber(6)
-  void clearCreateTime() => clearField(6);
+  void clearCreateTime() => $_clearField(6);
   @$pb.TagNumber(6)
   $0.Timestamp ensureCreateTime() => $_ensure(5);
 
+  /// UNIX Timestamp when the receipt validation was updated in DB.
   @$pb.TagNumber(7)
   $0.Timestamp get updateTime => $_getN(6);
   @$pb.TagNumber(7)
-  set updateTime($0.Timestamp v) {
-    setField(7, v);
-  }
-
+  set updateTime($0.Timestamp value) => $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasUpdateTime() => $_has(6);
   @$pb.TagNumber(7)
-  void clearUpdateTime() => clearField(7);
+  void clearUpdateTime() => $_clearField(7);
   @$pb.TagNumber(7)
   $0.Timestamp ensureUpdateTime() => $_ensure(6);
 
+  /// Whether the purchase was done in production or sandbox environment.
   @$pb.TagNumber(8)
   StoreEnvironment get environment => $_getN(7);
   @$pb.TagNumber(8)
-  set environment(StoreEnvironment v) {
-    setField(8, v);
-  }
-
+  set environment(StoreEnvironment value) => $_setField(8, value);
   @$pb.TagNumber(8)
   $core.bool hasEnvironment() => $_has(7);
   @$pb.TagNumber(8)
-  void clearEnvironment() => clearField(8);
+  void clearEnvironment() => $_clearField(8);
 
+  /// Subscription expiration time. The subscription can still be auto-renewed to extend the expiration time further.
   @$pb.TagNumber(9)
   $0.Timestamp get expiryTime => $_getN(8);
   @$pb.TagNumber(9)
-  set expiryTime($0.Timestamp v) {
-    setField(9, v);
-  }
-
+  set expiryTime($0.Timestamp value) => $_setField(9, value);
   @$pb.TagNumber(9)
   $core.bool hasExpiryTime() => $_has(8);
   @$pb.TagNumber(9)
-  void clearExpiryTime() => clearField(9);
+  void clearExpiryTime() => $_clearField(9);
   @$pb.TagNumber(9)
   $0.Timestamp ensureExpiryTime() => $_ensure(8);
 
+  /// Subscription refund time. If this time is set, the subscription was refunded.
   @$pb.TagNumber(10)
   $0.Timestamp get refundTime => $_getN(9);
   @$pb.TagNumber(10)
-  set refundTime($0.Timestamp v) {
-    setField(10, v);
-  }
-
+  set refundTime($0.Timestamp value) => $_setField(10, value);
   @$pb.TagNumber(10)
   $core.bool hasRefundTime() => $_has(9);
   @$pb.TagNumber(10)
-  void clearRefundTime() => clearField(10);
+  void clearRefundTime() => $_clearField(10);
   @$pb.TagNumber(10)
   $0.Timestamp ensureRefundTime() => $_ensure(9);
 
+  /// Raw provider validation response body.
   @$pb.TagNumber(11)
   $core.String get providerResponse => $_getSZ(10);
   @$pb.TagNumber(11)
-  set providerResponse($core.String v) {
-    $_setString(10, v);
-  }
-
+  set providerResponse($core.String value) => $_setString(10, value);
   @$pb.TagNumber(11)
   $core.bool hasProviderResponse() => $_has(10);
   @$pb.TagNumber(11)
-  void clearProviderResponse() => clearField(11);
+  void clearProviderResponse() => $_clearField(11);
 
+  /// Raw provider notification body.
   @$pb.TagNumber(12)
   $core.String get providerNotification => $_getSZ(11);
   @$pb.TagNumber(12)
-  set providerNotification($core.String v) {
-    $_setString(11, v);
-  }
-
+  set providerNotification($core.String value) => $_setString(11, value);
   @$pb.TagNumber(12)
   $core.bool hasProviderNotification() => $_has(11);
   @$pb.TagNumber(12)
-  void clearProviderNotification() => clearField(12);
+  void clearProviderNotification() => $_clearField(12);
 
+  /// Whether the subscription is currently active or not.
   @$pb.TagNumber(13)
   $core.bool get active => $_getBF(12);
   @$pb.TagNumber(13)
-  set active($core.bool v) {
-    $_setBool(12, v);
-  }
-
+  set active($core.bool value) => $_setBool(12, value);
   @$pb.TagNumber(13)
   $core.bool hasActive() => $_has(12);
   @$pb.TagNumber(13)
-  void clearActive() => clearField(13);
+  void clearActive() => $_clearField(13);
 }
 
+/// A list of validated purchases stored by Nakama.
 class PurchaseList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PurchaseList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<ValidatedPurchase>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'validatedPurchases',
-        $pb.PbFieldType.PM,
-        subBuilder: ValidatedPurchase.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'prevCursor')
-    ..hasRequiredFields = false;
-
-  PurchaseList._() : super();
   factory PurchaseList({
     $core.Iterable<ValidatedPurchase>? validatedPurchases,
     $core.String? cursor,
     $core.String? prevCursor,
   }) {
-    final _result = create();
-    if (validatedPurchases != null) {
-      _result.validatedPurchases.addAll(validatedPurchases);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    if (prevCursor != null) {
-      _result.prevCursor = prevCursor;
-    }
-    return _result;
+    final result = create();
+    if (validatedPurchases != null)
+      result.validatedPurchases.addAll(validatedPurchases);
+    if (cursor != null) result.cursor = cursor;
+    if (prevCursor != null) result.prevCursor = prevCursor;
+    return result;
   }
-  factory PurchaseList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PurchaseList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PurchaseList clone() => PurchaseList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PurchaseList._();
+
+  factory PurchaseList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PurchaseList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PurchaseList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<ValidatedPurchase>(1, _omitFieldNames ? '' : 'validatedPurchases',
+        subBuilder: ValidatedPurchase.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..aOS(3, _omitFieldNames ? '' : 'prevCursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PurchaseList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PurchaseList copyWith(void Function(PurchaseList) updates) =>
       super.copyWith((message) => updates(message as PurchaseList))
-          as PurchaseList; // ignore: deprecated_member_use
+          as PurchaseList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PurchaseList create() => PurchaseList._();
+  @$core.override
   PurchaseList createEmptyInstance() => create();
   static $pb.PbList<PurchaseList> createRepeated() =>
       $pb.PbList<PurchaseList>();
@@ -13093,100 +10492,79 @@ class PurchaseList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PurchaseList>(create);
   static PurchaseList? _defaultInstance;
 
+  /// Stored validated purchases.
   @$pb.TagNumber(1)
-  $core.List<ValidatedPurchase> get validatedPurchases => $_getList(0);
+  $pb.PbList<ValidatedPurchase> get validatedPurchases => $_getList(0);
 
+  /// The cursor to send when retrieving the next page, if any.
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 
+  /// The cursor to send when retrieving the previous page, if any.
   @$pb.TagNumber(3)
   $core.String get prevCursor => $_getSZ(2);
   @$pb.TagNumber(3)
-  set prevCursor($core.String v) {
-    $_setString(2, v);
-  }
-
+  set prevCursor($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasPrevCursor() => $_has(2);
   @$pb.TagNumber(3)
-  void clearPrevCursor() => clearField(3);
+  void clearPrevCursor() => $_clearField(3);
 }
 
+/// A list of validated subscriptions stored by Nakama.
 class SubscriptionList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'SubscriptionList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<ValidatedSubscription>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'validatedSubscriptions',
-        $pb.PbFieldType.PM,
-        subBuilder: ValidatedSubscription.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cursor')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'prevCursor')
-    ..hasRequiredFields = false;
-
-  SubscriptionList._() : super();
   factory SubscriptionList({
     $core.Iterable<ValidatedSubscription>? validatedSubscriptions,
     $core.String? cursor,
     $core.String? prevCursor,
   }) {
-    final _result = create();
-    if (validatedSubscriptions != null) {
-      _result.validatedSubscriptions.addAll(validatedSubscriptions);
-    }
-    if (cursor != null) {
-      _result.cursor = cursor;
-    }
-    if (prevCursor != null) {
-      _result.prevCursor = prevCursor;
-    }
-    return _result;
+    final result = create();
+    if (validatedSubscriptions != null)
+      result.validatedSubscriptions.addAll(validatedSubscriptions);
+    if (cursor != null) result.cursor = cursor;
+    if (prevCursor != null) result.prevCursor = prevCursor;
+    return result;
   }
-  factory SubscriptionList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SubscriptionList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  SubscriptionList clone() => SubscriptionList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  SubscriptionList._();
+
+  factory SubscriptionList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory SubscriptionList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'SubscriptionList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<ValidatedSubscription>(
+        1, _omitFieldNames ? '' : 'validatedSubscriptions',
+        subBuilder: ValidatedSubscription.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..aOS(3, _omitFieldNames ? '' : 'prevCursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  SubscriptionList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   SubscriptionList copyWith(void Function(SubscriptionList) updates) =>
       super.copyWith((message) => updates(message as SubscriptionList))
-          as SubscriptionList; // ignore: deprecated_member_use
+          as SubscriptionList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static SubscriptionList create() => SubscriptionList._();
+  @$core.override
   SubscriptionList createEmptyInstance() => create();
   static $pb.PbList<SubscriptionList> createRepeated() =>
       $pb.PbList<SubscriptionList>();
@@ -13195,120 +10573,89 @@ class SubscriptionList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<SubscriptionList>(create);
   static SubscriptionList? _defaultInstance;
 
+  /// Stored validated subscriptions.
   @$pb.TagNumber(1)
-  $core.List<ValidatedSubscription> get validatedSubscriptions => $_getList(0);
+  $pb.PbList<ValidatedSubscription> get validatedSubscriptions => $_getList(0);
 
+  /// The cursor to send when retrieving the next page, if any.
   @$pb.TagNumber(2)
   $core.String get cursor => $_getSZ(1);
   @$pb.TagNumber(2)
-  set cursor($core.String v) {
-    $_setString(1, v);
-  }
-
+  set cursor($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasCursor() => $_has(1);
   @$pb.TagNumber(2)
-  void clearCursor() => clearField(2);
+  void clearCursor() => $_clearField(2);
 
+  /// The cursor to send when retrieving the previous page, if any.
   @$pb.TagNumber(3)
   $core.String get prevCursor => $_getSZ(2);
   @$pb.TagNumber(3)
-  set prevCursor($core.String v) {
-    $_setString(2, v);
-  }
-
+  set prevCursor($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasPrevCursor() => $_has(2);
   @$pb.TagNumber(3)
-  void clearPrevCursor() => clearField(3);
+  void clearPrevCursor() => $_clearField(3);
 }
 
+/// Record values to write.
 class WriteLeaderboardRecordRequest_LeaderboardRecordWrite
     extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'WriteLeaderboardRecordRequest.LeaderboardRecordWrite',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aInt64(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'score')
-    ..aInt64(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'subscore')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'metadata')
-    ..e<Operator>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'operator',
-        $pb.PbFieldType.OE,
-        defaultOrMaker: Operator.NO_OVERRIDE,
-        valueOf: Operator.valueOf,
-        enumValues: Operator.values)
-    ..hasRequiredFields = false;
-
-  WriteLeaderboardRecordRequest_LeaderboardRecordWrite._() : super();
   factory WriteLeaderboardRecordRequest_LeaderboardRecordWrite({
     $fixnum.Int64? score,
     $fixnum.Int64? subscore,
     $core.String? metadata,
     Operator? operator,
   }) {
-    final _result = create();
-    if (score != null) {
-      _result.score = score;
-    }
-    if (subscore != null) {
-      _result.subscore = subscore;
-    }
-    if (metadata != null) {
-      _result.metadata = metadata;
-    }
-    if (operator != null) {
-      _result.operator = operator;
-    }
-    return _result;
+    final result = create();
+    if (score != null) result.score = score;
+    if (subscore != null) result.subscore = subscore;
+    if (metadata != null) result.metadata = metadata;
+    if (operator != null) result.operator = operator;
+    return result;
   }
+
+  WriteLeaderboardRecordRequest_LeaderboardRecordWrite._();
+
   factory WriteLeaderboardRecordRequest_LeaderboardRecordWrite.fromBuffer(
-          $core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
   factory WriteLeaderboardRecordRequest_LeaderboardRecordWrite.fromJson(
-          $core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  WriteLeaderboardRecordRequest_LeaderboardRecordWrite clone() =>
-      WriteLeaderboardRecordRequest_LeaderboardRecordWrite()
-        ..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+          $core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames
+          ? ''
+          : 'WriteLeaderboardRecordRequest.LeaderboardRecordWrite',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aInt64(1, _omitFieldNames ? '' : 'score')
+    ..aInt64(2, _omitFieldNames ? '' : 'subscore')
+    ..aOS(3, _omitFieldNames ? '' : 'metadata')
+    ..aE<Operator>(4, _omitFieldNames ? '' : 'operator',
+        enumValues: Operator.values)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  WriteLeaderboardRecordRequest_LeaderboardRecordWrite clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   WriteLeaderboardRecordRequest_LeaderboardRecordWrite copyWith(
           void Function(WriteLeaderboardRecordRequest_LeaderboardRecordWrite)
               updates) =>
       super.copyWith((message) => updates(
               message as WriteLeaderboardRecordRequest_LeaderboardRecordWrite))
-          as WriteLeaderboardRecordRequest_LeaderboardRecordWrite; // ignore: deprecated_member_use
+          as WriteLeaderboardRecordRequest_LeaderboardRecordWrite;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static WriteLeaderboardRecordRequest_LeaderboardRecordWrite create() =>
       WriteLeaderboardRecordRequest_LeaderboardRecordWrite._();
+  @$core.override
   WriteLeaderboardRecordRequest_LeaderboardRecordWrite createEmptyInstance() =>
       create();
   static $pb.PbList<WriteLeaderboardRecordRequest_LeaderboardRecordWrite>
@@ -13320,115 +10667,94 @@ class WriteLeaderboardRecordRequest_LeaderboardRecordWrite
           WriteLeaderboardRecordRequest_LeaderboardRecordWrite>(create);
   static WriteLeaderboardRecordRequest_LeaderboardRecordWrite? _defaultInstance;
 
+  /// The score value to submit.
   @$pb.TagNumber(1)
   $fixnum.Int64 get score => $_getI64(0);
   @$pb.TagNumber(1)
-  set score($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set score($fixnum.Int64 value) => $_setInt64(0, value);
   @$pb.TagNumber(1)
   $core.bool hasScore() => $_has(0);
   @$pb.TagNumber(1)
-  void clearScore() => clearField(1);
+  void clearScore() => $_clearField(1);
 
+  /// An optional secondary value.
   @$pb.TagNumber(2)
   $fixnum.Int64 get subscore => $_getI64(1);
   @$pb.TagNumber(2)
-  set subscore($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set subscore($fixnum.Int64 value) => $_setInt64(1, value);
   @$pb.TagNumber(2)
   $core.bool hasSubscore() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSubscore() => clearField(2);
+  void clearSubscore() => $_clearField(2);
 
+  /// Optional record metadata.
   @$pb.TagNumber(3)
   $core.String get metadata => $_getSZ(2);
   @$pb.TagNumber(3)
-  set metadata($core.String v) {
-    $_setString(2, v);
-  }
-
+  set metadata($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasMetadata() => $_has(2);
   @$pb.TagNumber(3)
-  void clearMetadata() => clearField(3);
+  void clearMetadata() => $_clearField(3);
 
+  /// Operator override.
   @$pb.TagNumber(4)
   Operator get operator => $_getN(3);
   @$pb.TagNumber(4)
-  set operator(Operator v) {
-    setField(4, v);
-  }
-
+  set operator(Operator value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasOperator() => $_has(3);
   @$pb.TagNumber(4)
-  void clearOperator() => clearField(4);
+  void clearOperator() => $_clearField(4);
 }
 
+/// A request to submit a score to a leaderboard.
 class WriteLeaderboardRecordRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'WriteLeaderboardRecordRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaderboardId')
-    ..aOM<WriteLeaderboardRecordRequest_LeaderboardRecordWrite>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'record',
-        subBuilder: WriteLeaderboardRecordRequest_LeaderboardRecordWrite.create)
-    ..hasRequiredFields = false;
-
-  WriteLeaderboardRecordRequest._() : super();
   factory WriteLeaderboardRecordRequest({
     $core.String? leaderboardId,
     WriteLeaderboardRecordRequest_LeaderboardRecordWrite? record,
   }) {
-    final _result = create();
-    if (leaderboardId != null) {
-      _result.leaderboardId = leaderboardId;
-    }
-    if (record != null) {
-      _result.record = record;
-    }
-    return _result;
+    final result = create();
+    if (leaderboardId != null) result.leaderboardId = leaderboardId;
+    if (record != null) result.record = record;
+    return result;
   }
-  factory WriteLeaderboardRecordRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteLeaderboardRecordRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  WriteLeaderboardRecordRequest clone() =>
-      WriteLeaderboardRecordRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  WriteLeaderboardRecordRequest._();
+
+  factory WriteLeaderboardRecordRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory WriteLeaderboardRecordRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'WriteLeaderboardRecordRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'leaderboardId')
+    ..aOM<WriteLeaderboardRecordRequest_LeaderboardRecordWrite>(
+        2, _omitFieldNames ? '' : 'record',
+        subBuilder: WriteLeaderboardRecordRequest_LeaderboardRecordWrite.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  WriteLeaderboardRecordRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   WriteLeaderboardRecordRequest copyWith(
           void Function(WriteLeaderboardRecordRequest) updates) =>
       super.copyWith(
               (message) => updates(message as WriteLeaderboardRecordRequest))
-          as WriteLeaderboardRecordRequest; // ignore: deprecated_member_use
+          as WriteLeaderboardRecordRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static WriteLeaderboardRecordRequest create() =>
       WriteLeaderboardRecordRequest._();
+  @$core.override
   WriteLeaderboardRecordRequest createEmptyInstance() => create();
   static $pb.PbList<WriteLeaderboardRecordRequest> createRepeated() =>
       $pb.PbList<WriteLeaderboardRecordRequest>();
@@ -13437,79 +10763,33 @@ class WriteLeaderboardRecordRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<WriteLeaderboardRecordRequest>(create);
   static WriteLeaderboardRecordRequest? _defaultInstance;
 
+  /// The ID of the leaderboard to write to.
   @$pb.TagNumber(1)
   $core.String get leaderboardId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set leaderboardId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set leaderboardId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasLeaderboardId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearLeaderboardId() => clearField(1);
+  void clearLeaderboardId() => $_clearField(1);
 
+  /// Record input.
   @$pb.TagNumber(2)
   WriteLeaderboardRecordRequest_LeaderboardRecordWrite get record => $_getN(1);
   @$pb.TagNumber(2)
-  set record(WriteLeaderboardRecordRequest_LeaderboardRecordWrite v) {
-    setField(2, v);
-  }
-
+  set record(WriteLeaderboardRecordRequest_LeaderboardRecordWrite value) =>
+      $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasRecord() => $_has(1);
   @$pb.TagNumber(2)
-  void clearRecord() => clearField(2);
+  void clearRecord() => $_clearField(2);
   @$pb.TagNumber(2)
   WriteLeaderboardRecordRequest_LeaderboardRecordWrite ensureRecord() =>
       $_ensure(1);
 }
 
+/// The object to store.
 class WriteStorageObject extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'WriteStorageObject',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'collection')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'key')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'version')
-    ..aOM<$1.Int32Value>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'permissionRead',
-        subBuilder: $1.Int32Value.create)
-    ..aOM<$1.Int32Value>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'permissionWrite',
-        subBuilder: $1.Int32Value.create)
-    ..hasRequiredFields = false;
-
-  WriteStorageObject._() : super();
   factory WriteStorageObject({
     $core.String? collection,
     $core.String? key,
@@ -13518,46 +10798,52 @@ class WriteStorageObject extends $pb.GeneratedMessage {
     $1.Int32Value? permissionRead,
     $1.Int32Value? permissionWrite,
   }) {
-    final _result = create();
-    if (collection != null) {
-      _result.collection = collection;
-    }
-    if (key != null) {
-      _result.key = key;
-    }
-    if (value != null) {
-      _result.value = value;
-    }
-    if (version != null) {
-      _result.version = version;
-    }
-    if (permissionRead != null) {
-      _result.permissionRead = permissionRead;
-    }
-    if (permissionWrite != null) {
-      _result.permissionWrite = permissionWrite;
-    }
-    return _result;
+    final result = create();
+    if (collection != null) result.collection = collection;
+    if (key != null) result.key = key;
+    if (value != null) result.value = value;
+    if (version != null) result.version = version;
+    if (permissionRead != null) result.permissionRead = permissionRead;
+    if (permissionWrite != null) result.permissionWrite = permissionWrite;
+    return result;
   }
-  factory WriteStorageObject.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteStorageObject.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  WriteStorageObject clone() => WriteStorageObject()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  WriteStorageObject._();
+
+  factory WriteStorageObject.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory WriteStorageObject.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'WriteStorageObject',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'collection')
+    ..aOS(2, _omitFieldNames ? '' : 'key')
+    ..aOS(3, _omitFieldNames ? '' : 'value')
+    ..aOS(4, _omitFieldNames ? '' : 'version')
+    ..aOM<$1.Int32Value>(5, _omitFieldNames ? '' : 'permissionRead',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.Int32Value>(6, _omitFieldNames ? '' : 'permissionWrite',
+        subBuilder: $1.Int32Value.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  WriteStorageObject clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   WriteStorageObject copyWith(void Function(WriteStorageObject) updates) =>
       super.copyWith((message) => updates(message as WriteStorageObject))
-          as WriteStorageObject; // ignore: deprecated_member_use
+          as WriteStorageObject;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static WriteStorageObject create() => WriteStorageObject._();
+  @$core.override
   WriteStorageObject createEmptyInstance() => create();
   static $pb.PbList<WriteStorageObject> createRepeated() =>
       $pb.PbList<WriteStorageObject>();
@@ -13566,134 +10852,113 @@ class WriteStorageObject extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<WriteStorageObject>(create);
   static WriteStorageObject? _defaultInstance;
 
+  /// The collection to store the object.
   @$pb.TagNumber(1)
   $core.String get collection => $_getSZ(0);
   @$pb.TagNumber(1)
-  set collection($core.String v) {
-    $_setString(0, v);
-  }
-
+  set collection($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCollection() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCollection() => clearField(1);
+  void clearCollection() => $_clearField(1);
 
+  /// The key for the object within the collection.
   @$pb.TagNumber(2)
   $core.String get key => $_getSZ(1);
   @$pb.TagNumber(2)
-  set key($core.String v) {
-    $_setString(1, v);
-  }
-
+  set key($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasKey() => $_has(1);
   @$pb.TagNumber(2)
-  void clearKey() => clearField(2);
+  void clearKey() => $_clearField(2);
 
+  /// The value of the object.
   @$pb.TagNumber(3)
   $core.String get value => $_getSZ(2);
   @$pb.TagNumber(3)
-  set value($core.String v) {
-    $_setString(2, v);
-  }
-
+  set value($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasValue() => $_has(2);
   @$pb.TagNumber(3)
-  void clearValue() => clearField(3);
+  void clearValue() => $_clearField(3);
 
+  /// The version hash of the object to check. Possible values are: ["", "*", "#hash#"].
   @$pb.TagNumber(4)
   $core.String get version => $_getSZ(3);
   @$pb.TagNumber(4)
-  set version($core.String v) {
-    $_setString(3, v);
-  }
-
+  set version($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasVersion() => $_has(3);
   @$pb.TagNumber(4)
-  void clearVersion() => clearField(4);
+  void clearVersion() => $_clearField(4);
 
+  /// The read access permissions for the object.
   @$pb.TagNumber(5)
   $1.Int32Value get permissionRead => $_getN(4);
   @$pb.TagNumber(5)
-  set permissionRead($1.Int32Value v) {
-    setField(5, v);
-  }
-
+  set permissionRead($1.Int32Value value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasPermissionRead() => $_has(4);
   @$pb.TagNumber(5)
-  void clearPermissionRead() => clearField(5);
+  void clearPermissionRead() => $_clearField(5);
   @$pb.TagNumber(5)
   $1.Int32Value ensurePermissionRead() => $_ensure(4);
 
+  /// The write access permissions for the object.
   @$pb.TagNumber(6)
   $1.Int32Value get permissionWrite => $_getN(5);
   @$pb.TagNumber(6)
-  set permissionWrite($1.Int32Value v) {
-    setField(6, v);
-  }
-
+  set permissionWrite($1.Int32Value value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasPermissionWrite() => $_has(5);
   @$pb.TagNumber(6)
-  void clearPermissionWrite() => clearField(6);
+  void clearPermissionWrite() => $_clearField(6);
   @$pb.TagNumber(6)
   $1.Int32Value ensurePermissionWrite() => $_ensure(5);
 }
 
+/// Write objects to the storage engine.
 class WriteStorageObjectsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'WriteStorageObjectsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..pc<WriteStorageObject>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'objects',
-        $pb.PbFieldType.PM,
-        subBuilder: WriteStorageObject.create)
-    ..hasRequiredFields = false;
-
-  WriteStorageObjectsRequest._() : super();
   factory WriteStorageObjectsRequest({
     $core.Iterable<WriteStorageObject>? objects,
   }) {
-    final _result = create();
-    if (objects != null) {
-      _result.objects.addAll(objects);
-    }
-    return _result;
+    final result = create();
+    if (objects != null) result.objects.addAll(objects);
+    return result;
   }
-  factory WriteStorageObjectsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteStorageObjectsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  WriteStorageObjectsRequest clone() =>
-      WriteStorageObjectsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  WriteStorageObjectsRequest._();
+
+  factory WriteStorageObjectsRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory WriteStorageObjectsRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'WriteStorageObjectsRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<WriteStorageObject>(1, _omitFieldNames ? '' : 'objects',
+        subBuilder: WriteStorageObject.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  WriteStorageObjectsRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   WriteStorageObjectsRequest copyWith(
           void Function(WriteStorageObjectsRequest) updates) =>
       super.copyWith(
               (message) => updates(message as WriteStorageObjectsRequest))
-          as WriteStorageObjectsRequest; // ignore: deprecated_member_use
+          as WriteStorageObjectsRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static WriteStorageObjectsRequest create() => WriteStorageObjectsRequest._();
+  @$core.override
   WriteStorageObjectsRequest createEmptyInstance() => create();
   static $pb.PbList<WriteStorageObjectsRequest> createRepeated() =>
       $pb.PbList<WriteStorageObjectsRequest>();
@@ -13702,96 +10967,69 @@ class WriteStorageObjectsRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<WriteStorageObjectsRequest>(create);
   static WriteStorageObjectsRequest? _defaultInstance;
 
+  /// The objects to store on the server.
   @$pb.TagNumber(1)
-  $core.List<WriteStorageObject> get objects => $_getList(0);
+  $pb.PbList<WriteStorageObject> get objects => $_getList(0);
 }
 
+/// Record values to write.
 class WriteTournamentRecordRequest_TournamentRecordWrite
     extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'WriteTournamentRecordRequest.TournamentRecordWrite',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aInt64(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'score')
-    ..aInt64(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'subscore')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'metadata')
-    ..e<Operator>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'operator',
-        $pb.PbFieldType.OE,
-        defaultOrMaker: Operator.NO_OVERRIDE,
-        valueOf: Operator.valueOf,
-        enumValues: Operator.values)
-    ..hasRequiredFields = false;
-
-  WriteTournamentRecordRequest_TournamentRecordWrite._() : super();
   factory WriteTournamentRecordRequest_TournamentRecordWrite({
     $fixnum.Int64? score,
     $fixnum.Int64? subscore,
     $core.String? metadata,
     Operator? operator,
   }) {
-    final _result = create();
-    if (score != null) {
-      _result.score = score;
-    }
-    if (subscore != null) {
-      _result.subscore = subscore;
-    }
-    if (metadata != null) {
-      _result.metadata = metadata;
-    }
-    if (operator != null) {
-      _result.operator = operator;
-    }
-    return _result;
+    final result = create();
+    if (score != null) result.score = score;
+    if (subscore != null) result.subscore = subscore;
+    if (metadata != null) result.metadata = metadata;
+    if (operator != null) result.operator = operator;
+    return result;
   }
+
+  WriteTournamentRecordRequest_TournamentRecordWrite._();
+
   factory WriteTournamentRecordRequest_TournamentRecordWrite.fromBuffer(
-          $core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
   factory WriteTournamentRecordRequest_TournamentRecordWrite.fromJson(
-          $core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  WriteTournamentRecordRequest_TournamentRecordWrite clone() =>
-      WriteTournamentRecordRequest_TournamentRecordWrite()
-        ..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+          $core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames
+          ? ''
+          : 'WriteTournamentRecordRequest.TournamentRecordWrite',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aInt64(1, _omitFieldNames ? '' : 'score')
+    ..aInt64(2, _omitFieldNames ? '' : 'subscore')
+    ..aOS(3, _omitFieldNames ? '' : 'metadata')
+    ..aE<Operator>(4, _omitFieldNames ? '' : 'operator',
+        enumValues: Operator.values)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  WriteTournamentRecordRequest_TournamentRecordWrite clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   WriteTournamentRecordRequest_TournamentRecordWrite copyWith(
           void Function(WriteTournamentRecordRequest_TournamentRecordWrite)
               updates) =>
       super.copyWith((message) => updates(
               message as WriteTournamentRecordRequest_TournamentRecordWrite))
-          as WriteTournamentRecordRequest_TournamentRecordWrite; // ignore: deprecated_member_use
+          as WriteTournamentRecordRequest_TournamentRecordWrite;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static WriteTournamentRecordRequest_TournamentRecordWrite create() =>
       WriteTournamentRecordRequest_TournamentRecordWrite._();
+  @$core.override
   WriteTournamentRecordRequest_TournamentRecordWrite createEmptyInstance() =>
       create();
   static $pb.PbList<WriteTournamentRecordRequest_TournamentRecordWrite>
@@ -13803,115 +11041,94 @@ class WriteTournamentRecordRequest_TournamentRecordWrite
           WriteTournamentRecordRequest_TournamentRecordWrite>(create);
   static WriteTournamentRecordRequest_TournamentRecordWrite? _defaultInstance;
 
+  /// The score value to submit.
   @$pb.TagNumber(1)
   $fixnum.Int64 get score => $_getI64(0);
   @$pb.TagNumber(1)
-  set score($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set score($fixnum.Int64 value) => $_setInt64(0, value);
   @$pb.TagNumber(1)
   $core.bool hasScore() => $_has(0);
   @$pb.TagNumber(1)
-  void clearScore() => clearField(1);
+  void clearScore() => $_clearField(1);
 
+  /// An optional secondary value.
   @$pb.TagNumber(2)
   $fixnum.Int64 get subscore => $_getI64(1);
   @$pb.TagNumber(2)
-  set subscore($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set subscore($fixnum.Int64 value) => $_setInt64(1, value);
   @$pb.TagNumber(2)
   $core.bool hasSubscore() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSubscore() => clearField(2);
+  void clearSubscore() => $_clearField(2);
 
+  /// A JSON object of additional properties (optional).
   @$pb.TagNumber(3)
   $core.String get metadata => $_getSZ(2);
   @$pb.TagNumber(3)
-  set metadata($core.String v) {
-    $_setString(2, v);
-  }
-
+  set metadata($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasMetadata() => $_has(2);
   @$pb.TagNumber(3)
-  void clearMetadata() => clearField(3);
+  void clearMetadata() => $_clearField(3);
 
+  /// Operator override.
   @$pb.TagNumber(4)
   Operator get operator => $_getN(3);
   @$pb.TagNumber(4)
-  set operator(Operator v) {
-    setField(4, v);
-  }
-
+  set operator(Operator value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasOperator() => $_has(3);
   @$pb.TagNumber(4)
-  void clearOperator() => clearField(4);
+  void clearOperator() => $_clearField(4);
 }
 
+/// A request to submit a score to a tournament.
 class WriteTournamentRecordRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'WriteTournamentRecordRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.api'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'tournamentId')
-    ..aOM<WriteTournamentRecordRequest_TournamentRecordWrite>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'record',
-        subBuilder: WriteTournamentRecordRequest_TournamentRecordWrite.create)
-    ..hasRequiredFields = false;
-
-  WriteTournamentRecordRequest._() : super();
   factory WriteTournamentRecordRequest({
     $core.String? tournamentId,
     WriteTournamentRecordRequest_TournamentRecordWrite? record,
   }) {
-    final _result = create();
-    if (tournamentId != null) {
-      _result.tournamentId = tournamentId;
-    }
-    if (record != null) {
-      _result.record = record;
-    }
-    return _result;
+    final result = create();
+    if (tournamentId != null) result.tournamentId = tournamentId;
+    if (record != null) result.record = record;
+    return result;
   }
-  factory WriteTournamentRecordRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteTournamentRecordRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  WriteTournamentRecordRequest clone() =>
-      WriteTournamentRecordRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  WriteTournamentRecordRequest._();
+
+  factory WriteTournamentRecordRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory WriteTournamentRecordRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'WriteTournamentRecordRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'tournamentId')
+    ..aOM<WriteTournamentRecordRequest_TournamentRecordWrite>(
+        2, _omitFieldNames ? '' : 'record',
+        subBuilder: WriteTournamentRecordRequest_TournamentRecordWrite.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  WriteTournamentRecordRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   WriteTournamentRecordRequest copyWith(
           void Function(WriteTournamentRecordRequest) updates) =>
       super.copyWith(
               (message) => updates(message as WriteTournamentRecordRequest))
-          as WriteTournamentRecordRequest; // ignore: deprecated_member_use
+          as WriteTournamentRecordRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static WriteTournamentRecordRequest create() =>
       WriteTournamentRecordRequest._();
+  @$core.override
   WriteTournamentRecordRequest createEmptyInstance() => create();
   static $pb.PbList<WriteTournamentRecordRequest> createRepeated() =>
       $pb.PbList<WriteTournamentRecordRequest>();
@@ -13920,30 +11137,312 @@ class WriteTournamentRecordRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<WriteTournamentRecordRequest>(create);
   static WriteTournamentRecordRequest? _defaultInstance;
 
+  /// The tournament ID to write the record for.
   @$pb.TagNumber(1)
   $core.String get tournamentId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set tournamentId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set tournamentId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTournamentId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTournamentId() => clearField(1);
+  void clearTournamentId() => $_clearField(1);
 
+  /// Record input.
   @$pb.TagNumber(2)
   WriteTournamentRecordRequest_TournamentRecordWrite get record => $_getN(1);
   @$pb.TagNumber(2)
-  set record(WriteTournamentRecordRequest_TournamentRecordWrite v) {
-    setField(2, v);
-  }
-
+  set record(WriteTournamentRecordRequest_TournamentRecordWrite value) =>
+      $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasRecord() => $_has(1);
   @$pb.TagNumber(2)
-  void clearRecord() => clearField(2);
+  void clearRecord() => $_clearField(2);
   @$pb.TagNumber(2)
   WriteTournamentRecordRequest_TournamentRecordWrite ensureRecord() =>
       $_ensure(1);
 }
+
+/// A request to list parties.
+class ListPartiesRequest extends $pb.GeneratedMessage {
+  factory ListPartiesRequest({
+    $1.Int32Value? limit,
+    $1.BoolValue? open,
+    $1.StringValue? query,
+    $1.StringValue? cursor,
+  }) {
+    final result = create();
+    if (limit != null) result.limit = limit;
+    if (open != null) result.open = open;
+    if (query != null) result.query = query;
+    if (cursor != null) result.cursor = cursor;
+    return result;
+  }
+
+  ListPartiesRequest._();
+
+  factory ListPartiesRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ListPartiesRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListPartiesRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOM<$1.Int32Value>(1, _omitFieldNames ? '' : 'limit',
+        subBuilder: $1.Int32Value.create)
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'open',
+        subBuilder: $1.BoolValue.create)
+    ..aOM<$1.StringValue>(3, _omitFieldNames ? '' : 'query',
+        subBuilder: $1.StringValue.create)
+    ..aOM<$1.StringValue>(4, _omitFieldNames ? '' : 'cursor',
+        subBuilder: $1.StringValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListPartiesRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ListPartiesRequest copyWith(void Function(ListPartiesRequest) updates) =>
+      super.copyWith((message) => updates(message as ListPartiesRequest))
+          as ListPartiesRequest;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ListPartiesRequest create() => ListPartiesRequest._();
+  @$core.override
+  ListPartiesRequest createEmptyInstance() => create();
+  static $pb.PbList<ListPartiesRequest> createRepeated() =>
+      $pb.PbList<ListPartiesRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ListPartiesRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ListPartiesRequest>(create);
+  static ListPartiesRequest? _defaultInstance;
+
+  /// Limit the number of returned parties.
+  @$pb.TagNumber(1)
+  $1.Int32Value get limit => $_getN(0);
+  @$pb.TagNumber(1)
+  set limit($1.Int32Value value) => $_setField(1, value);
+  @$pb.TagNumber(1)
+  $core.bool hasLimit() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearLimit() => $_clearField(1);
+  @$pb.TagNumber(1)
+  $1.Int32Value ensureLimit() => $_ensure(0);
+
+  /// Optionally filter by open/closed parties.
+  @$pb.TagNumber(2)
+  $1.BoolValue get open => $_getN(1);
+  @$pb.TagNumber(2)
+  set open($1.BoolValue value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasOpen() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearOpen() => $_clearField(2);
+  @$pb.TagNumber(2)
+  $1.BoolValue ensureOpen() => $_ensure(1);
+
+  /// Arbitrary label query.
+  @$pb.TagNumber(3)
+  $1.StringValue get query => $_getN(2);
+  @$pb.TagNumber(3)
+  set query($1.StringValue value) => $_setField(3, value);
+  @$pb.TagNumber(3)
+  $core.bool hasQuery() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearQuery() => $_clearField(3);
+  @$pb.TagNumber(3)
+  $1.StringValue ensureQuery() => $_ensure(2);
+
+  /// Cursor for the next page of results, if any.
+  @$pb.TagNumber(4)
+  $1.StringValue get cursor => $_getN(3);
+  @$pb.TagNumber(4)
+  set cursor($1.StringValue value) => $_setField(4, value);
+  @$pb.TagNumber(4)
+  $core.bool hasCursor() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCursor() => $_clearField(4);
+  @$pb.TagNumber(4)
+  $1.StringValue ensureCursor() => $_ensure(3);
+}
+
+/// Incoming information about a party.
+class Party extends $pb.GeneratedMessage {
+  factory Party({
+    $core.String? partyId,
+    $core.bool? open,
+    $core.bool? hidden,
+    $core.int? maxSize,
+    $core.String? label,
+  }) {
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (open != null) result.open = open;
+    if (hidden != null) result.hidden = hidden;
+    if (maxSize != null) result.maxSize = maxSize;
+    if (label != null) result.label = label;
+    return result;
+  }
+
+  Party._();
+
+  factory Party.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Party.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Party',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOB(2, _omitFieldNames ? '' : 'open')
+    ..aOB(3, _omitFieldNames ? '' : 'hidden')
+    ..aI(4, _omitFieldNames ? '' : 'maxSize')
+    ..aOS(5, _omitFieldNames ? '' : 'label')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Party clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Party copyWith(void Function(Party) updates) =>
+      super.copyWith((message) => updates(message as Party)) as Party;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Party create() => Party._();
+  @$core.override
+  Party createEmptyInstance() => create();
+  static $pb.PbList<Party> createRepeated() => $pb.PbList<Party>();
+  @$core.pragma('dart2js:noInline')
+  static Party getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Party>(create);
+  static Party? _defaultInstance;
+
+  /// Unique party identifier.
+  @$pb.TagNumber(1)
+  $core.String get partyId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set partyId($core.String value) => $_setString(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasPartyId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPartyId() => $_clearField(1);
+
+  /// Open flag.
+  @$pb.TagNumber(2)
+  $core.bool get open => $_getBF(1);
+  @$pb.TagNumber(2)
+  set open($core.bool value) => $_setBool(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasOpen() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearOpen() => $_clearField(2);
+
+  /// Hidden flag.
+  @$pb.TagNumber(3)
+  $core.bool get hidden => $_getBF(2);
+  @$pb.TagNumber(3)
+  set hidden($core.bool value) => $_setBool(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasHidden() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearHidden() => $_clearField(3);
+
+  /// Maximum number of party members.
+  @$pb.TagNumber(4)
+  $core.int get maxSize => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set maxSize($core.int value) => $_setSignedInt32(3, value);
+  @$pb.TagNumber(4)
+  $core.bool hasMaxSize() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMaxSize() => $_clearField(4);
+
+  /// The party label, if any.
+  @$pb.TagNumber(5)
+  $core.String get label => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set label($core.String value) => $_setString(4, value);
+  @$pb.TagNumber(5)
+  $core.bool hasLabel() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearLabel() => $_clearField(5);
+}
+
+/// A list of realtime matches.
+class PartyList extends $pb.GeneratedMessage {
+  factory PartyList({
+    $core.Iterable<Party>? parties,
+    $core.String? cursor,
+  }) {
+    final result = create();
+    if (parties != null) result.parties.addAll(parties);
+    if (cursor != null) result.cursor = cursor;
+    return result;
+  }
+
+  PartyList._();
+
+  factory PartyList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyList',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..pPM<Party>(1, _omitFieldNames ? '' : 'parties', subBuilder: Party.create)
+    ..aOS(2, _omitFieldNames ? '' : 'cursor')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyList copyWith(void Function(PartyList) updates) =>
+      super.copyWith((message) => updates(message as PartyList)) as PartyList;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PartyList create() => PartyList._();
+  @$core.override
+  PartyList createEmptyInstance() => create();
+  static $pb.PbList<PartyList> createRepeated() => $pb.PbList<PartyList>();
+  @$core.pragma('dart2js:noInline')
+  static PartyList getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PartyList>(create);
+  static PartyList? _defaultInstance;
+
+  /// A number of parties corresponding to a list operation.
+  @$pb.TagNumber(1)
+  $pb.PbList<Party> get parties => $_getList(0);
+
+  /// A cursor to send when retrieving the next page, if any.
+  @$pb.TagNumber(2)
+  $core.String get cursor => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set cursor($core.String value) => $_setString(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasCursor() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCursor() => $_clearField(2);
+}
+
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/nakama/lib/src/api/proto/api/api.pbenum.dart
+++ b/nakama/lib/src/api/proto/api/api.pbenum.dart
@@ -1,60 +1,65 @@
-///
-//  Generated code. Do not modify.
-//  source: api/api.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from api/api.proto.
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
+
 import 'dart:core' as $core;
+
 import 'package:protobuf/protobuf.dart' as $pb;
 
+/// Validation Provider,
 class StoreProvider extends $pb.ProtobufEnum {
-  static const StoreProvider APPLE_APP_STORE = StoreProvider._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'APPLE_APP_STORE');
-  static const StoreProvider GOOGLE_PLAY_STORE = StoreProvider._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'GOOGLE_PLAY_STORE');
-  static const StoreProvider HUAWEI_APP_GALLERY = StoreProvider._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'HUAWEI_APP_GALLERY');
+  /// Apple App Store
+  static const StoreProvider APPLE_APP_STORE =
+      StoreProvider._(0, _omitEnumNames ? '' : 'APPLE_APP_STORE');
+
+  /// Google Play Store
+  static const StoreProvider GOOGLE_PLAY_STORE =
+      StoreProvider._(1, _omitEnumNames ? '' : 'GOOGLE_PLAY_STORE');
+
+  /// Huawei App Gallery
+  static const StoreProvider HUAWEI_APP_GALLERY =
+      StoreProvider._(2, _omitEnumNames ? '' : 'HUAWEI_APP_GALLERY');
+
+  /// Facebook Instant Store
+  static const StoreProvider FACEBOOK_INSTANT_STORE =
+      StoreProvider._(3, _omitEnumNames ? '' : 'FACEBOOK_INSTANT_STORE');
 
   static const $core.List<StoreProvider> values = <StoreProvider>[
     APPLE_APP_STORE,
     GOOGLE_PLAY_STORE,
     HUAWEI_APP_GALLERY,
+    FACEBOOK_INSTANT_STORE,
   ];
 
-  static final $core.Map<$core.int, StoreProvider> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
-  static StoreProvider? valueOf($core.int value) => _byValue[value];
+  static final $core.List<StoreProvider?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 3);
+  static StoreProvider? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const StoreProvider._($core.int v, $core.String n) : super(v, n);
+  const StoreProvider._(super.value, super.name);
 }
 
+/// Environment where a purchase/subscription took place,
 class StoreEnvironment extends $pb.ProtobufEnum {
-  static const StoreEnvironment UNKNOWN = StoreEnvironment._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'UNKNOWN');
-  static const StoreEnvironment SANDBOX = StoreEnvironment._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'SANDBOX');
-  static const StoreEnvironment PRODUCTION = StoreEnvironment._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'PRODUCTION');
+  /// Unknown environment.
+  static const StoreEnvironment UNKNOWN =
+      StoreEnvironment._(0, _omitEnumNames ? '' : 'UNKNOWN');
+
+  /// Sandbox/test environment.
+  static const StoreEnvironment SANDBOX =
+      StoreEnvironment._(1, _omitEnumNames ? '' : 'SANDBOX');
+
+  /// Production environment.
+  static const StoreEnvironment PRODUCTION =
+      StoreEnvironment._(2, _omitEnumNames ? '' : 'PRODUCTION');
 
   static const $core.List<StoreEnvironment> values = <StoreEnvironment>[
     UNKNOWN,
@@ -62,39 +67,33 @@ class StoreEnvironment extends $pb.ProtobufEnum {
     PRODUCTION,
   ];
 
-  static final $core.Map<$core.int, StoreEnvironment> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
-  static StoreEnvironment? valueOf($core.int value) => _byValue[value];
+  static final $core.List<StoreEnvironment?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 2);
+  static StoreEnvironment? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const StoreEnvironment._($core.int v, $core.String n) : super(v, n);
+  const StoreEnvironment._(super.value, super.name);
 }
 
+/// Operator that can be used to override the one set in the leaderboard.
 class Operator extends $pb.ProtobufEnum {
-  static const Operator NO_OVERRIDE = Operator._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'NO_OVERRIDE');
-  static const Operator BEST = Operator._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'BEST');
-  static const Operator SET = Operator._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'SET');
-  static const Operator INCREMENT = Operator._(
-      3,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'INCREMENT');
-  static const Operator DECREMENT = Operator._(
-      4,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'DECREMENT');
+  /// Do not override the leaderboard operator.
+  static const Operator NO_OVERRIDE =
+      Operator._(0, _omitEnumNames ? '' : 'NO_OVERRIDE');
+
+  /// Override the leaderboard operator with BEST.
+  static const Operator BEST = Operator._(1, _omitEnumNames ? '' : 'BEST');
+
+  /// Override the leaderboard operator with SET.
+  static const Operator SET = Operator._(2, _omitEnumNames ? '' : 'SET');
+
+  /// Override the leaderboard operator with INCREMENT.
+  static const Operator INCREMENT =
+      Operator._(3, _omitEnumNames ? '' : 'INCREMENT');
+
+  /// Override the leaderboard operator with DECREMENT.
+  static const Operator DECREMENT =
+      Operator._(4, _omitEnumNames ? '' : 'DECREMENT');
 
   static const $core.List<Operator> values = <Operator>[
     NO_OVERRIDE,
@@ -104,34 +103,31 @@ class Operator extends $pb.ProtobufEnum {
     DECREMENT,
   ];
 
-  static final $core.Map<$core.int, Operator> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
-  static Operator? valueOf($core.int value) => _byValue[value];
+  static final $core.List<Operator?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 4);
+  static Operator? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const Operator._($core.int v, $core.String n) : super(v, n);
+  const Operator._(super.value, super.name);
 }
 
+/// The friendship status.
 class Friend_State extends $pb.ProtobufEnum {
-  static const Friend_State FRIEND = Friend_State._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'FRIEND');
-  static const Friend_State INVITE_SENT = Friend_State._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'INVITE_SENT');
-  static const Friend_State INVITE_RECEIVED = Friend_State._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'INVITE_RECEIVED');
-  static const Friend_State BLOCKED = Friend_State._(
-      3,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'BLOCKED');
+  /// The user is a friend of the current user.
+  static const Friend_State FRIEND =
+      Friend_State._(0, _omitEnumNames ? '' : 'FRIEND');
+
+  /// The current user has sent an invite to the user.
+  static const Friend_State INVITE_SENT =
+      Friend_State._(1, _omitEnumNames ? '' : 'INVITE_SENT');
+
+  /// The current user has received an invite from this user.
+  static const Friend_State INVITE_RECEIVED =
+      Friend_State._(2, _omitEnumNames ? '' : 'INVITE_RECEIVED');
+
+  /// The current user has blocked this user.
+  static const Friend_State BLOCKED =
+      Friend_State._(3, _omitEnumNames ? '' : 'BLOCKED');
 
   static const $core.List<Friend_State> values = <Friend_State>[
     FRIEND,
@@ -140,38 +136,31 @@ class Friend_State extends $pb.ProtobufEnum {
     BLOCKED,
   ];
 
-  static final $core.Map<$core.int, Friend_State> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
-  static Friend_State? valueOf($core.int value) => _byValue[value];
+  static final $core.List<Friend_State?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 3);
+  static Friend_State? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const Friend_State._($core.int v, $core.String n) : super(v, n);
+  const Friend_State._(super.value, super.name);
 }
 
+/// The group role status.
 class GroupUserList_GroupUser_State extends $pb.ProtobufEnum {
+  /// The user is a superadmin with full control of the group.
   static const GroupUserList_GroupUser_State SUPERADMIN =
-      GroupUserList_GroupUser_State._(
-          0,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'SUPERADMIN');
+      GroupUserList_GroupUser_State._(0, _omitEnumNames ? '' : 'SUPERADMIN');
+
+  /// The user is an admin with additional privileges.
   static const GroupUserList_GroupUser_State ADMIN =
-      GroupUserList_GroupUser_State._(
-          1,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'ADMIN');
+      GroupUserList_GroupUser_State._(1, _omitEnumNames ? '' : 'ADMIN');
+
+  /// The user is a regular member.
   static const GroupUserList_GroupUser_State MEMBER =
-      GroupUserList_GroupUser_State._(
-          2,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'MEMBER');
+      GroupUserList_GroupUser_State._(2, _omitEnumNames ? '' : 'MEMBER');
+
+  /// The user has requested to join the group
   static const GroupUserList_GroupUser_State JOIN_REQUEST =
-      GroupUserList_GroupUser_State._(
-          3,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'JOIN_REQUEST');
+      GroupUserList_GroupUser_State._(3, _omitEnumNames ? '' : 'JOIN_REQUEST');
 
   static const $core.List<GroupUserList_GroupUser_State> values =
       <GroupUserList_GroupUser_State>[
@@ -181,40 +170,31 @@ class GroupUserList_GroupUser_State extends $pb.ProtobufEnum {
     JOIN_REQUEST,
   ];
 
-  static final $core.Map<$core.int, GroupUserList_GroupUser_State> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.List<GroupUserList_GroupUser_State?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 3);
   static GroupUserList_GroupUser_State? valueOf($core.int value) =>
-      _byValue[value];
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const GroupUserList_GroupUser_State._($core.int v, $core.String n)
-      : super(v, n);
+  const GroupUserList_GroupUser_State._(super.value, super.name);
 }
 
+/// The group role status.
 class UserGroupList_UserGroup_State extends $pb.ProtobufEnum {
+  /// The user is a superadmin with full control of the group.
   static const UserGroupList_UserGroup_State SUPERADMIN =
-      UserGroupList_UserGroup_State._(
-          0,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'SUPERADMIN');
+      UserGroupList_UserGroup_State._(0, _omitEnumNames ? '' : 'SUPERADMIN');
+
+  /// The user is an admin with additional privileges.
   static const UserGroupList_UserGroup_State ADMIN =
-      UserGroupList_UserGroup_State._(
-          1,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'ADMIN');
+      UserGroupList_UserGroup_State._(1, _omitEnumNames ? '' : 'ADMIN');
+
+  /// The user is a regular member.
   static const UserGroupList_UserGroup_State MEMBER =
-      UserGroupList_UserGroup_State._(
-          2,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'MEMBER');
+      UserGroupList_UserGroup_State._(2, _omitEnumNames ? '' : 'MEMBER');
+
+  /// The user has requested to join the group
   static const UserGroupList_UserGroup_State JOIN_REQUEST =
-      UserGroupList_UserGroup_State._(
-          3,
-          const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-              ? ''
-              : 'JOIN_REQUEST');
+      UserGroupList_UserGroup_State._(3, _omitEnumNames ? '' : 'JOIN_REQUEST');
 
   static const $core.List<UserGroupList_UserGroup_State> values =
       <UserGroupList_UserGroup_State>[
@@ -224,11 +204,13 @@ class UserGroupList_UserGroup_State extends $pb.ProtobufEnum {
     JOIN_REQUEST,
   ];
 
-  static final $core.Map<$core.int, UserGroupList_UserGroup_State> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.List<UserGroupList_UserGroup_State?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 3);
   static UserGroupList_UserGroup_State? valueOf($core.int value) =>
-      _byValue[value];
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const UserGroupList_UserGroup_State._($core.int v, $core.String n)
-      : super(v, n);
+  const UserGroupList_UserGroup_State._(super.value, super.name);
 }
+
+const $core.bool _omitEnumNames =
+    $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/nakama/lib/src/api/proto/api/api.pbjson.dart
+++ b/nakama/lib/src/api/proto/api/api.pbjson.dart
@@ -1,60 +1,72 @@
-///
-//  Generated code. Do not modify.
-//  source: api/api.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from api/api.proto.
 
-import 'dart:core' as $core;
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 
 @$core.Deprecated('Use storeProviderDescriptor instead')
-const StoreProvider$json = const {
+const StoreProvider$json = {
   '1': 'StoreProvider',
-  '2': const [
-    const {'1': 'APPLE_APP_STORE', '2': 0},
-    const {'1': 'GOOGLE_PLAY_STORE', '2': 1},
-    const {'1': 'HUAWEI_APP_GALLERY', '2': 2},
+  '2': [
+    {'1': 'APPLE_APP_STORE', '2': 0},
+    {'1': 'GOOGLE_PLAY_STORE', '2': 1},
+    {'1': 'HUAWEI_APP_GALLERY', '2': 2},
+    {'1': 'FACEBOOK_INSTANT_STORE', '2': 3},
   ],
 };
 
 /// Descriptor for `StoreProvider`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List storeProviderDescriptor = $convert.base64Decode(
-    'Cg1TdG9yZVByb3ZpZGVyEhMKD0FQUExFX0FQUF9TVE9SRRAAEhUKEUdPT0dMRV9QTEFZX1NUT1JFEAESFgoSSFVBV0VJX0FQUF9HQUxMRVJZEAI=');
+    'Cg1TdG9yZVByb3ZpZGVyEhMKD0FQUExFX0FQUF9TVE9SRRAAEhUKEUdPT0dMRV9QTEFZX1NUT1'
+    'JFEAESFgoSSFVBV0VJX0FQUF9HQUxMRVJZEAISGgoWRkFDRUJPT0tfSU5TVEFOVF9TVE9SRRAD');
+
 @$core.Deprecated('Use storeEnvironmentDescriptor instead')
-const StoreEnvironment$json = const {
+const StoreEnvironment$json = {
   '1': 'StoreEnvironment',
-  '2': const [
-    const {'1': 'UNKNOWN', '2': 0},
-    const {'1': 'SANDBOX', '2': 1},
-    const {'1': 'PRODUCTION', '2': 2},
+  '2': [
+    {'1': 'UNKNOWN', '2': 0},
+    {'1': 'SANDBOX', '2': 1},
+    {'1': 'PRODUCTION', '2': 2},
   ],
 };
 
 /// Descriptor for `StoreEnvironment`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List storeEnvironmentDescriptor = $convert.base64Decode(
-    'ChBTdG9yZUVudmlyb25tZW50EgsKB1VOS05PV04QABILCgdTQU5EQk9YEAESDgoKUFJPRFVDVElPThAC');
+    'ChBTdG9yZUVudmlyb25tZW50EgsKB1VOS05PV04QABILCgdTQU5EQk9YEAESDgoKUFJPRFVDVE'
+    'lPThAC');
+
 @$core.Deprecated('Use operatorDescriptor instead')
-const Operator$json = const {
+const Operator$json = {
   '1': 'Operator',
-  '2': const [
-    const {'1': 'NO_OVERRIDE', '2': 0},
-    const {'1': 'BEST', '2': 1},
-    const {'1': 'SET', '2': 2},
-    const {'1': 'INCREMENT', '2': 3},
-    const {'1': 'DECREMENT', '2': 4},
+  '2': [
+    {'1': 'NO_OVERRIDE', '2': 0},
+    {'1': 'BEST', '2': 1},
+    {'1': 'SET', '2': 2},
+    {'1': 'INCREMENT', '2': 3},
+    {'1': 'DECREMENT', '2': 4},
   ],
 };
 
 /// Descriptor for `Operator`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List operatorDescriptor = $convert.base64Decode(
-    'CghPcGVyYXRvchIPCgtOT19PVkVSUklERRAAEggKBEJFU1QQARIHCgNTRVQQAhINCglJTkNSRU1FTlQQAxINCglERUNSRU1FTlQQBA==');
+    'CghPcGVyYXRvchIPCgtOT19PVkVSUklERRAAEggKBEJFU1QQARIHCgNTRVQQAhINCglJTkNSRU'
+    '1FTlQQAxINCglERUNSRU1FTlQQBA==');
+
 @$core.Deprecated('Use accountDescriptor instead')
-const Account$json = const {
+const Account$json = {
   '1': 'Account',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'user',
       '3': 1,
       '4': 1,
@@ -62,9 +74,9 @@ const Account$json = const {
       '6': '.nakama.api.User',
       '10': 'user'
     },
-    const {'1': 'wallet', '3': 2, '4': 1, '5': 9, '10': 'wallet'},
-    const {'1': 'email', '3': 3, '4': 1, '5': 9, '10': 'email'},
-    const {
+    {'1': 'wallet', '3': 2, '4': 1, '5': 9, '10': 'wallet'},
+    {'1': 'email', '3': 3, '4': 1, '5': 9, '10': 'email'},
+    {
       '1': 'devices',
       '3': 4,
       '4': 3,
@@ -72,8 +84,8 @@ const Account$json = const {
       '6': '.nakama.api.AccountDevice',
       '10': 'devices'
     },
-    const {'1': 'custom_id', '3': 5, '4': 1, '5': 9, '10': 'customId'},
-    const {
+    {'1': 'custom_id', '3': 5, '4': 1, '5': 9, '10': 'customId'},
+    {
       '1': 'verify_time',
       '3': 6,
       '4': 1,
@@ -81,7 +93,7 @@ const Account$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'verifyTime'
     },
-    const {
+    {
       '1': 'disable_time',
       '3': 7,
       '4': 1,
@@ -94,13 +106,19 @@ const Account$json = const {
 
 /// Descriptor for `Account`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountDescriptor = $convert.base64Decode(
-    'CgdBY2NvdW50EiQKBHVzZXIYASABKAsyEC5uYWthbWEuYXBpLlVzZXJSBHVzZXISFgoGd2FsbGV0GAIgASgJUgZ3YWxsZXQSFAoFZW1haWwYAyABKAlSBWVtYWlsEjMKB2RldmljZXMYBCADKAsyGS5uYWthbWEuYXBpLkFjY291bnREZXZpY2VSB2RldmljZXMSGwoJY3VzdG9tX2lkGAUgASgJUghjdXN0b21JZBI7Cgt2ZXJpZnlfdGltZRgGIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnZlcmlmeVRpbWUSPQoMZGlzYWJsZV90aW1lGAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFILZGlzYWJsZVRpbWU=');
+    'CgdBY2NvdW50EiQKBHVzZXIYASABKAsyEC5uYWthbWEuYXBpLlVzZXJSBHVzZXISFgoGd2FsbG'
+    'V0GAIgASgJUgZ3YWxsZXQSFAoFZW1haWwYAyABKAlSBWVtYWlsEjMKB2RldmljZXMYBCADKAsy'
+    'GS5uYWthbWEuYXBpLkFjY291bnREZXZpY2VSB2RldmljZXMSGwoJY3VzdG9tX2lkGAUgASgJUg'
+    'hjdXN0b21JZBI7Cgt2ZXJpZnlfdGltZRgGIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3Rh'
+    'bXBSCnZlcmlmeVRpbWUSPQoMZGlzYWJsZV90aW1lGAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLl'
+    'RpbWVzdGFtcFILZGlzYWJsZVRpbWU=');
+
 @$core.Deprecated('Use accountRefreshDescriptor instead')
-const AccountRefresh$json = const {
+const AccountRefresh$json = {
   '1': 'AccountRefresh',
-  '2': const [
-    const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
-    const {
+  '2': [
+    {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -109,28 +127,31 @@ const AccountRefresh$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountRefresh_VarsEntry$json],
+  '3': [AccountRefresh_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountRefreshDescriptor instead')
-const AccountRefresh_VarsEntry$json = const {
+const AccountRefresh_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountRefresh`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountRefreshDescriptor = $convert.base64Decode(
-    'Cg5BY2NvdW50UmVmcmVzaBIUCgV0b2tlbhgBIAEoCVIFdG9rZW4SOAoEdmFycxgCIAMoCzIkLm5ha2FtYS5hcGkuQWNjb3VudFJlZnJlc2guVmFyc0VudHJ5UgR2YXJzGjcKCVZhcnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+    'Cg5BY2NvdW50UmVmcmVzaBIUCgV0b2tlbhgBIAEoCVIFdG9rZW4SOAoEdmFycxgCIAMoCzIkLm'
+    '5ha2FtYS5hcGkuQWNjb3VudFJlZnJlc2guVmFyc0VudHJ5UgR2YXJzGjcKCVZhcnNFbnRyeRIQ'
+    'CgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+
 @$core.Deprecated('Use accountAppleDescriptor instead')
-const AccountApple$json = const {
+const AccountApple$json = {
   '1': 'AccountApple',
-  '2': const [
-    const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
-    const {
+  '2': [
+    {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -139,28 +160,31 @@ const AccountApple$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountApple_VarsEntry$json],
+  '3': [AccountApple_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountAppleDescriptor instead')
-const AccountApple_VarsEntry$json = const {
+const AccountApple_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountApple`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountAppleDescriptor = $convert.base64Decode(
-    'CgxBY2NvdW50QXBwbGUSFAoFdG9rZW4YASABKAlSBXRva2VuEjYKBHZhcnMYAiADKAsyIi5uYWthbWEuYXBpLkFjY291bnRBcHBsZS5WYXJzRW50cnlSBHZhcnMaNwoJVmFyc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+    'CgxBY2NvdW50QXBwbGUSFAoFdG9rZW4YASABKAlSBXRva2VuEjYKBHZhcnMYAiADKAsyIi5uYW'
+    'thbWEuYXBpLkFjY291bnRBcHBsZS5WYXJzRW50cnlSBHZhcnMaNwoJVmFyc0VudHJ5EhAKA2tl'
+    'eRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+
 @$core.Deprecated('Use accountCustomDescriptor instead')
-const AccountCustom$json = const {
+const AccountCustom$json = {
   '1': 'AccountCustom',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -169,28 +193,31 @@ const AccountCustom$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountCustom_VarsEntry$json],
+  '3': [AccountCustom_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountCustomDescriptor instead')
-const AccountCustom_VarsEntry$json = const {
+const AccountCustom_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountCustom`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountCustomDescriptor = $convert.base64Decode(
-    'Cg1BY2NvdW50Q3VzdG9tEg4KAmlkGAEgASgJUgJpZBI3CgR2YXJzGAIgAygLMiMubmFrYW1hLmFwaS5BY2NvdW50Q3VzdG9tLlZhcnNFbnRyeVIEdmFycxo3CglWYXJzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+    'Cg1BY2NvdW50Q3VzdG9tEg4KAmlkGAEgASgJUgJpZBI3CgR2YXJzGAIgAygLMiMubmFrYW1hLm'
+    'FwaS5BY2NvdW50Q3VzdG9tLlZhcnNFbnRyeVIEdmFycxo3CglWYXJzRW50cnkSEAoDa2V5GAEg'
+    'ASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+
 @$core.Deprecated('Use accountDeviceDescriptor instead')
-const AccountDevice$json = const {
+const AccountDevice$json = {
   '1': 'AccountDevice',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -199,29 +226,32 @@ const AccountDevice$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountDevice_VarsEntry$json],
+  '3': [AccountDevice_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountDeviceDescriptor instead')
-const AccountDevice_VarsEntry$json = const {
+const AccountDevice_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountDevice`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountDeviceDescriptor = $convert.base64Decode(
-    'Cg1BY2NvdW50RGV2aWNlEg4KAmlkGAEgASgJUgJpZBI3CgR2YXJzGAIgAygLMiMubmFrYW1hLmFwaS5BY2NvdW50RGV2aWNlLlZhcnNFbnRyeVIEdmFycxo3CglWYXJzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+    'Cg1BY2NvdW50RGV2aWNlEg4KAmlkGAEgASgJUgJpZBI3CgR2YXJzGAIgAygLMiMubmFrYW1hLm'
+    'FwaS5BY2NvdW50RGV2aWNlLlZhcnNFbnRyeVIEdmFycxo3CglWYXJzRW50cnkSEAoDa2V5GAEg'
+    'ASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+
 @$core.Deprecated('Use accountEmailDescriptor instead')
-const AccountEmail$json = const {
+const AccountEmail$json = {
   '1': 'AccountEmail',
-  '2': const [
-    const {'1': 'email', '3': 1, '4': 1, '5': 9, '10': 'email'},
-    const {'1': 'password', '3': 2, '4': 1, '5': 9, '10': 'password'},
-    const {
+  '2': [
+    {'1': 'email', '3': 1, '4': 1, '5': 9, '10': 'email'},
+    {'1': 'password', '3': 2, '4': 1, '5': 9, '10': 'password'},
+    {
       '1': 'vars',
       '3': 3,
       '4': 3,
@@ -230,28 +260,32 @@ const AccountEmail$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountEmail_VarsEntry$json],
+  '3': [AccountEmail_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountEmailDescriptor instead')
-const AccountEmail_VarsEntry$json = const {
+const AccountEmail_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountEmail`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountEmailDescriptor = $convert.base64Decode(
-    'CgxBY2NvdW50RW1haWwSFAoFZW1haWwYASABKAlSBWVtYWlsEhoKCHBhc3N3b3JkGAIgASgJUghwYXNzd29yZBI2CgR2YXJzGAMgAygLMiIubmFrYW1hLmFwaS5BY2NvdW50RW1haWwuVmFyc0VudHJ5UgR2YXJzGjcKCVZhcnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+    'CgxBY2NvdW50RW1haWwSFAoFZW1haWwYASABKAlSBWVtYWlsEhoKCHBhc3N3b3JkGAIgASgJUg'
+    'hwYXNzd29yZBI2CgR2YXJzGAMgAygLMiIubmFrYW1hLmFwaS5BY2NvdW50RW1haWwuVmFyc0Vu'
+    'dHJ5UgR2YXJzGjcKCVZhcnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCV'
+    'IFdmFsdWU6AjgB');
+
 @$core.Deprecated('Use accountFacebookDescriptor instead')
-const AccountFacebook$json = const {
+const AccountFacebook$json = {
   '1': 'AccountFacebook',
-  '2': const [
-    const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
-    const {
+  '2': [
+    {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -260,34 +294,37 @@ const AccountFacebook$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountFacebook_VarsEntry$json],
+  '3': [AccountFacebook_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountFacebookDescriptor instead')
-const AccountFacebook_VarsEntry$json = const {
+const AccountFacebook_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountFacebook`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountFacebookDescriptor = $convert.base64Decode(
-    'Cg9BY2NvdW50RmFjZWJvb2sSFAoFdG9rZW4YASABKAlSBXRva2VuEjkKBHZhcnMYAiADKAsyJS5uYWthbWEuYXBpLkFjY291bnRGYWNlYm9vay5WYXJzRW50cnlSBHZhcnMaNwoJVmFyc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+    'Cg9BY2NvdW50RmFjZWJvb2sSFAoFdG9rZW4YASABKAlSBXRva2VuEjkKBHZhcnMYAiADKAsyJS'
+    '5uYWthbWEuYXBpLkFjY291bnRGYWNlYm9vay5WYXJzRW50cnlSBHZhcnMaNwoJVmFyc0VudHJ5'
+    'EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+
 @$core.Deprecated('Use accountFacebookInstantGameDescriptor instead')
-const AccountFacebookInstantGame$json = const {
+const AccountFacebookInstantGame$json = {
   '1': 'AccountFacebookInstantGame',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'signed_player_info',
       '3': 1,
       '4': 1,
       '5': 9,
       '10': 'signedPlayerInfo'
     },
-    const {
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -296,40 +333,43 @@ const AccountFacebookInstantGame$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountFacebookInstantGame_VarsEntry$json],
+  '3': [AccountFacebookInstantGame_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountFacebookInstantGameDescriptor instead')
-const AccountFacebookInstantGame_VarsEntry$json = const {
+const AccountFacebookInstantGame_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountFacebookInstantGame`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List accountFacebookInstantGameDescriptor =
-    $convert.base64Decode(
-        'ChpBY2NvdW50RmFjZWJvb2tJbnN0YW50R2FtZRIsChJzaWduZWRfcGxheWVyX2luZm8YASABKAlSEHNpZ25lZFBsYXllckluZm8SRAoEdmFycxgCIAMoCzIwLm5ha2FtYS5hcGkuQWNjb3VudEZhY2Vib29rSW5zdGFudEdhbWUuVmFyc0VudHJ5UgR2YXJzGjcKCVZhcnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+final $typed_data.Uint8List accountFacebookInstantGameDescriptor = $convert.base64Decode(
+    'ChpBY2NvdW50RmFjZWJvb2tJbnN0YW50R2FtZRIsChJzaWduZWRfcGxheWVyX2luZm8YASABKA'
+    'lSEHNpZ25lZFBsYXllckluZm8SRAoEdmFycxgCIAMoCzIwLm5ha2FtYS5hcGkuQWNjb3VudEZh'
+    'Y2Vib29rSW5zdGFudEdhbWUuVmFyc0VudHJ5UgR2YXJzGjcKCVZhcnNFbnRyeRIQCgNrZXkYAS'
+    'ABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+
 @$core.Deprecated('Use accountGameCenterDescriptor instead')
-const AccountGameCenter$json = const {
+const AccountGameCenter$json = {
   '1': 'AccountGameCenter',
-  '2': const [
-    const {'1': 'player_id', '3': 1, '4': 1, '5': 9, '10': 'playerId'},
-    const {'1': 'bundle_id', '3': 2, '4': 1, '5': 9, '10': 'bundleId'},
-    const {
+  '2': [
+    {'1': 'player_id', '3': 1, '4': 1, '5': 9, '10': 'playerId'},
+    {'1': 'bundle_id', '3': 2, '4': 1, '5': 9, '10': 'bundleId'},
+    {
       '1': 'timestamp_seconds',
       '3': 3,
       '4': 1,
       '5': 3,
       '10': 'timestampSeconds'
     },
-    const {'1': 'salt', '3': 4, '4': 1, '5': 9, '10': 'salt'},
-    const {'1': 'signature', '3': 5, '4': 1, '5': 9, '10': 'signature'},
-    const {'1': 'public_key_url', '3': 6, '4': 1, '5': 9, '10': 'publicKeyUrl'},
-    const {
+    {'1': 'salt', '3': 4, '4': 1, '5': 9, '10': 'salt'},
+    {'1': 'signature', '3': 5, '4': 1, '5': 9, '10': 'signature'},
+    {'1': 'public_key_url', '3': 6, '4': 1, '5': 9, '10': 'publicKeyUrl'},
+    {
       '1': 'vars',
       '3': 7,
       '4': 3,
@@ -338,28 +378,34 @@ const AccountGameCenter$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountGameCenter_VarsEntry$json],
+  '3': [AccountGameCenter_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountGameCenterDescriptor instead')
-const AccountGameCenter_VarsEntry$json = const {
+const AccountGameCenter_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountGameCenter`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountGameCenterDescriptor = $convert.base64Decode(
-    'ChFBY2NvdW50R2FtZUNlbnRlchIbCglwbGF5ZXJfaWQYASABKAlSCHBsYXllcklkEhsKCWJ1bmRsZV9pZBgCIAEoCVIIYnVuZGxlSWQSKwoRdGltZXN0YW1wX3NlY29uZHMYAyABKANSEHRpbWVzdGFtcFNlY29uZHMSEgoEc2FsdBgEIAEoCVIEc2FsdBIcCglzaWduYXR1cmUYBSABKAlSCXNpZ25hdHVyZRIkCg5wdWJsaWNfa2V5X3VybBgGIAEoCVIMcHVibGljS2V5VXJsEjsKBHZhcnMYByADKAsyJy5uYWthbWEuYXBpLkFjY291bnRHYW1lQ2VudGVyLlZhcnNFbnRyeVIEdmFycxo3CglWYXJzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+    'ChFBY2NvdW50R2FtZUNlbnRlchIbCglwbGF5ZXJfaWQYASABKAlSCHBsYXllcklkEhsKCWJ1bm'
+    'RsZV9pZBgCIAEoCVIIYnVuZGxlSWQSKwoRdGltZXN0YW1wX3NlY29uZHMYAyABKANSEHRpbWVz'
+    'dGFtcFNlY29uZHMSEgoEc2FsdBgEIAEoCVIEc2FsdBIcCglzaWduYXR1cmUYBSABKAlSCXNpZ2'
+    '5hdHVyZRIkCg5wdWJsaWNfa2V5X3VybBgGIAEoCVIMcHVibGljS2V5VXJsEjsKBHZhcnMYByAD'
+    'KAsyJy5uYWthbWEuYXBpLkFjY291bnRHYW1lQ2VudGVyLlZhcnNFbnRyeVIEdmFycxo3CglWYX'
+    'JzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+
 @$core.Deprecated('Use accountGoogleDescriptor instead')
-const AccountGoogle$json = const {
+const AccountGoogle$json = {
   '1': 'AccountGoogle',
-  '2': const [
-    const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
-    const {
+  '2': [
+    {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -368,28 +414,31 @@ const AccountGoogle$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountGoogle_VarsEntry$json],
+  '3': [AccountGoogle_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountGoogleDescriptor instead')
-const AccountGoogle_VarsEntry$json = const {
+const AccountGoogle_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountGoogle`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountGoogleDescriptor = $convert.base64Decode(
-    'Cg1BY2NvdW50R29vZ2xlEhQKBXRva2VuGAEgASgJUgV0b2tlbhI3CgR2YXJzGAIgAygLMiMubmFrYW1hLmFwaS5BY2NvdW50R29vZ2xlLlZhcnNFbnRyeVIEdmFycxo3CglWYXJzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+    'Cg1BY2NvdW50R29vZ2xlEhQKBXRva2VuGAEgASgJUgV0b2tlbhI3CgR2YXJzGAIgAygLMiMubm'
+    'FrYW1hLmFwaS5BY2NvdW50R29vZ2xlLlZhcnNFbnRyeVIEdmFycxo3CglWYXJzRW50cnkSEAoD'
+    'a2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+
 @$core.Deprecated('Use accountSteamDescriptor instead')
-const AccountSteam$json = const {
+const AccountSteam$json = {
   '1': 'AccountSteam',
-  '2': const [
-    const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
-    const {
+  '2': [
+    {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -398,52 +447,60 @@ const AccountSteam$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [AccountSteam_VarsEntry$json],
+  '3': [AccountSteam_VarsEntry$json],
 };
 
 @$core.Deprecated('Use accountSteamDescriptor instead')
-const AccountSteam_VarsEntry$json = const {
+const AccountSteam_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `AccountSteam`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List accountSteamDescriptor = $convert.base64Decode(
-    'CgxBY2NvdW50U3RlYW0SFAoFdG9rZW4YASABKAlSBXRva2VuEjYKBHZhcnMYAiADKAsyIi5uYWthbWEuYXBpLkFjY291bnRTdGVhbS5WYXJzRW50cnlSBHZhcnMaNwoJVmFyc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+    'CgxBY2NvdW50U3RlYW0SFAoFdG9rZW4YASABKAlSBXRva2VuEjYKBHZhcnMYAiADKAsyIi5uYW'
+    'thbWEuYXBpLkFjY291bnRTdGVhbS5WYXJzRW50cnlSBHZhcnMaNwoJVmFyc0VudHJ5EhAKA2tl'
+    'eRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+
 @$core.Deprecated('Use addFriendsRequestDescriptor instead')
-const AddFriendsRequest$json = const {
+const AddFriendsRequest$json = {
   '1': 'AddFriendsRequest',
-  '2': const [
-    const {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
-    const {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
+  '2': [
+    {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
+    {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
+    {'1': 'metadata', '3': 3, '4': 1, '5': 9, '10': 'metadata'},
   ],
 };
 
 /// Descriptor for `AddFriendsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List addFriendsRequestDescriptor = $convert.base64Decode(
-    'ChFBZGRGcmllbmRzUmVxdWVzdBIQCgNpZHMYASADKAlSA2lkcxIcCgl1c2VybmFtZXMYAiADKAlSCXVzZXJuYW1lcw==');
+    'ChFBZGRGcmllbmRzUmVxdWVzdBIQCgNpZHMYASADKAlSA2lkcxIcCgl1c2VybmFtZXMYAiADKA'
+    'lSCXVzZXJuYW1lcxIaCghtZXRhZGF0YRgDIAEoCVIIbWV0YWRhdGE=');
+
 @$core.Deprecated('Use addGroupUsersRequestDescriptor instead')
-const AddGroupUsersRequest$json = const {
+const AddGroupUsersRequest$json = {
   '1': 'AddGroupUsersRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
   ],
 };
 
 /// Descriptor for `AddGroupUsersRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List addGroupUsersRequestDescriptor = $convert.base64Decode(
-    'ChRBZGRHcm91cFVzZXJzUmVxdWVzdBIZCghncm91cF9pZBgBIAEoCVIHZ3JvdXBJZBIZCgh1c2VyX2lkcxgCIAMoCVIHdXNlcklkcw==');
+    'ChRBZGRHcm91cFVzZXJzUmVxdWVzdBIZCghncm91cF9pZBgBIAEoCVIHZ3JvdXBJZBIZCgh1c2'
+    'VyX2lkcxgCIAMoCVIHdXNlcklkcw==');
+
 @$core.Deprecated('Use sessionRefreshRequestDescriptor instead')
-const SessionRefreshRequest$json = const {
+const SessionRefreshRequest$json = {
   '1': 'SessionRefreshRequest',
-  '2': const [
-    const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
-    const {
+  '2': [
+    {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
+    {
       '1': 'vars',
       '3': 2,
       '4': 3,
@@ -452,39 +509,45 @@ const SessionRefreshRequest$json = const {
       '10': 'vars'
     },
   ],
-  '3': const [SessionRefreshRequest_VarsEntry$json],
+  '3': [SessionRefreshRequest_VarsEntry$json],
 };
 
 @$core.Deprecated('Use sessionRefreshRequestDescriptor instead')
-const SessionRefreshRequest_VarsEntry$json = const {
+const SessionRefreshRequest_VarsEntry$json = {
   '1': 'VarsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `SessionRefreshRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List sessionRefreshRequestDescriptor = $convert.base64Decode(
-    'ChVTZXNzaW9uUmVmcmVzaFJlcXVlc3QSFAoFdG9rZW4YASABKAlSBXRva2VuEj8KBHZhcnMYAiADKAsyKy5uYWthbWEuYXBpLlNlc3Npb25SZWZyZXNoUmVxdWVzdC5WYXJzRW50cnlSBHZhcnMaNwoJVmFyc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+    'ChVTZXNzaW9uUmVmcmVzaFJlcXVlc3QSFAoFdG9rZW4YASABKAlSBXRva2VuEj8KBHZhcnMYAi'
+    'ADKAsyKy5uYWthbWEuYXBpLlNlc3Npb25SZWZyZXNoUmVxdWVzdC5WYXJzRW50cnlSBHZhcnMa'
+    'NwoJVmFyc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOA'
+    'E=');
+
 @$core.Deprecated('Use sessionLogoutRequestDescriptor instead')
-const SessionLogoutRequest$json = const {
+const SessionLogoutRequest$json = {
   '1': 'SessionLogoutRequest',
-  '2': const [
-    const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
-    const {'1': 'refresh_token', '3': 2, '4': 1, '5': 9, '10': 'refreshToken'},
+  '2': [
+    {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
+    {'1': 'refresh_token', '3': 2, '4': 1, '5': 9, '10': 'refreshToken'},
   ],
 };
 
 /// Descriptor for `SessionLogoutRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List sessionLogoutRequestDescriptor = $convert.base64Decode(
-    'ChRTZXNzaW9uTG9nb3V0UmVxdWVzdBIUCgV0b2tlbhgBIAEoCVIFdG9rZW4SIwoNcmVmcmVzaF90b2tlbhgCIAEoCVIMcmVmcmVzaFRva2Vu');
+    'ChRTZXNzaW9uTG9nb3V0UmVxdWVzdBIUCgV0b2tlbhgBIAEoCVIFdG9rZW4SIwoNcmVmcmVzaF'
+    '90b2tlbhgCIAEoCVIMcmVmcmVzaFRva2Vu');
+
 @$core.Deprecated('Use authenticateAppleRequestDescriptor instead')
-const AuthenticateAppleRequest$json = const {
+const AuthenticateAppleRequest$json = {
   '1': 'AuthenticateAppleRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -492,7 +555,7 @@ const AuthenticateAppleRequest$json = const {
       '6': '.nakama.api.AccountApple',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -500,19 +563,21 @@ const AuthenticateAppleRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
   ],
 };
 
 /// Descriptor for `AuthenticateAppleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List authenticateAppleRequestDescriptor =
-    $convert.base64Decode(
-        'ChhBdXRoZW50aWNhdGVBcHBsZVJlcXVlc3QSMgoHYWNjb3VudBgBIAEoCzIYLm5ha2FtYS5hcGkuQWNjb3VudEFwcGxlUgdhY2NvdW50EjIKBmNyZWF0ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBmNyZWF0ZRIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWU=');
+final $typed_data.Uint8List authenticateAppleRequestDescriptor = $convert.base64Decode(
+    'ChhBdXRoZW50aWNhdGVBcHBsZVJlcXVlc3QSMgoHYWNjb3VudBgBIAEoCzIYLm5ha2FtYS5hcG'
+    'kuQWNjb3VudEFwcGxlUgdhY2NvdW50EjIKBmNyZWF0ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1'
+    'Zi5Cb29sVmFsdWVSBmNyZWF0ZRIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWU=');
+
 @$core.Deprecated('Use authenticateCustomRequestDescriptor instead')
-const AuthenticateCustomRequest$json = const {
+const AuthenticateCustomRequest$json = {
   '1': 'AuthenticateCustomRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -520,7 +585,7 @@ const AuthenticateCustomRequest$json = const {
       '6': '.nakama.api.AccountCustom',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -528,19 +593,21 @@ const AuthenticateCustomRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
   ],
 };
 
 /// Descriptor for `AuthenticateCustomRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List authenticateCustomRequestDescriptor =
-    $convert.base64Decode(
-        'ChlBdXRoZW50aWNhdGVDdXN0b21SZXF1ZXN0EjMKB2FjY291bnQYASABKAsyGS5uYWthbWEuYXBpLkFjY291bnRDdXN0b21SB2FjY291bnQSMgoGY3JlYXRlGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIGY3JlYXRlEhoKCHVzZXJuYW1lGAMgASgJUgh1c2VybmFtZQ==');
+final $typed_data.Uint8List authenticateCustomRequestDescriptor = $convert.base64Decode(
+    'ChlBdXRoZW50aWNhdGVDdXN0b21SZXF1ZXN0EjMKB2FjY291bnQYASABKAsyGS5uYWthbWEuYX'
+    'BpLkFjY291bnRDdXN0b21SB2FjY291bnQSMgoGY3JlYXRlGAIgASgLMhouZ29vZ2xlLnByb3Rv'
+    'YnVmLkJvb2xWYWx1ZVIGY3JlYXRlEhoKCHVzZXJuYW1lGAMgASgJUgh1c2VybmFtZQ==');
+
 @$core.Deprecated('Use authenticateDeviceRequestDescriptor instead')
-const AuthenticateDeviceRequest$json = const {
+const AuthenticateDeviceRequest$json = {
   '1': 'AuthenticateDeviceRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -548,7 +615,7 @@ const AuthenticateDeviceRequest$json = const {
       '6': '.nakama.api.AccountDevice',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -556,19 +623,21 @@ const AuthenticateDeviceRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
   ],
 };
 
 /// Descriptor for `AuthenticateDeviceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List authenticateDeviceRequestDescriptor =
-    $convert.base64Decode(
-        'ChlBdXRoZW50aWNhdGVEZXZpY2VSZXF1ZXN0EjMKB2FjY291bnQYASABKAsyGS5uYWthbWEuYXBpLkFjY291bnREZXZpY2VSB2FjY291bnQSMgoGY3JlYXRlGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIGY3JlYXRlEhoKCHVzZXJuYW1lGAMgASgJUgh1c2VybmFtZQ==');
+final $typed_data.Uint8List authenticateDeviceRequestDescriptor = $convert.base64Decode(
+    'ChlBdXRoZW50aWNhdGVEZXZpY2VSZXF1ZXN0EjMKB2FjY291bnQYASABKAsyGS5uYWthbWEuYX'
+    'BpLkFjY291bnREZXZpY2VSB2FjY291bnQSMgoGY3JlYXRlGAIgASgLMhouZ29vZ2xlLnByb3Rv'
+    'YnVmLkJvb2xWYWx1ZVIGY3JlYXRlEhoKCHVzZXJuYW1lGAMgASgJUgh1c2VybmFtZQ==');
+
 @$core.Deprecated('Use authenticateEmailRequestDescriptor instead')
-const AuthenticateEmailRequest$json = const {
+const AuthenticateEmailRequest$json = {
   '1': 'AuthenticateEmailRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -576,7 +645,7 @@ const AuthenticateEmailRequest$json = const {
       '6': '.nakama.api.AccountEmail',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -584,19 +653,21 @@ const AuthenticateEmailRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
   ],
 };
 
 /// Descriptor for `AuthenticateEmailRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List authenticateEmailRequestDescriptor =
-    $convert.base64Decode(
-        'ChhBdXRoZW50aWNhdGVFbWFpbFJlcXVlc3QSMgoHYWNjb3VudBgBIAEoCzIYLm5ha2FtYS5hcGkuQWNjb3VudEVtYWlsUgdhY2NvdW50EjIKBmNyZWF0ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBmNyZWF0ZRIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWU=');
+final $typed_data.Uint8List authenticateEmailRequestDescriptor = $convert.base64Decode(
+    'ChhBdXRoZW50aWNhdGVFbWFpbFJlcXVlc3QSMgoHYWNjb3VudBgBIAEoCzIYLm5ha2FtYS5hcG'
+    'kuQWNjb3VudEVtYWlsUgdhY2NvdW50EjIKBmNyZWF0ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1'
+    'Zi5Cb29sVmFsdWVSBmNyZWF0ZRIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWU=');
+
 @$core.Deprecated('Use authenticateFacebookRequestDescriptor instead')
-const AuthenticateFacebookRequest$json = const {
+const AuthenticateFacebookRequest$json = {
   '1': 'AuthenticateFacebookRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -604,7 +675,7 @@ const AuthenticateFacebookRequest$json = const {
       '6': '.nakama.api.AccountFacebook',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -612,8 +683,8 @@ const AuthenticateFacebookRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
-    const {
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {
       '1': 'sync',
       '3': 4,
       '4': 1,
@@ -625,15 +696,18 @@ const AuthenticateFacebookRequest$json = const {
 };
 
 /// Descriptor for `AuthenticateFacebookRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List authenticateFacebookRequestDescriptor =
-    $convert.base64Decode(
-        'ChtBdXRoZW50aWNhdGVGYWNlYm9va1JlcXVlc3QSNQoHYWNjb3VudBgBIAEoCzIbLm5ha2FtYS5hcGkuQWNjb3VudEZhY2Vib29rUgdhY2NvdW50EjIKBmNyZWF0ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBmNyZWF0ZRIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWUSLgoEc3luYxgEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBHN5bmM=');
+final $typed_data.Uint8List authenticateFacebookRequestDescriptor = $convert.base64Decode(
+    'ChtBdXRoZW50aWNhdGVGYWNlYm9va1JlcXVlc3QSNQoHYWNjb3VudBgBIAEoCzIbLm5ha2FtYS'
+    '5hcGkuQWNjb3VudEZhY2Vib29rUgdhY2NvdW50EjIKBmNyZWF0ZRgCIAEoCzIaLmdvb2dsZS5w'
+    'cm90b2J1Zi5Cb29sVmFsdWVSBmNyZWF0ZRIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWUSLg'
+    'oEc3luYxgEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBHN5bmM=');
+
 @$core
     .Deprecated('Use authenticateFacebookInstantGameRequestDescriptor instead')
-const AuthenticateFacebookInstantGameRequest$json = const {
+const AuthenticateFacebookInstantGameRequest$json = {
   '1': 'AuthenticateFacebookInstantGameRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -641,7 +715,7 @@ const AuthenticateFacebookInstantGameRequest$json = const {
       '6': '.nakama.api.AccountFacebookInstantGame',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -649,19 +723,23 @@ const AuthenticateFacebookInstantGameRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
   ],
 };
 
 /// Descriptor for `AuthenticateFacebookInstantGameRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List authenticateFacebookInstantGameRequestDescriptor =
     $convert.base64Decode(
-        'CiZBdXRoZW50aWNhdGVGYWNlYm9va0luc3RhbnRHYW1lUmVxdWVzdBJACgdhY2NvdW50GAEgASgLMiYubmFrYW1hLmFwaS5BY2NvdW50RmFjZWJvb2tJbnN0YW50R2FtZVIHYWNjb3VudBIyCgZjcmVhdGUYAiABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZhbHVlUgZjcmVhdGUSGgoIdXNlcm5hbWUYAyABKAlSCHVzZXJuYW1l');
+        'CiZBdXRoZW50aWNhdGVGYWNlYm9va0luc3RhbnRHYW1lUmVxdWVzdBJACgdhY2NvdW50GAEgAS'
+        'gLMiYubmFrYW1hLmFwaS5BY2NvdW50RmFjZWJvb2tJbnN0YW50R2FtZVIHYWNjb3VudBIyCgZj'
+        'cmVhdGUYAiABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZhbHVlUgZjcmVhdGUSGgoIdXNlcm'
+        '5hbWUYAyABKAlSCHVzZXJuYW1l');
+
 @$core.Deprecated('Use authenticateGameCenterRequestDescriptor instead')
-const AuthenticateGameCenterRequest$json = const {
+const AuthenticateGameCenterRequest$json = {
   '1': 'AuthenticateGameCenterRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -669,7 +747,7 @@ const AuthenticateGameCenterRequest$json = const {
       '6': '.nakama.api.AccountGameCenter',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -677,19 +755,22 @@ const AuthenticateGameCenterRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
   ],
 };
 
 /// Descriptor for `AuthenticateGameCenterRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List authenticateGameCenterRequestDescriptor =
-    $convert.base64Decode(
-        'Ch1BdXRoZW50aWNhdGVHYW1lQ2VudGVyUmVxdWVzdBI3CgdhY2NvdW50GAEgASgLMh0ubmFrYW1hLmFwaS5BY2NvdW50R2FtZUNlbnRlclIHYWNjb3VudBIyCgZjcmVhdGUYAiABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZhbHVlUgZjcmVhdGUSGgoIdXNlcm5hbWUYAyABKAlSCHVzZXJuYW1l');
+final $typed_data.Uint8List authenticateGameCenterRequestDescriptor = $convert.base64Decode(
+    'Ch1BdXRoZW50aWNhdGVHYW1lQ2VudGVyUmVxdWVzdBI3CgdhY2NvdW50GAEgASgLMh0ubmFrYW'
+    '1hLmFwaS5BY2NvdW50R2FtZUNlbnRlclIHYWNjb3VudBIyCgZjcmVhdGUYAiABKAsyGi5nb29n'
+    'bGUucHJvdG9idWYuQm9vbFZhbHVlUgZjcmVhdGUSGgoIdXNlcm5hbWUYAyABKAlSCHVzZXJuYW'
+    '1l');
+
 @$core.Deprecated('Use authenticateGoogleRequestDescriptor instead')
-const AuthenticateGoogleRequest$json = const {
+const AuthenticateGoogleRequest$json = {
   '1': 'AuthenticateGoogleRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -697,7 +778,7 @@ const AuthenticateGoogleRequest$json = const {
       '6': '.nakama.api.AccountGoogle',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -705,19 +786,21 @@ const AuthenticateGoogleRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
   ],
 };
 
 /// Descriptor for `AuthenticateGoogleRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List authenticateGoogleRequestDescriptor =
-    $convert.base64Decode(
-        'ChlBdXRoZW50aWNhdGVHb29nbGVSZXF1ZXN0EjMKB2FjY291bnQYASABKAsyGS5uYWthbWEuYXBpLkFjY291bnRHb29nbGVSB2FjY291bnQSMgoGY3JlYXRlGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIGY3JlYXRlEhoKCHVzZXJuYW1lGAMgASgJUgh1c2VybmFtZQ==');
+final $typed_data.Uint8List authenticateGoogleRequestDescriptor = $convert.base64Decode(
+    'ChlBdXRoZW50aWNhdGVHb29nbGVSZXF1ZXN0EjMKB2FjY291bnQYASABKAsyGS5uYWthbWEuYX'
+    'BpLkFjY291bnRHb29nbGVSB2FjY291bnQSMgoGY3JlYXRlGAIgASgLMhouZ29vZ2xlLnByb3Rv'
+    'YnVmLkJvb2xWYWx1ZVIGY3JlYXRlEhoKCHVzZXJuYW1lGAMgASgJUgh1c2VybmFtZQ==');
+
 @$core.Deprecated('Use authenticateSteamRequestDescriptor instead')
-const AuthenticateSteamRequest$json = const {
+const AuthenticateSteamRequest$json = {
   '1': 'AuthenticateSteamRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -725,7 +808,7 @@ const AuthenticateSteamRequest$json = const {
       '6': '.nakama.api.AccountSteam',
       '10': 'account'
     },
-    const {
+    {
       '1': 'create',
       '3': 2,
       '4': 1,
@@ -733,8 +816,8 @@ const AuthenticateSteamRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'create'
     },
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
-    const {
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {
       '1': 'sync',
       '3': 4,
       '4': 1,
@@ -746,40 +829,47 @@ const AuthenticateSteamRequest$json = const {
 };
 
 /// Descriptor for `AuthenticateSteamRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List authenticateSteamRequestDescriptor =
-    $convert.base64Decode(
-        'ChhBdXRoZW50aWNhdGVTdGVhbVJlcXVlc3QSMgoHYWNjb3VudBgBIAEoCzIYLm5ha2FtYS5hcGkuQWNjb3VudFN0ZWFtUgdhY2NvdW50EjIKBmNyZWF0ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBmNyZWF0ZRIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWUSLgoEc3luYxgEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBHN5bmM=');
+final $typed_data.Uint8List authenticateSteamRequestDescriptor = $convert.base64Decode(
+    'ChhBdXRoZW50aWNhdGVTdGVhbVJlcXVlc3QSMgoHYWNjb3VudBgBIAEoCzIYLm5ha2FtYS5hcG'
+    'kuQWNjb3VudFN0ZWFtUgdhY2NvdW50EjIKBmNyZWF0ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1'
+    'Zi5Cb29sVmFsdWVSBmNyZWF0ZRIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWUSLgoEc3luYx'
+    'gEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBHN5bmM=');
+
 @$core.Deprecated('Use banGroupUsersRequestDescriptor instead')
-const BanGroupUsersRequest$json = const {
+const BanGroupUsersRequest$json = {
   '1': 'BanGroupUsersRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
   ],
 };
 
 /// Descriptor for `BanGroupUsersRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List banGroupUsersRequestDescriptor = $convert.base64Decode(
-    'ChRCYW5Hcm91cFVzZXJzUmVxdWVzdBIZCghncm91cF9pZBgBIAEoCVIHZ3JvdXBJZBIZCgh1c2VyX2lkcxgCIAMoCVIHdXNlcklkcw==');
+    'ChRCYW5Hcm91cFVzZXJzUmVxdWVzdBIZCghncm91cF9pZBgBIAEoCVIHZ3JvdXBJZBIZCgh1c2'
+    'VyX2lkcxgCIAMoCVIHdXNlcklkcw==');
+
 @$core.Deprecated('Use blockFriendsRequestDescriptor instead')
-const BlockFriendsRequest$json = const {
+const BlockFriendsRequest$json = {
   '1': 'BlockFriendsRequest',
-  '2': const [
-    const {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
-    const {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
+  '2': [
+    {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
+    {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
   ],
 };
 
 /// Descriptor for `BlockFriendsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List blockFriendsRequestDescriptor = $convert.base64Decode(
-    'ChNCbG9ja0ZyaWVuZHNSZXF1ZXN0EhAKA2lkcxgBIAMoCVIDaWRzEhwKCXVzZXJuYW1lcxgCIAMoCVIJdXNlcm5hbWVz');
+    'ChNCbG9ja0ZyaWVuZHNSZXF1ZXN0EhAKA2lkcxgBIAMoCVIDaWRzEhwKCXVzZXJuYW1lcxgCIA'
+    'MoCVIJdXNlcm5hbWVz');
+
 @$core.Deprecated('Use channelMessageDescriptor instead')
-const ChannelMessage$json = const {
+const ChannelMessage$json = {
   '1': 'ChannelMessage',
-  '2': const [
-    const {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
-    const {'1': 'message_id', '3': 2, '4': 1, '5': 9, '10': 'messageId'},
-    const {
+  '2': [
+    {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
+    {'1': 'message_id', '3': 2, '4': 1, '5': 9, '10': 'messageId'},
+    {
       '1': 'code',
       '3': 3,
       '4': 1,
@@ -787,10 +877,10 @@ const ChannelMessage$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'code'
     },
-    const {'1': 'sender_id', '3': 4, '4': 1, '5': 9, '10': 'senderId'},
-    const {'1': 'username', '3': 5, '4': 1, '5': 9, '10': 'username'},
-    const {'1': 'content', '3': 6, '4': 1, '5': 9, '10': 'content'},
-    const {
+    {'1': 'sender_id', '3': 4, '4': 1, '5': 9, '10': 'senderId'},
+    {'1': 'username', '3': 5, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'content', '3': 6, '4': 1, '5': 9, '10': 'content'},
+    {
       '1': 'create_time',
       '3': 7,
       '4': 1,
@@ -798,7 +888,7 @@ const ChannelMessage$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 8,
       '4': 1,
@@ -806,7 +896,7 @@ const ChannelMessage$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'updateTime'
     },
-    const {
+    {
       '1': 'persistent',
       '3': 9,
       '4': 1,
@@ -814,21 +904,31 @@ const ChannelMessage$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'persistent'
     },
-    const {'1': 'room_name', '3': 10, '4': 1, '5': 9, '10': 'roomName'},
-    const {'1': 'group_id', '3': 11, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_id_one', '3': 12, '4': 1, '5': 9, '10': 'userIdOne'},
-    const {'1': 'user_id_two', '3': 13, '4': 1, '5': 9, '10': 'userIdTwo'},
+    {'1': 'room_name', '3': 10, '4': 1, '5': 9, '10': 'roomName'},
+    {'1': 'group_id', '3': 11, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_id_one', '3': 12, '4': 1, '5': 9, '10': 'userIdOne'},
+    {'1': 'user_id_two', '3': 13, '4': 1, '5': 9, '10': 'userIdTwo'},
   ],
 };
 
 /// Descriptor for `ChannelMessage`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelMessageDescriptor = $convert.base64Decode(
-    'Cg5DaGFubmVsTWVzc2FnZRIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSHQoKbWVzc2FnZV9pZBgCIAEoCVIJbWVzc2FnZUlkEi8KBGNvZGUYAyABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIEY29kZRIbCglzZW5kZXJfaWQYBCABKAlSCHNlbmRlcklkEhoKCHVzZXJuYW1lGAUgASgJUgh1c2VybmFtZRIYCgdjb250ZW50GAYgASgJUgdjb250ZW50EjsKC2NyZWF0ZV90aW1lGAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI7Cgt1cGRhdGVfdGltZRgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUSOgoKcGVyc2lzdGVudBgJIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSCnBlcnNpc3RlbnQSGwoJcm9vbV9uYW1lGAogASgJUghyb29tTmFtZRIZCghncm91cF9pZBgLIAEoCVIHZ3JvdXBJZBIeCgt1c2VyX2lkX29uZRgMIAEoCVIJdXNlcklkT25lEh4KC3VzZXJfaWRfdHdvGA0gASgJUgl1c2VySWRUd28=');
+    'Cg5DaGFubmVsTWVzc2FnZRIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSHQoKbWVzc2'
+    'FnZV9pZBgCIAEoCVIJbWVzc2FnZUlkEi8KBGNvZGUYAyABKAsyGy5nb29nbGUucHJvdG9idWYu'
+    'SW50MzJWYWx1ZVIEY29kZRIbCglzZW5kZXJfaWQYBCABKAlSCHNlbmRlcklkEhoKCHVzZXJuYW'
+    '1lGAUgASgJUgh1c2VybmFtZRIYCgdjb250ZW50GAYgASgJUgdjb250ZW50EjsKC2NyZWF0ZV90'
+    'aW1lGAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI7Cgt1cG'
+    'RhdGVfdGltZRgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUS'
+    'OgoKcGVyc2lzdGVudBgJIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSCnBlcnNpc3'
+    'RlbnQSGwoJcm9vbV9uYW1lGAogASgJUghyb29tTmFtZRIZCghncm91cF9pZBgLIAEoCVIHZ3Jv'
+    'dXBJZBIeCgt1c2VyX2lkX29uZRgMIAEoCVIJdXNlcklkT25lEh4KC3VzZXJfaWRfdHdvGA0gAS'
+    'gJUgl1c2VySWRUd28=');
+
 @$core.Deprecated('Use channelMessageListDescriptor instead')
-const ChannelMessageList$json = const {
+const ChannelMessageList$json = {
   '1': 'ChannelMessageList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'messages',
       '3': 1,
       '4': 3,
@@ -836,54 +936,58 @@ const ChannelMessageList$json = const {
       '6': '.nakama.api.ChannelMessage',
       '10': 'messages'
     },
-    const {'1': 'next_cursor', '3': 2, '4': 1, '5': 9, '10': 'nextCursor'},
-    const {'1': 'prev_cursor', '3': 3, '4': 1, '5': 9, '10': 'prevCursor'},
-    const {
-      '1': 'cacheable_cursor',
-      '3': 4,
-      '4': 1,
-      '5': 9,
-      '10': 'cacheableCursor'
-    },
+    {'1': 'next_cursor', '3': 2, '4': 1, '5': 9, '10': 'nextCursor'},
+    {'1': 'prev_cursor', '3': 3, '4': 1, '5': 9, '10': 'prevCursor'},
+    {'1': 'cacheable_cursor', '3': 4, '4': 1, '5': 9, '10': 'cacheableCursor'},
   ],
 };
 
 /// Descriptor for `ChannelMessageList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelMessageListDescriptor = $convert.base64Decode(
-    'ChJDaGFubmVsTWVzc2FnZUxpc3QSNgoIbWVzc2FnZXMYASADKAsyGi5uYWthbWEuYXBpLkNoYW5uZWxNZXNzYWdlUghtZXNzYWdlcxIfCgtuZXh0X2N1cnNvchgCIAEoCVIKbmV4dEN1cnNvchIfCgtwcmV2X2N1cnNvchgDIAEoCVIKcHJldkN1cnNvchIpChBjYWNoZWFibGVfY3Vyc29yGAQgASgJUg9jYWNoZWFibGVDdXJzb3I=');
+    'ChJDaGFubmVsTWVzc2FnZUxpc3QSNgoIbWVzc2FnZXMYASADKAsyGi5uYWthbWEuYXBpLkNoYW'
+    '5uZWxNZXNzYWdlUghtZXNzYWdlcxIfCgtuZXh0X2N1cnNvchgCIAEoCVIKbmV4dEN1cnNvchIf'
+    'CgtwcmV2X2N1cnNvchgDIAEoCVIKcHJldkN1cnNvchIpChBjYWNoZWFibGVfY3Vyc29yGAQgAS'
+    'gJUg9jYWNoZWFibGVDdXJzb3I=');
+
 @$core.Deprecated('Use createGroupRequestDescriptor instead')
-const CreateGroupRequest$json = const {
+const CreateGroupRequest$json = {
   '1': 'CreateGroupRequest',
-  '2': const [
-    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
-    const {'1': 'description', '3': 2, '4': 1, '5': 9, '10': 'description'},
-    const {'1': 'lang_tag', '3': 3, '4': 1, '5': 9, '10': 'langTag'},
-    const {'1': 'avatar_url', '3': 4, '4': 1, '5': 9, '10': 'avatarUrl'},
-    const {'1': 'open', '3': 5, '4': 1, '5': 8, '10': 'open'},
-    const {'1': 'max_count', '3': 6, '4': 1, '5': 5, '10': 'maxCount'},
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'description', '3': 2, '4': 1, '5': 9, '10': 'description'},
+    {'1': 'lang_tag', '3': 3, '4': 1, '5': 9, '10': 'langTag'},
+    {'1': 'avatar_url', '3': 4, '4': 1, '5': 9, '10': 'avatarUrl'},
+    {'1': 'open', '3': 5, '4': 1, '5': 8, '10': 'open'},
+    {'1': 'max_count', '3': 6, '4': 1, '5': 5, '10': 'maxCount'},
   ],
 };
 
 /// Descriptor for `CreateGroupRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List createGroupRequestDescriptor = $convert.base64Decode(
-    'ChJDcmVhdGVHcm91cFJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIgCgtkZXNjcmlwdGlvbhgCIAEoCVILZGVzY3JpcHRpb24SGQoIbGFuZ190YWcYAyABKAlSB2xhbmdUYWcSHQoKYXZhdGFyX3VybBgEIAEoCVIJYXZhdGFyVXJsEhIKBG9wZW4YBSABKAhSBG9wZW4SGwoJbWF4X2NvdW50GAYgASgFUghtYXhDb3VudA==');
+    'ChJDcmVhdGVHcm91cFJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRIgCgtkZXNjcmlwdGlvbh'
+    'gCIAEoCVILZGVzY3JpcHRpb24SGQoIbGFuZ190YWcYAyABKAlSB2xhbmdUYWcSHQoKYXZhdGFy'
+    'X3VybBgEIAEoCVIJYXZhdGFyVXJsEhIKBG9wZW4YBSABKAhSBG9wZW4SGwoJbWF4X2NvdW50GA'
+    'YgASgFUghtYXhDb3VudA==');
+
 @$core.Deprecated('Use deleteFriendsRequestDescriptor instead')
-const DeleteFriendsRequest$json = const {
+const DeleteFriendsRequest$json = {
   '1': 'DeleteFriendsRequest',
-  '2': const [
-    const {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
-    const {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
+  '2': [
+    {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
+    {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
   ],
 };
 
 /// Descriptor for `DeleteFriendsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List deleteFriendsRequestDescriptor = $convert.base64Decode(
-    'ChREZWxldGVGcmllbmRzUmVxdWVzdBIQCgNpZHMYASADKAlSA2lkcxIcCgl1c2VybmFtZXMYAiADKAlSCXVzZXJuYW1lcw==');
+    'ChREZWxldGVGcmllbmRzUmVxdWVzdBIQCgNpZHMYASADKAlSA2lkcxIcCgl1c2VybmFtZXMYAi'
+    'ADKAlSCXVzZXJuYW1lcw==');
+
 @$core.Deprecated('Use deleteGroupRequestDescriptor instead')
-const DeleteGroupRequest$json = const {
+const DeleteGroupRequest$json = {
   '1': 'DeleteGroupRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
   ],
 };
 
@@ -891,29 +995,26 @@ const DeleteGroupRequest$json = const {
 final $typed_data.Uint8List deleteGroupRequestDescriptor =
     $convert.base64Decode(
         'ChJEZWxldGVHcm91cFJlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQ=');
+
 @$core.Deprecated('Use deleteLeaderboardRecordRequestDescriptor instead')
-const DeleteLeaderboardRecordRequest$json = const {
+const DeleteLeaderboardRecordRequest$json = {
   '1': 'DeleteLeaderboardRecordRequest',
-  '2': const [
-    const {
-      '1': 'leaderboard_id',
-      '3': 1,
-      '4': 1,
-      '5': 9,
-      '10': 'leaderboardId'
-    },
+  '2': [
+    {'1': 'leaderboard_id', '3': 1, '4': 1, '5': 9, '10': 'leaderboardId'},
   ],
 };
 
 /// Descriptor for `DeleteLeaderboardRecordRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List deleteLeaderboardRecordRequestDescriptor =
     $convert.base64Decode(
-        'Ch5EZWxldGVMZWFkZXJib2FyZFJlY29yZFJlcXVlc3QSJQoObGVhZGVyYm9hcmRfaWQYASABKAlSDWxlYWRlcmJvYXJkSWQ=');
+        'Ch5EZWxldGVMZWFkZXJib2FyZFJlY29yZFJlcXVlc3QSJQoObGVhZGVyYm9hcmRfaWQYASABKA'
+        'lSDWxlYWRlcmJvYXJkSWQ=');
+
 @$core.Deprecated('Use deleteNotificationsRequestDescriptor instead')
-const DeleteNotificationsRequest$json = const {
+const DeleteNotificationsRequest$json = {
   '1': 'DeleteNotificationsRequest',
-  '2': const [
-    const {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
+  '2': [
+    {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
   ],
 };
 
@@ -921,36 +1022,41 @@ const DeleteNotificationsRequest$json = const {
 final $typed_data.Uint8List deleteNotificationsRequestDescriptor =
     $convert.base64Decode(
         'ChpEZWxldGVOb3RpZmljYXRpb25zUmVxdWVzdBIQCgNpZHMYASADKAlSA2lkcw==');
+
 @$core.Deprecated('Use deleteTournamentRecordRequestDescriptor instead')
-const DeleteTournamentRecordRequest$json = const {
+const DeleteTournamentRecordRequest$json = {
   '1': 'DeleteTournamentRecordRequest',
-  '2': const [
-    const {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
+  '2': [
+    {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
   ],
 };
 
 /// Descriptor for `DeleteTournamentRecordRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List deleteTournamentRecordRequestDescriptor =
     $convert.base64Decode(
-        'Ch1EZWxldGVUb3VybmFtZW50UmVjb3JkUmVxdWVzdBIjCg10b3VybmFtZW50X2lkGAEgASgJUgx0b3VybmFtZW50SWQ=');
+        'Ch1EZWxldGVUb3VybmFtZW50UmVjb3JkUmVxdWVzdBIjCg10b3VybmFtZW50X2lkGAEgASgJUg'
+        'x0b3VybmFtZW50SWQ=');
+
 @$core.Deprecated('Use deleteStorageObjectIdDescriptor instead')
-const DeleteStorageObjectId$json = const {
+const DeleteStorageObjectId$json = {
   '1': 'DeleteStorageObjectId',
-  '2': const [
-    const {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
-    const {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'version', '3': 3, '4': 1, '5': 9, '10': 'version'},
+  '2': [
+    {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
+    {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'version', '3': 3, '4': 1, '5': 9, '10': 'version'},
   ],
 };
 
 /// Descriptor for `DeleteStorageObjectId`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List deleteStorageObjectIdDescriptor = $convert.base64Decode(
-    'ChVEZWxldGVTdG9yYWdlT2JqZWN0SWQSHgoKY29sbGVjdGlvbhgBIAEoCVIKY29sbGVjdGlvbhIQCgNrZXkYAiABKAlSA2tleRIYCgd2ZXJzaW9uGAMgASgJUgd2ZXJzaW9u');
+    'ChVEZWxldGVTdG9yYWdlT2JqZWN0SWQSHgoKY29sbGVjdGlvbhgBIAEoCVIKY29sbGVjdGlvbh'
+    'IQCgNrZXkYAiABKAlSA2tleRIYCgd2ZXJzaW9uGAMgASgJUgd2ZXJzaW9u');
+
 @$core.Deprecated('Use deleteStorageObjectsRequestDescriptor instead')
-const DeleteStorageObjectsRequest$json = const {
+const DeleteStorageObjectsRequest$json = {
   '1': 'DeleteStorageObjectsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'object_ids',
       '3': 1,
       '4': 3,
@@ -964,13 +1070,15 @@ const DeleteStorageObjectsRequest$json = const {
 /// Descriptor for `DeleteStorageObjectsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List deleteStorageObjectsRequestDescriptor =
     $convert.base64Decode(
-        'ChtEZWxldGVTdG9yYWdlT2JqZWN0c1JlcXVlc3QSQAoKb2JqZWN0X2lkcxgBIAMoCzIhLm5ha2FtYS5hcGkuRGVsZXRlU3RvcmFnZU9iamVjdElkUglvYmplY3RJZHM=');
+        'ChtEZWxldGVTdG9yYWdlT2JqZWN0c1JlcXVlc3QSQAoKb2JqZWN0X2lkcxgBIAMoCzIhLm5ha2'
+        'FtYS5hcGkuRGVsZXRlU3RvcmFnZU9iamVjdElkUglvYmplY3RJZHM=');
+
 @$core.Deprecated('Use eventDescriptor instead')
-const Event$json = const {
+const Event$json = {
   '1': 'Event',
-  '2': const [
-    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
-    const {
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {
       '1': 'properties',
       '3': 2,
       '4': 3,
@@ -978,7 +1086,7 @@ const Event$json = const {
       '6': '.nakama.api.Event.PropertiesEntry',
       '10': 'properties'
     },
-    const {
+    {
       '1': 'timestamp',
       '3': 3,
       '4': 1,
@@ -986,29 +1094,34 @@ const Event$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'timestamp'
     },
-    const {'1': 'external', '3': 4, '4': 1, '5': 8, '10': 'external'},
+    {'1': 'external', '3': 4, '4': 1, '5': 8, '10': 'external'},
   ],
-  '3': const [Event_PropertiesEntry$json],
+  '3': [Event_PropertiesEntry$json],
 };
 
 @$core.Deprecated('Use eventDescriptor instead')
-const Event_PropertiesEntry$json = const {
+const Event_PropertiesEntry$json = {
   '1': 'PropertiesEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `Event`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List eventDescriptor = $convert.base64Decode(
-    'CgVFdmVudBISCgRuYW1lGAEgASgJUgRuYW1lEkEKCnByb3BlcnRpZXMYAiADKAsyIS5uYWthbWEuYXBpLkV2ZW50LlByb3BlcnRpZXNFbnRyeVIKcHJvcGVydGllcxI4Cgl0aW1lc3RhbXAYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgl0aW1lc3RhbXASGgoIZXh0ZXJuYWwYBCABKAhSCGV4dGVybmFsGj0KD1Byb3BlcnRpZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+    'CgVFdmVudBISCgRuYW1lGAEgASgJUgRuYW1lEkEKCnByb3BlcnRpZXMYAiADKAsyIS5uYWthbW'
+    'EuYXBpLkV2ZW50LlByb3BlcnRpZXNFbnRyeVIKcHJvcGVydGllcxI4Cgl0aW1lc3RhbXAYAyAB'
+    'KAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgl0aW1lc3RhbXASGgoIZXh0ZXJuYWwYBC'
+    'ABKAhSCGV4dGVybmFsGj0KD1Byb3BlcnRpZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2'
+    'YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+
 @$core.Deprecated('Use friendDescriptor instead')
-const Friend$json = const {
+const Friend$json = {
   '1': 'Friend',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'user',
       '3': 1,
       '4': 1,
@@ -1016,7 +1129,7 @@ const Friend$json = const {
       '6': '.nakama.api.User',
       '10': 'user'
     },
-    const {
+    {
       '1': 'state',
       '3': 2,
       '4': 1,
@@ -1024,7 +1137,7 @@ const Friend$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'state'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 3,
       '4': 1,
@@ -1032,29 +1145,35 @@ const Friend$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'updateTime'
     },
+    {'1': 'metadata', '3': 4, '4': 1, '5': 9, '10': 'metadata'},
   ],
-  '4': const [Friend_State$json],
+  '4': [Friend_State$json],
 };
 
 @$core.Deprecated('Use friendDescriptor instead')
-const Friend_State$json = const {
+const Friend_State$json = {
   '1': 'State',
-  '2': const [
-    const {'1': 'FRIEND', '2': 0},
-    const {'1': 'INVITE_SENT', '2': 1},
-    const {'1': 'INVITE_RECEIVED', '2': 2},
-    const {'1': 'BLOCKED', '2': 3},
+  '2': [
+    {'1': 'FRIEND', '2': 0},
+    {'1': 'INVITE_SENT', '2': 1},
+    {'1': 'INVITE_RECEIVED', '2': 2},
+    {'1': 'BLOCKED', '2': 3},
   ],
 };
 
 /// Descriptor for `Friend`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List friendDescriptor = $convert.base64Decode(
-    'CgZGcmllbmQSJAoEdXNlchgBIAEoCzIQLm5ha2FtYS5hcGkuVXNlclIEdXNlchIxCgVzdGF0ZRgCIAEoCzIbLmdvb2dsZS5wcm90b2J1Zi5JbnQzMlZhbHVlUgVzdGF0ZRI7Cgt1cGRhdGVfdGltZRgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUiRgoFU3RhdGUSCgoGRlJJRU5EEAASDwoLSU5WSVRFX1NFTlQQARITCg9JTlZJVEVfUkVDRUlWRUQQAhILCgdCTE9DS0VEEAM=');
+    'CgZGcmllbmQSJAoEdXNlchgBIAEoCzIQLm5ha2FtYS5hcGkuVXNlclIEdXNlchIxCgVzdGF0ZR'
+    'gCIAEoCzIbLmdvb2dsZS5wcm90b2J1Zi5JbnQzMlZhbHVlUgVzdGF0ZRI7Cgt1cGRhdGVfdGlt'
+    'ZRgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUSGgoIbWV0YW'
+    'RhdGEYBCABKAlSCG1ldGFkYXRhIkYKBVN0YXRlEgoKBkZSSUVORBAAEg8KC0lOVklURV9TRU5U'
+    'EAESEwoPSU5WSVRFX1JFQ0VJVkVEEAISCwoHQkxPQ0tFRBAD');
+
 @$core.Deprecated('Use friendListDescriptor instead')
-const FriendList$json = const {
+const FriendList$json = {
   '1': 'FriendList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'friends',
       '3': 1,
       '4': 3,
@@ -1062,50 +1181,97 @@ const FriendList$json = const {
       '6': '.nakama.api.Friend',
       '10': 'friends'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `FriendList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List friendListDescriptor = $convert.base64Decode(
-    'CgpGcmllbmRMaXN0EiwKB2ZyaWVuZHMYASADKAsyEi5uYWthbWEuYXBpLkZyaWVuZFIHZnJpZW5kcxIWCgZjdXJzb3IYAiABKAlSBmN1cnNvcg==');
+    'CgpGcmllbmRMaXN0EiwKB2ZyaWVuZHMYASADKAsyEi5uYWthbWEuYXBpLkZyaWVuZFIHZnJpZW'
+    '5kcxIWCgZjdXJzb3IYAiABKAlSBmN1cnNvcg==');
+
+@$core.Deprecated('Use friendsOfFriendsListDescriptor instead')
+const FriendsOfFriendsList$json = {
+  '1': 'FriendsOfFriendsList',
+  '2': [
+    {
+      '1': 'friends_of_friends',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.nakama.api.FriendsOfFriendsList.FriendOfFriend',
+      '10': 'friendsOfFriends'
+    },
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+  ],
+  '3': [FriendsOfFriendsList_FriendOfFriend$json],
+};
+
+@$core.Deprecated('Use friendsOfFriendsListDescriptor instead')
+const FriendsOfFriendsList_FriendOfFriend$json = {
+  '1': 'FriendOfFriend',
+  '2': [
+    {'1': 'referrer', '3': 1, '4': 1, '5': 9, '10': 'referrer'},
+    {
+      '1': 'user',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.nakama.api.User',
+      '10': 'user'
+    },
+  ],
+};
+
+/// Descriptor for `FriendsOfFriendsList`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List friendsOfFriendsListDescriptor = $convert.base64Decode(
+    'ChRGcmllbmRzT2ZGcmllbmRzTGlzdBJdChJmcmllbmRzX29mX2ZyaWVuZHMYASADKAsyLy5uYW'
+    'thbWEuYXBpLkZyaWVuZHNPZkZyaWVuZHNMaXN0LkZyaWVuZE9mRnJpZW5kUhBmcmllbmRzT2ZG'
+    'cmllbmRzEhYKBmN1cnNvchgCIAEoCVIGY3Vyc29yGlIKDkZyaWVuZE9mRnJpZW5kEhoKCHJlZm'
+    'VycmVyGAEgASgJUghyZWZlcnJlchIkCgR1c2VyGAIgASgLMhAubmFrYW1hLmFwaS5Vc2VyUgR1'
+    'c2Vy');
+
 @$core.Deprecated('Use getUsersRequestDescriptor instead')
-const GetUsersRequest$json = const {
+const GetUsersRequest$json = {
   '1': 'GetUsersRequest',
-  '2': const [
-    const {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
-    const {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
-    const {'1': 'facebook_ids', '3': 3, '4': 3, '5': 9, '10': 'facebookIds'},
+  '2': [
+    {'1': 'ids', '3': 1, '4': 3, '5': 9, '10': 'ids'},
+    {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
+    {'1': 'facebook_ids', '3': 3, '4': 3, '5': 9, '10': 'facebookIds'},
   ],
 };
 
 /// Descriptor for `GetUsersRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List getUsersRequestDescriptor = $convert.base64Decode(
-    'Cg9HZXRVc2Vyc1JlcXVlc3QSEAoDaWRzGAEgAygJUgNpZHMSHAoJdXNlcm5hbWVzGAIgAygJUgl1c2VybmFtZXMSIQoMZmFjZWJvb2tfaWRzGAMgAygJUgtmYWNlYm9va0lkcw==');
+    'Cg9HZXRVc2Vyc1JlcXVlc3QSEAoDaWRzGAEgAygJUgNpZHMSHAoJdXNlcm5hbWVzGAIgAygJUg'
+    'l1c2VybmFtZXMSIQoMZmFjZWJvb2tfaWRzGAMgAygJUgtmYWNlYm9va0lkcw==');
+
 @$core.Deprecated('Use getSubscriptionRequestDescriptor instead')
-const GetSubscriptionRequest$json = const {
+const GetSubscriptionRequest$json = {
   '1': 'GetSubscriptionRequest',
-  '2': const [
-    const {'1': 'product_id', '3': 1, '4': 1, '5': 9, '10': 'productId'},
+  '2': [
+    {'1': 'product_id', '3': 1, '4': 1, '5': 9, '10': 'productId'},
   ],
 };
 
 /// Descriptor for `GetSubscriptionRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List getSubscriptionRequestDescriptor =
     $convert.base64Decode(
-        'ChZHZXRTdWJzY3JpcHRpb25SZXF1ZXN0Eh0KCnByb2R1Y3RfaWQYASABKAlSCXByb2R1Y3RJZA==');
+        'ChZHZXRTdWJzY3JpcHRpb25SZXF1ZXN0Eh0KCnByb2R1Y3RfaWQYASABKAlSCXByb2R1Y3RJZA'
+        '==');
+
 @$core.Deprecated('Use groupDescriptor instead')
-const Group$json = const {
+const Group$json = {
   '1': 'Group',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {'1': 'creator_id', '3': 2, '4': 1, '5': 9, '10': 'creatorId'},
-    const {'1': 'name', '3': 3, '4': 1, '5': 9, '10': 'name'},
-    const {'1': 'description', '3': 4, '4': 1, '5': 9, '10': 'description'},
-    const {'1': 'lang_tag', '3': 5, '4': 1, '5': 9, '10': 'langTag'},
-    const {'1': 'metadata', '3': 6, '4': 1, '5': 9, '10': 'metadata'},
-    const {'1': 'avatar_url', '3': 7, '4': 1, '5': 9, '10': 'avatarUrl'},
-    const {
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {'1': 'creator_id', '3': 2, '4': 1, '5': 9, '10': 'creatorId'},
+    {'1': 'name', '3': 3, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'description', '3': 4, '4': 1, '5': 9, '10': 'description'},
+    {'1': 'lang_tag', '3': 5, '4': 1, '5': 9, '10': 'langTag'},
+    {'1': 'metadata', '3': 6, '4': 1, '5': 9, '10': 'metadata'},
+    {'1': 'avatar_url', '3': 7, '4': 1, '5': 9, '10': 'avatarUrl'},
+    {
       '1': 'open',
       '3': 8,
       '4': 1,
@@ -1113,9 +1279,9 @@ const Group$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'open'
     },
-    const {'1': 'edge_count', '3': 9, '4': 1, '5': 5, '10': 'edgeCount'},
-    const {'1': 'max_count', '3': 10, '4': 1, '5': 5, '10': 'maxCount'},
-    const {
+    {'1': 'edge_count', '3': 9, '4': 1, '5': 5, '10': 'edgeCount'},
+    {'1': 'max_count', '3': 10, '4': 1, '5': 5, '10': 'maxCount'},
+    {
       '1': 'create_time',
       '3': 11,
       '4': 1,
@@ -1123,7 +1289,7 @@ const Group$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 12,
       '4': 1,
@@ -1136,12 +1302,20 @@ const Group$json = const {
 
 /// Descriptor for `Group`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List groupDescriptor = $convert.base64Decode(
-    'CgVHcm91cBIOCgJpZBgBIAEoCVICaWQSHQoKY3JlYXRvcl9pZBgCIAEoCVIJY3JlYXRvcklkEhIKBG5hbWUYAyABKAlSBG5hbWUSIAoLZGVzY3JpcHRpb24YBCABKAlSC2Rlc2NyaXB0aW9uEhkKCGxhbmdfdGFnGAUgASgJUgdsYW5nVGFnEhoKCG1ldGFkYXRhGAYgASgJUghtZXRhZGF0YRIdCgphdmF0YXJfdXJsGAcgASgJUglhdmF0YXJVcmwSLgoEb3BlbhgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBG9wZW4SHQoKZWRnZV9jb3VudBgJIAEoBVIJZWRnZUNvdW50EhsKCW1heF9jb3VudBgKIAEoBVIIbWF4Q291bnQSOwoLY3JlYXRlX3RpbWUYCyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgpjcmVhdGVUaW1lEjsKC3VwZGF0ZV90aW1lGAwgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKdXBkYXRlVGltZQ==');
+    'CgVHcm91cBIOCgJpZBgBIAEoCVICaWQSHQoKY3JlYXRvcl9pZBgCIAEoCVIJY3JlYXRvcklkEh'
+    'IKBG5hbWUYAyABKAlSBG5hbWUSIAoLZGVzY3JpcHRpb24YBCABKAlSC2Rlc2NyaXB0aW9uEhkK'
+    'CGxhbmdfdGFnGAUgASgJUgdsYW5nVGFnEhoKCG1ldGFkYXRhGAYgASgJUghtZXRhZGF0YRIdCg'
+    'phdmF0YXJfdXJsGAcgASgJUglhdmF0YXJVcmwSLgoEb3BlbhgIIAEoCzIaLmdvb2dsZS5wcm90'
+    'b2J1Zi5Cb29sVmFsdWVSBG9wZW4SHQoKZWRnZV9jb3VudBgJIAEoBVIJZWRnZUNvdW50EhsKCW'
+    '1heF9jb3VudBgKIAEoBVIIbWF4Q291bnQSOwoLY3JlYXRlX3RpbWUYCyABKAsyGi5nb29nbGUu'
+    'cHJvdG9idWYuVGltZXN0YW1wUgpjcmVhdGVUaW1lEjsKC3VwZGF0ZV90aW1lGAwgASgLMhouZ2'
+    '9vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKdXBkYXRlVGltZQ==');
+
 @$core.Deprecated('Use groupListDescriptor instead')
-const GroupList$json = const {
+const GroupList$json = {
   '1': 'GroupList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'groups',
       '3': 1,
       '4': 3,
@@ -1149,18 +1323,20 @@ const GroupList$json = const {
       '6': '.nakama.api.Group',
       '10': 'groups'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `GroupList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List groupListDescriptor = $convert.base64Decode(
-    'CglHcm91cExpc3QSKQoGZ3JvdXBzGAEgAygLMhEubmFrYW1hLmFwaS5Hcm91cFIGZ3JvdXBzEhYKBmN1cnNvchgCIAEoCVIGY3Vyc29y');
+    'CglHcm91cExpc3QSKQoGZ3JvdXBzGAEgAygLMhEubmFrYW1hLmFwaS5Hcm91cFIGZ3JvdXBzEh'
+    'YKBmN1cnNvchgCIAEoCVIGY3Vyc29y');
+
 @$core.Deprecated('Use groupUserListDescriptor instead')
-const GroupUserList$json = const {
+const GroupUserList$json = {
   '1': 'GroupUserList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'group_users',
       '3': 1,
       '4': 3,
@@ -1168,16 +1344,16 @@ const GroupUserList$json = const {
       '6': '.nakama.api.GroupUserList.GroupUser',
       '10': 'groupUsers'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
   ],
-  '3': const [GroupUserList_GroupUser$json],
+  '3': [GroupUserList_GroupUser$json],
 };
 
 @$core.Deprecated('Use groupUserListDescriptor instead')
-const GroupUserList_GroupUser$json = const {
+const GroupUserList_GroupUser$json = {
   '1': 'GroupUser',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'user',
       '3': 1,
       '4': 1,
@@ -1185,7 +1361,7 @@ const GroupUserList_GroupUser$json = const {
       '6': '.nakama.api.User',
       '10': 'user'
     },
-    const {
+    {
       '1': 'state',
       '3': 2,
       '4': 1,
@@ -1194,28 +1370,34 @@ const GroupUserList_GroupUser$json = const {
       '10': 'state'
     },
   ],
-  '4': const [GroupUserList_GroupUser_State$json],
+  '4': [GroupUserList_GroupUser_State$json],
 };
 
 @$core.Deprecated('Use groupUserListDescriptor instead')
-const GroupUserList_GroupUser_State$json = const {
+const GroupUserList_GroupUser_State$json = {
   '1': 'State',
-  '2': const [
-    const {'1': 'SUPERADMIN', '2': 0},
-    const {'1': 'ADMIN', '2': 1},
-    const {'1': 'MEMBER', '2': 2},
-    const {'1': 'JOIN_REQUEST', '2': 3},
+  '2': [
+    {'1': 'SUPERADMIN', '2': 0},
+    {'1': 'ADMIN', '2': 1},
+    {'1': 'MEMBER', '2': 2},
+    {'1': 'JOIN_REQUEST', '2': 3},
   ],
 };
 
 /// Descriptor for `GroupUserList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List groupUserListDescriptor = $convert.base64Decode(
-    'Cg1Hcm91cFVzZXJMaXN0EkQKC2dyb3VwX3VzZXJzGAEgAygLMiMubmFrYW1hLmFwaS5Hcm91cFVzZXJMaXN0Lkdyb3VwVXNlclIKZ3JvdXBVc2VycxIWCgZjdXJzb3IYAiABKAlSBmN1cnNvchqmAQoJR3JvdXBVc2VyEiQKBHVzZXIYASABKAsyEC5uYWthbWEuYXBpLlVzZXJSBHVzZXISMQoFc3RhdGUYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFc3RhdGUiQAoFU3RhdGUSDgoKU1VQRVJBRE1JThAAEgkKBUFETUlOEAESCgoGTUVNQkVSEAISEAoMSk9JTl9SRVFVRVNUEAM=');
+    'Cg1Hcm91cFVzZXJMaXN0EkQKC2dyb3VwX3VzZXJzGAEgAygLMiMubmFrYW1hLmFwaS5Hcm91cF'
+    'VzZXJMaXN0Lkdyb3VwVXNlclIKZ3JvdXBVc2VycxIWCgZjdXJzb3IYAiABKAlSBmN1cnNvchqm'
+    'AQoJR3JvdXBVc2VyEiQKBHVzZXIYASABKAsyEC5uYWthbWEuYXBpLlVzZXJSBHVzZXISMQoFc3'
+    'RhdGUYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFc3RhdGUiQAoFU3RhdGUS'
+    'DgoKU1VQRVJBRE1JThAAEgkKBUFETUlOEAESCgoGTUVNQkVSEAISEAoMSk9JTl9SRVFVRVNUEA'
+    'M=');
+
 @$core.Deprecated('Use importFacebookFriendsRequestDescriptor instead')
-const ImportFacebookFriendsRequest$json = const {
+const ImportFacebookFriendsRequest$json = {
   '1': 'ImportFacebookFriendsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -1223,7 +1405,7 @@ const ImportFacebookFriendsRequest$json = const {
       '6': '.nakama.api.AccountFacebook',
       '10': 'account'
     },
-    const {
+    {
       '1': 'reset',
       '3': 2,
       '4': 1,
@@ -1237,12 +1419,15 @@ const ImportFacebookFriendsRequest$json = const {
 /// Descriptor for `ImportFacebookFriendsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List importFacebookFriendsRequestDescriptor =
     $convert.base64Decode(
-        'ChxJbXBvcnRGYWNlYm9va0ZyaWVuZHNSZXF1ZXN0EjUKB2FjY291bnQYASABKAsyGy5uYWthbWEuYXBpLkFjY291bnRGYWNlYm9va1IHYWNjb3VudBIwCgVyZXNldBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBXJlc2V0');
+        'ChxJbXBvcnRGYWNlYm9va0ZyaWVuZHNSZXF1ZXN0EjUKB2FjY291bnQYASABKAsyGy5uYWthbW'
+        'EuYXBpLkFjY291bnRGYWNlYm9va1IHYWNjb3VudBIwCgVyZXNldBgCIAEoCzIaLmdvb2dsZS5w'
+        'cm90b2J1Zi5Cb29sVmFsdWVSBXJlc2V0');
+
 @$core.Deprecated('Use importSteamFriendsRequestDescriptor instead')
-const ImportSteamFriendsRequest$json = const {
+const ImportSteamFriendsRequest$json = {
   '1': 'ImportSteamFriendsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -1250,7 +1435,7 @@ const ImportSteamFriendsRequest$json = const {
       '6': '.nakama.api.AccountSteam',
       '10': 'account'
     },
-    const {
+    {
       '1': 'reset',
       '3': 2,
       '4': 1,
@@ -1262,50 +1447,57 @@ const ImportSteamFriendsRequest$json = const {
 };
 
 /// Descriptor for `ImportSteamFriendsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List importSteamFriendsRequestDescriptor =
-    $convert.base64Decode(
-        'ChlJbXBvcnRTdGVhbUZyaWVuZHNSZXF1ZXN0EjIKB2FjY291bnQYASABKAsyGC5uYWthbWEuYXBpLkFjY291bnRTdGVhbVIHYWNjb3VudBIwCgVyZXNldBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSBXJlc2V0');
+final $typed_data.Uint8List importSteamFriendsRequestDescriptor = $convert.base64Decode(
+    'ChlJbXBvcnRTdGVhbUZyaWVuZHNSZXF1ZXN0EjIKB2FjY291bnQYASABKAsyGC5uYWthbWEuYX'
+    'BpLkFjY291bnRTdGVhbVIHYWNjb3VudBIwCgVyZXNldBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1'
+    'Zi5Cb29sVmFsdWVSBXJlc2V0');
+
 @$core.Deprecated('Use joinGroupRequestDescriptor instead')
-const JoinGroupRequest$json = const {
+const JoinGroupRequest$json = {
   '1': 'JoinGroupRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
   ],
 };
 
 /// Descriptor for `JoinGroupRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List joinGroupRequestDescriptor = $convert.base64Decode(
     'ChBKb2luR3JvdXBSZXF1ZXN0EhkKCGdyb3VwX2lkGAEgASgJUgdncm91cElk');
+
 @$core.Deprecated('Use joinTournamentRequestDescriptor instead')
-const JoinTournamentRequest$json = const {
+const JoinTournamentRequest$json = {
   '1': 'JoinTournamentRequest',
-  '2': const [
-    const {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
+  '2': [
+    {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
   ],
 };
 
 /// Descriptor for `JoinTournamentRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List joinTournamentRequestDescriptor = $convert.base64Decode(
-    'ChVKb2luVG91cm5hbWVudFJlcXVlc3QSIwoNdG91cm5hbWVudF9pZBgBIAEoCVIMdG91cm5hbWVudElk');
+    'ChVKb2luVG91cm5hbWVudFJlcXVlc3QSIwoNdG91cm5hbWVudF9pZBgBIAEoCVIMdG91cm5hbW'
+    'VudElk');
+
 @$core.Deprecated('Use kickGroupUsersRequestDescriptor instead')
-const KickGroupUsersRequest$json = const {
+const KickGroupUsersRequest$json = {
   '1': 'KickGroupUsersRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
   ],
 };
 
 /// Descriptor for `KickGroupUsersRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List kickGroupUsersRequestDescriptor = $convert.base64Decode(
-    'ChVLaWNrR3JvdXBVc2Vyc1JlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQSGQoIdXNlcl9pZHMYAiADKAlSB3VzZXJJZHM=');
+    'ChVLaWNrR3JvdXBVc2Vyc1JlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQSGQoIdX'
+    'Nlcl9pZHMYAiADKAlSB3VzZXJJZHM=');
+
 @$core.Deprecated('Use leaderboardDescriptor instead')
-const Leaderboard$json = const {
+const Leaderboard$json = {
   '1': 'Leaderboard',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {'1': 'sort_order', '3': 2, '4': 1, '5': 13, '10': 'sortOrder'},
-    const {
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {'1': 'sort_order', '3': 2, '4': 1, '5': 13, '10': 'sortOrder'},
+    {
       '1': 'operator',
       '3': 3,
       '4': 1,
@@ -1313,10 +1505,10 @@ const Leaderboard$json = const {
       '6': '.nakama.api.Operator',
       '10': 'operator'
     },
-    const {'1': 'prev_reset', '3': 4, '4': 1, '5': 13, '10': 'prevReset'},
-    const {'1': 'next_reset', '3': 5, '4': 1, '5': 13, '10': 'nextReset'},
-    const {'1': 'metadata', '3': 6, '4': 1, '5': 9, '10': 'metadata'},
-    const {
+    {'1': 'prev_reset', '3': 4, '4': 1, '5': 13, '10': 'prevReset'},
+    {'1': 'next_reset', '3': 5, '4': 1, '5': 13, '10': 'nextReset'},
+    {'1': 'metadata', '3': 6, '4': 1, '5': 9, '10': 'metadata'},
+    {
       '1': 'create_time',
       '3': 7,
       '4': 1,
@@ -1324,18 +1516,24 @@ const Leaderboard$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {'1': 'authoritative', '3': 8, '4': 1, '5': 8, '10': 'authoritative'},
+    {'1': 'authoritative', '3': 8, '4': 1, '5': 8, '10': 'authoritative'},
   ],
 };
 
 /// Descriptor for `Leaderboard`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List leaderboardDescriptor = $convert.base64Decode(
-    'CgtMZWFkZXJib2FyZBIOCgJpZBgBIAEoCVICaWQSHQoKc29ydF9vcmRlchgCIAEoDVIJc29ydE9yZGVyEjAKCG9wZXJhdG9yGAMgASgOMhQubmFrYW1hLmFwaS5PcGVyYXRvclIIb3BlcmF0b3ISHQoKcHJldl9yZXNldBgEIAEoDVIJcHJldlJlc2V0Eh0KCm5leHRfcmVzZXQYBSABKA1SCW5leHRSZXNldBIaCghtZXRhZGF0YRgGIAEoCVIIbWV0YWRhdGESOwoLY3JlYXRlX3RpbWUYByABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgpjcmVhdGVUaW1lEiQKDWF1dGhvcml0YXRpdmUYCCABKAhSDWF1dGhvcml0YXRpdmU=');
+    'CgtMZWFkZXJib2FyZBIOCgJpZBgBIAEoCVICaWQSHQoKc29ydF9vcmRlchgCIAEoDVIJc29ydE'
+    '9yZGVyEjAKCG9wZXJhdG9yGAMgASgOMhQubmFrYW1hLmFwaS5PcGVyYXRvclIIb3BlcmF0b3IS'
+    'HQoKcHJldl9yZXNldBgEIAEoDVIJcHJldlJlc2V0Eh0KCm5leHRfcmVzZXQYBSABKA1SCW5leH'
+    'RSZXNldBIaCghtZXRhZGF0YRgGIAEoCVIIbWV0YWRhdGESOwoLY3JlYXRlX3RpbWUYByABKAsy'
+    'Gi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgpjcmVhdGVUaW1lEiQKDWF1dGhvcml0YXRpdm'
+    'UYCCABKAhSDWF1dGhvcml0YXRpdmU=');
+
 @$core.Deprecated('Use leaderboardListDescriptor instead')
-const LeaderboardList$json = const {
+const LeaderboardList$json = {
   '1': 'LeaderboardList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'leaderboards',
       '3': 1,
       '4': 3,
@@ -1343,26 +1541,22 @@ const LeaderboardList$json = const {
       '6': '.nakama.api.Leaderboard',
       '10': 'leaderboards'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `LeaderboardList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List leaderboardListDescriptor = $convert.base64Decode(
-    'Cg9MZWFkZXJib2FyZExpc3QSOwoMbGVhZGVyYm9hcmRzGAEgAygLMhcubmFrYW1hLmFwaS5MZWFkZXJib2FyZFIMbGVhZGVyYm9hcmRzEhYKBmN1cnNvchgCIAEoCVIGY3Vyc29y');
+    'Cg9MZWFkZXJib2FyZExpc3QSOwoMbGVhZGVyYm9hcmRzGAEgAygLMhcubmFrYW1hLmFwaS5MZW'
+    'FkZXJib2FyZFIMbGVhZGVyYm9hcmRzEhYKBmN1cnNvchgCIAEoCVIGY3Vyc29y');
+
 @$core.Deprecated('Use leaderboardRecordDescriptor instead')
-const LeaderboardRecord$json = const {
+const LeaderboardRecord$json = {
   '1': 'LeaderboardRecord',
-  '2': const [
-    const {
-      '1': 'leaderboard_id',
-      '3': 1,
-      '4': 1,
-      '5': 9,
-      '10': 'leaderboardId'
-    },
-    const {'1': 'owner_id', '3': 2, '4': 1, '5': 9, '10': 'ownerId'},
-    const {
+  '2': [
+    {'1': 'leaderboard_id', '3': 1, '4': 1, '5': 9, '10': 'leaderboardId'},
+    {'1': 'owner_id', '3': 2, '4': 1, '5': 9, '10': 'ownerId'},
+    {
       '1': 'username',
       '3': 3,
       '4': 1,
@@ -1370,11 +1564,11 @@ const LeaderboardRecord$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'username'
     },
-    const {'1': 'score', '3': 4, '4': 1, '5': 3, '10': 'score'},
-    const {'1': 'subscore', '3': 5, '4': 1, '5': 3, '10': 'subscore'},
-    const {'1': 'num_score', '3': 6, '4': 1, '5': 5, '10': 'numScore'},
-    const {'1': 'metadata', '3': 7, '4': 1, '5': 9, '10': 'metadata'},
-    const {
+    {'1': 'score', '3': 4, '4': 1, '5': 3, '10': 'score'},
+    {'1': 'subscore', '3': 5, '4': 1, '5': 3, '10': 'subscore'},
+    {'1': 'num_score', '3': 6, '4': 1, '5': 5, '10': 'numScore'},
+    {'1': 'metadata', '3': 7, '4': 1, '5': 9, '10': 'metadata'},
+    {
       '1': 'create_time',
       '3': 8,
       '4': 1,
@@ -1382,7 +1576,7 @@ const LeaderboardRecord$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 9,
       '4': 1,
@@ -1390,7 +1584,7 @@ const LeaderboardRecord$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'updateTime'
     },
-    const {
+    {
       '1': 'expiry_time',
       '3': 10,
       '4': 1,
@@ -1398,19 +1592,28 @@ const LeaderboardRecord$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'expiryTime'
     },
-    const {'1': 'rank', '3': 11, '4': 1, '5': 3, '10': 'rank'},
-    const {'1': 'max_num_score', '3': 12, '4': 1, '5': 13, '10': 'maxNumScore'},
+    {'1': 'rank', '3': 11, '4': 1, '5': 3, '10': 'rank'},
+    {'1': 'max_num_score', '3': 12, '4': 1, '5': 13, '10': 'maxNumScore'},
   ],
 };
 
 /// Descriptor for `LeaderboardRecord`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List leaderboardRecordDescriptor = $convert.base64Decode(
-    'ChFMZWFkZXJib2FyZFJlY29yZBIlCg5sZWFkZXJib2FyZF9pZBgBIAEoCVINbGVhZGVyYm9hcmRJZBIZCghvd25lcl9pZBgCIAEoCVIHb3duZXJJZBI4Cgh1c2VybmFtZRgDIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIIdXNlcm5hbWUSFAoFc2NvcmUYBCABKANSBXNjb3JlEhoKCHN1YnNjb3JlGAUgASgDUghzdWJzY29yZRIbCgludW1fc2NvcmUYBiABKAVSCG51bVNjb3JlEhoKCG1ldGFkYXRhGAcgASgJUghtZXRhZGF0YRI7CgtjcmVhdGVfdGltZRgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCmNyZWF0ZVRpbWUSOwoLdXBkYXRlX3RpbWUYCSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgp1cGRhdGVUaW1lEjsKC2V4cGlyeV90aW1lGAogASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKZXhwaXJ5VGltZRISCgRyYW5rGAsgASgDUgRyYW5rEiIKDW1heF9udW1fc2NvcmUYDCABKA1SC21heE51bVNjb3Jl');
+    'ChFMZWFkZXJib2FyZFJlY29yZBIlCg5sZWFkZXJib2FyZF9pZBgBIAEoCVINbGVhZGVyYm9hcm'
+    'RJZBIZCghvd25lcl9pZBgCIAEoCVIHb3duZXJJZBI4Cgh1c2VybmFtZRgDIAEoCzIcLmdvb2ds'
+    'ZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIIdXNlcm5hbWUSFAoFc2NvcmUYBCABKANSBXNjb3JlEh'
+    'oKCHN1YnNjb3JlGAUgASgDUghzdWJzY29yZRIbCgludW1fc2NvcmUYBiABKAVSCG51bVNjb3Jl'
+    'EhoKCG1ldGFkYXRhGAcgASgJUghtZXRhZGF0YRI7CgtjcmVhdGVfdGltZRgIIAEoCzIaLmdvb2'
+    'dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCmNyZWF0ZVRpbWUSOwoLdXBkYXRlX3RpbWUYCSABKAsy'
+    'Gi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgp1cGRhdGVUaW1lEjsKC2V4cGlyeV90aW1lGA'
+    'ogASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKZXhwaXJ5VGltZRISCgRyYW5rGAsg'
+    'ASgDUgRyYW5rEiIKDW1heF9udW1fc2NvcmUYDCABKA1SC21heE51bVNjb3Jl');
+
 @$core.Deprecated('Use leaderboardRecordListDescriptor instead')
-const LeaderboardRecordList$json = const {
+const LeaderboardRecordList$json = {
   '1': 'LeaderboardRecordList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'records',
       '3': 1,
       '4': 3,
@@ -1418,7 +1621,7 @@ const LeaderboardRecordList$json = const {
       '6': '.nakama.api.LeaderboardRecord',
       '10': 'records'
     },
-    const {
+    {
       '1': 'owner_records',
       '3': 2,
       '4': 3,
@@ -1426,30 +1629,37 @@ const LeaderboardRecordList$json = const {
       '6': '.nakama.api.LeaderboardRecord',
       '10': 'ownerRecords'
     },
-    const {'1': 'next_cursor', '3': 3, '4': 1, '5': 9, '10': 'nextCursor'},
-    const {'1': 'prev_cursor', '3': 4, '4': 1, '5': 9, '10': 'prevCursor'},
+    {'1': 'next_cursor', '3': 3, '4': 1, '5': 9, '10': 'nextCursor'},
+    {'1': 'prev_cursor', '3': 4, '4': 1, '5': 9, '10': 'prevCursor'},
+    {'1': 'rank_count', '3': 5, '4': 1, '5': 3, '10': 'rankCount'},
   ],
 };
 
 /// Descriptor for `LeaderboardRecordList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List leaderboardRecordListDescriptor = $convert.base64Decode(
-    'ChVMZWFkZXJib2FyZFJlY29yZExpc3QSNwoHcmVjb3JkcxgBIAMoCzIdLm5ha2FtYS5hcGkuTGVhZGVyYm9hcmRSZWNvcmRSB3JlY29yZHMSQgoNb3duZXJfcmVjb3JkcxgCIAMoCzIdLm5ha2FtYS5hcGkuTGVhZGVyYm9hcmRSZWNvcmRSDG93bmVyUmVjb3JkcxIfCgtuZXh0X2N1cnNvchgDIAEoCVIKbmV4dEN1cnNvchIfCgtwcmV2X2N1cnNvchgEIAEoCVIKcHJldkN1cnNvcg==');
+    'ChVMZWFkZXJib2FyZFJlY29yZExpc3QSNwoHcmVjb3JkcxgBIAMoCzIdLm5ha2FtYS5hcGkuTG'
+    'VhZGVyYm9hcmRSZWNvcmRSB3JlY29yZHMSQgoNb3duZXJfcmVjb3JkcxgCIAMoCzIdLm5ha2Ft'
+    'YS5hcGkuTGVhZGVyYm9hcmRSZWNvcmRSDG93bmVyUmVjb3JkcxIfCgtuZXh0X2N1cnNvchgDIA'
+    'EoCVIKbmV4dEN1cnNvchIfCgtwcmV2X2N1cnNvchgEIAEoCVIKcHJldkN1cnNvchIdCgpyYW5r'
+    'X2NvdW50GAUgASgDUglyYW5rQ291bnQ=');
+
 @$core.Deprecated('Use leaveGroupRequestDescriptor instead')
-const LeaveGroupRequest$json = const {
+const LeaveGroupRequest$json = {
   '1': 'LeaveGroupRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
   ],
 };
 
 /// Descriptor for `LeaveGroupRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List leaveGroupRequestDescriptor = $convert.base64Decode(
     'ChFMZWF2ZUdyb3VwUmVxdWVzdBIZCghncm91cF9pZBgBIAEoCVIHZ3JvdXBJZA==');
+
 @$core.Deprecated('Use linkFacebookRequestDescriptor instead')
-const LinkFacebookRequest$json = const {
+const LinkFacebookRequest$json = {
   '1': 'LinkFacebookRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -1457,7 +1667,7 @@ const LinkFacebookRequest$json = const {
       '6': '.nakama.api.AccountFacebook',
       '10': 'account'
     },
-    const {
+    {
       '1': 'sync',
       '3': 2,
       '4': 1,
@@ -1470,12 +1680,15 @@ const LinkFacebookRequest$json = const {
 
 /// Descriptor for `LinkFacebookRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List linkFacebookRequestDescriptor = $convert.base64Decode(
-    'ChNMaW5rRmFjZWJvb2tSZXF1ZXN0EjUKB2FjY291bnQYASABKAsyGy5uYWthbWEuYXBpLkFjY291bnRGYWNlYm9va1IHYWNjb3VudBIuCgRzeW5jGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIEc3luYw==');
+    'ChNMaW5rRmFjZWJvb2tSZXF1ZXN0EjUKB2FjY291bnQYASABKAsyGy5uYWthbWEuYXBpLkFjY2'
+    '91bnRGYWNlYm9va1IHYWNjb3VudBIuCgRzeW5jGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJv'
+    'b2xWYWx1ZVIEc3luYw==');
+
 @$core.Deprecated('Use linkSteamRequestDescriptor instead')
-const LinkSteamRequest$json = const {
+const LinkSteamRequest$json = {
   '1': 'LinkSteamRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'account',
       '3': 1,
       '4': 1,
@@ -1483,7 +1696,7 @@ const LinkSteamRequest$json = const {
       '6': '.nakama.api.AccountSteam',
       '10': 'account'
     },
-    const {
+    {
       '1': 'sync',
       '3': 2,
       '4': 1,
@@ -1496,13 +1709,16 @@ const LinkSteamRequest$json = const {
 
 /// Descriptor for `LinkSteamRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List linkSteamRequestDescriptor = $convert.base64Decode(
-    'ChBMaW5rU3RlYW1SZXF1ZXN0EjIKB2FjY291bnQYASABKAsyGC5uYWthbWEuYXBpLkFjY291bnRTdGVhbVIHYWNjb3VudBIuCgRzeW5jGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIEc3luYw==');
+    'ChBMaW5rU3RlYW1SZXF1ZXN0EjIKB2FjY291bnQYASABKAsyGC5uYWthbWEuYXBpLkFjY291bn'
+    'RTdGVhbVIHYWNjb3VudBIuCgRzeW5jGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1'
+    'ZVIEc3luYw==');
+
 @$core.Deprecated('Use listChannelMessagesRequestDescriptor instead')
-const ListChannelMessagesRequest$json = const {
+const ListChannelMessagesRequest$json = {
   '1': 'ListChannelMessagesRequest',
-  '2': const [
-    const {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
-    const {
+  '2': [
+    {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
+    {
       '1': 'limit',
       '3': 2,
       '4': 1,
@@ -1510,7 +1726,7 @@ const ListChannelMessagesRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {
+    {
       '1': 'forward',
       '3': 3,
       '4': 1,
@@ -1518,19 +1734,22 @@ const ListChannelMessagesRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'forward'
     },
-    const {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListChannelMessagesRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listChannelMessagesRequestDescriptor =
-    $convert.base64Decode(
-        'ChpMaXN0Q2hhbm5lbE1lc3NhZ2VzUmVxdWVzdBIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSMQoFbGltaXQYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQSNAoHZm9yd2FyZBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSB2ZvcndhcmQSFgoGY3Vyc29yGAQgASgJUgZjdXJzb3I=');
+final $typed_data.Uint8List listChannelMessagesRequestDescriptor = $convert.base64Decode(
+    'ChpMaXN0Q2hhbm5lbE1lc3NhZ2VzUmVxdWVzdBIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubm'
+    'VsSWQSMQoFbGltaXQYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQS'
+    'NAoHZm9yd2FyZBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSB2ZvcndhcmQSFg'
+    'oGY3Vyc29yGAQgASgJUgZjdXJzb3I=');
+
 @$core.Deprecated('Use listFriendsRequestDescriptor instead')
-const ListFriendsRequest$json = const {
+const ListFriendsRequest$json = {
   '1': 'ListFriendsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'limit',
       '3': 1,
       '4': 1,
@@ -1538,7 +1757,7 @@ const ListFriendsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {
+    {
       '1': 'state',
       '3': 2,
       '4': 1,
@@ -1546,20 +1765,45 @@ const ListFriendsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'state'
     },
-    const {'1': 'cursor', '3': 3, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 3, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListFriendsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List listFriendsRequestDescriptor = $convert.base64Decode(
-    'ChJMaXN0RnJpZW5kc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQSMQoFc3RhdGUYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFc3RhdGUSFgoGY3Vyc29yGAMgASgJUgZjdXJzb3I=');
+    'ChJMaXN0RnJpZW5kc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG9idWYuSW'
+    '50MzJWYWx1ZVIFbGltaXQSMQoFc3RhdGUYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJW'
+    'YWx1ZVIFc3RhdGUSFgoGY3Vyc29yGAMgASgJUgZjdXJzb3I=');
+
+@$core.Deprecated('Use listFriendsOfFriendsRequestDescriptor instead')
+const ListFriendsOfFriendsRequest$json = {
+  '1': 'ListFriendsOfFriendsRequest',
+  '2': [
+    {
+      '1': 'limit',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Int32Value',
+      '10': 'limit'
+    },
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+  ],
+};
+
+/// Descriptor for `ListFriendsOfFriendsRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List listFriendsOfFriendsRequestDescriptor =
+    $convert.base64Decode(
+        'ChtMaXN0RnJpZW5kc09mRnJpZW5kc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucH'
+        'JvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQSFgoGY3Vyc29yGAIgASgJUgZjdXJzb3I=');
+
 @$core.Deprecated('Use listGroupsRequestDescriptor instead')
-const ListGroupsRequest$json = const {
+const ListGroupsRequest$json = {
   '1': 'ListGroupsRequest',
-  '2': const [
-    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
-    const {
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {
       '1': 'limit',
       '3': 3,
       '4': 1,
@@ -1567,8 +1811,8 @@ const ListGroupsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {'1': 'lang_tag', '3': 4, '4': 1, '5': 9, '10': 'langTag'},
-    const {
+    {'1': 'lang_tag', '3': 4, '4': 1, '5': 9, '10': 'langTag'},
+    {
       '1': 'members',
       '3': 5,
       '4': 1,
@@ -1576,7 +1820,7 @@ const ListGroupsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'members'
     },
-    const {
+    {
       '1': 'open',
       '3': 6,
       '4': 1,
@@ -1589,13 +1833,18 @@ const ListGroupsRequest$json = const {
 
 /// Descriptor for `ListGroupsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List listGroupsRequestDescriptor = $convert.base64Decode(
-    'ChFMaXN0R3JvdXBzUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhYKBmN1cnNvchgCIAEoCVIGY3Vyc29yEjEKBWxpbWl0GAMgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhkKCGxhbmdfdGFnGAQgASgJUgdsYW5nVGFnEjUKB21lbWJlcnMYBSABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIHbWVtYmVycxIuCgRvcGVuGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIEb3Blbg==');
+    'ChFMaXN0R3JvdXBzUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEhYKBmN1cnNvchgCIAEoCV'
+    'IGY3Vyc29yEjEKBWxpbWl0GAMgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxp'
+    'bWl0EhkKCGxhbmdfdGFnGAQgASgJUgdsYW5nVGFnEjUKB21lbWJlcnMYBSABKAsyGy5nb29nbG'
+    'UucHJvdG9idWYuSW50MzJWYWx1ZVIHbWVtYmVycxIuCgRvcGVuGAYgASgLMhouZ29vZ2xlLnBy'
+    'b3RvYnVmLkJvb2xWYWx1ZVIEb3Blbg==');
+
 @$core.Deprecated('Use listGroupUsersRequestDescriptor instead')
-const ListGroupUsersRequest$json = const {
+const ListGroupUsersRequest$json = {
   '1': 'ListGroupUsersRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
-    const {
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+    {
       '1': 'limit',
       '3': 2,
       '4': 1,
@@ -1603,7 +1852,7 @@ const ListGroupUsersRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {
+    {
       '1': 'state',
       '3': 3,
       '4': 1,
@@ -1611,26 +1860,24 @@ const ListGroupUsersRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'state'
     },
-    const {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListGroupUsersRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List listGroupUsersRequestDescriptor = $convert.base64Decode(
-    'ChVMaXN0R3JvdXBVc2Vyc1JlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQSMQoFbGltaXQYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQSMQoFc3RhdGUYAyABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFc3RhdGUSFgoGY3Vyc29yGAQgASgJUgZjdXJzb3I=');
+    'ChVMaXN0R3JvdXBVc2Vyc1JlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQSMQoFbG'
+    'ltaXQYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQSMQoFc3RhdGUY'
+    'AyABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFc3RhdGUSFgoGY3Vyc29yGAQgAS'
+    'gJUgZjdXJzb3I=');
+
 @$core.Deprecated(
     'Use listLeaderboardRecordsAroundOwnerRequestDescriptor instead')
-const ListLeaderboardRecordsAroundOwnerRequest$json = const {
+const ListLeaderboardRecordsAroundOwnerRequest$json = {
   '1': 'ListLeaderboardRecordsAroundOwnerRequest',
-  '2': const [
-    const {
-      '1': 'leaderboard_id',
-      '3': 1,
-      '4': 1,
-      '5': 9,
-      '10': 'leaderboardId'
-    },
-    const {
+  '2': [
+    {'1': 'leaderboard_id', '3': 1, '4': 1, '5': 9, '10': 'leaderboardId'},
+    {
       '1': 'limit',
       '3': 2,
       '4': 1,
@@ -1638,8 +1885,8 @@ const ListLeaderboardRecordsAroundOwnerRequest$json = const {
       '6': '.google.protobuf.UInt32Value',
       '10': 'limit'
     },
-    const {'1': 'owner_id', '3': 3, '4': 1, '5': 9, '10': 'ownerId'},
-    const {
+    {'1': 'owner_id', '3': 3, '4': 1, '5': 9, '10': 'ownerId'},
+    {
       '1': 'expiry',
       '3': 4,
       '4': 1,
@@ -1647,27 +1894,26 @@ const ListLeaderboardRecordsAroundOwnerRequest$json = const {
       '6': '.google.protobuf.Int64Value',
       '10': 'expiry'
     },
-    const {'1': 'cursor', '3': 5, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 5, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListLeaderboardRecordsAroundOwnerRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List listLeaderboardRecordsAroundOwnerRequestDescriptor =
     $convert.base64Decode(
-        'CihMaXN0TGVhZGVyYm9hcmRSZWNvcmRzQXJvdW5kT3duZXJSZXF1ZXN0EiUKDmxlYWRlcmJvYXJkX2lkGAEgASgJUg1sZWFkZXJib2FyZElkEjIKBWxpbWl0GAIgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlVJbnQzMlZhbHVlUgVsaW1pdBIZCghvd25lcl9pZBgDIAEoCVIHb3duZXJJZBIzCgZleHBpcnkYBCABKAsyGy5nb29nbGUucHJvdG9idWYuSW50NjRWYWx1ZVIGZXhwaXJ5EhYKBmN1cnNvchgFIAEoCVIGY3Vyc29y');
+        'CihMaXN0TGVhZGVyYm9hcmRSZWNvcmRzQXJvdW5kT3duZXJSZXF1ZXN0EiUKDmxlYWRlcmJvYX'
+        'JkX2lkGAEgASgJUg1sZWFkZXJib2FyZElkEjIKBWxpbWl0GAIgASgLMhwuZ29vZ2xlLnByb3Rv'
+        'YnVmLlVJbnQzMlZhbHVlUgVsaW1pdBIZCghvd25lcl9pZBgDIAEoCVIHb3duZXJJZBIzCgZleH'
+        'BpcnkYBCABKAsyGy5nb29nbGUucHJvdG9idWYuSW50NjRWYWx1ZVIGZXhwaXJ5EhYKBmN1cnNv'
+        'chgFIAEoCVIGY3Vyc29y');
+
 @$core.Deprecated('Use listLeaderboardRecordsRequestDescriptor instead')
-const ListLeaderboardRecordsRequest$json = const {
+const ListLeaderboardRecordsRequest$json = {
   '1': 'ListLeaderboardRecordsRequest',
-  '2': const [
-    const {
-      '1': 'leaderboard_id',
-      '3': 1,
-      '4': 1,
-      '5': 9,
-      '10': 'leaderboardId'
-    },
-    const {'1': 'owner_ids', '3': 2, '4': 3, '5': 9, '10': 'ownerIds'},
-    const {
+  '2': [
+    {'1': 'leaderboard_id', '3': 1, '4': 1, '5': 9, '10': 'leaderboardId'},
+    {'1': 'owner_ids', '3': 2, '4': 3, '5': 9, '10': 'ownerIds'},
+    {
       '1': 'limit',
       '3': 3,
       '4': 1,
@@ -1675,8 +1921,8 @@ const ListLeaderboardRecordsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
-    const {
+    {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
+    {
       '1': 'expiry',
       '3': 5,
       '4': 1,
@@ -1688,14 +1934,18 @@ const ListLeaderboardRecordsRequest$json = const {
 };
 
 /// Descriptor for `ListLeaderboardRecordsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listLeaderboardRecordsRequestDescriptor =
-    $convert.base64Decode(
-        'Ch1MaXN0TGVhZGVyYm9hcmRSZWNvcmRzUmVxdWVzdBIlCg5sZWFkZXJib2FyZF9pZBgBIAEoCVINbGVhZGVyYm9hcmRJZBIbCglvd25lcl9pZHMYAiADKAlSCG93bmVySWRzEjEKBWxpbWl0GAMgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhYKBmN1cnNvchgEIAEoCVIGY3Vyc29yEjMKBmV4cGlyeRgFIAEoCzIbLmdvb2dsZS5wcm90b2J1Zi5JbnQ2NFZhbHVlUgZleHBpcnk=');
+final $typed_data.Uint8List listLeaderboardRecordsRequestDescriptor = $convert.base64Decode(
+    'Ch1MaXN0TGVhZGVyYm9hcmRSZWNvcmRzUmVxdWVzdBIlCg5sZWFkZXJib2FyZF9pZBgBIAEoCV'
+    'INbGVhZGVyYm9hcmRJZBIbCglvd25lcl9pZHMYAiADKAlSCG93bmVySWRzEjEKBWxpbWl0GAMg'
+    'ASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhYKBmN1cnNvchgEIAEoCV'
+    'IGY3Vyc29yEjMKBmV4cGlyeRgFIAEoCzIbLmdvb2dsZS5wcm90b2J1Zi5JbnQ2NFZhbHVlUgZl'
+    'eHBpcnk=');
+
 @$core.Deprecated('Use listMatchesRequestDescriptor instead')
-const ListMatchesRequest$json = const {
+const ListMatchesRequest$json = {
   '1': 'ListMatchesRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'limit',
       '3': 1,
       '4': 1,
@@ -1703,7 +1953,7 @@ const ListMatchesRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {
+    {
       '1': 'authoritative',
       '3': 2,
       '4': 1,
@@ -1711,7 +1961,7 @@ const ListMatchesRequest$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'authoritative'
     },
-    const {
+    {
       '1': 'label',
       '3': 3,
       '4': 1,
@@ -1719,7 +1969,7 @@ const ListMatchesRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'label'
     },
-    const {
+    {
       '1': 'min_size',
       '3': 4,
       '4': 1,
@@ -1727,7 +1977,7 @@ const ListMatchesRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'minSize'
     },
-    const {
+    {
       '1': 'max_size',
       '3': 5,
       '4': 1,
@@ -1735,7 +1985,7 @@ const ListMatchesRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'maxSize'
     },
-    const {
+    {
       '1': 'query',
       '3': 6,
       '4': 1,
@@ -1748,12 +1998,19 @@ const ListMatchesRequest$json = const {
 
 /// Descriptor for `ListMatchesRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List listMatchesRequestDescriptor = $convert.base64Decode(
-    'ChJMaXN0TWF0Y2hlc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQSQAoNYXV0aG9yaXRhdGl2ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSDWF1dGhvcml0YXRpdmUSMgoFbGFiZWwYAyABKAsyHC5nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWVSBWxhYmVsEjYKCG1pbl9zaXplGAQgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSB21pblNpemUSNgoIbWF4X3NpemUYBSABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIHbWF4U2l6ZRIyCgVxdWVyeRgGIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIFcXVlcnk=');
+    'ChJMaXN0TWF0Y2hlc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG9idWYuSW'
+    '50MzJWYWx1ZVIFbGltaXQSQAoNYXV0aG9yaXRhdGl2ZRgCIAEoCzIaLmdvb2dsZS5wcm90b2J1'
+    'Zi5Cb29sVmFsdWVSDWF1dGhvcml0YXRpdmUSMgoFbGFiZWwYAyABKAsyHC5nb29nbGUucHJvdG'
+    '9idWYuU3RyaW5nVmFsdWVSBWxhYmVsEjYKCG1pbl9zaXplGAQgASgLMhsuZ29vZ2xlLnByb3Rv'
+    'YnVmLkludDMyVmFsdWVSB21pblNpemUSNgoIbWF4X3NpemUYBSABKAsyGy5nb29nbGUucHJvdG'
+    '9idWYuSW50MzJWYWx1ZVIHbWF4U2l6ZRIyCgVxdWVyeRgGIAEoCzIcLmdvb2dsZS5wcm90b2J1'
+    'Zi5TdHJpbmdWYWx1ZVIFcXVlcnk=');
+
 @$core.Deprecated('Use listNotificationsRequestDescriptor instead')
-const ListNotificationsRequest$json = const {
+const ListNotificationsRequest$json = {
   '1': 'ListNotificationsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'limit',
       '3': 1,
       '4': 1,
@@ -1761,27 +2018,23 @@ const ListNotificationsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {
-      '1': 'cacheable_cursor',
-      '3': 2,
-      '4': 1,
-      '5': 9,
-      '10': 'cacheableCursor'
-    },
+    {'1': 'cacheable_cursor', '3': 2, '4': 1, '5': 9, '10': 'cacheableCursor'},
   ],
 };
 
 /// Descriptor for `ListNotificationsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listNotificationsRequestDescriptor =
-    $convert.base64Decode(
-        'ChhMaXN0Tm90aWZpY2F0aW9uc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQSKQoQY2FjaGVhYmxlX2N1cnNvchgCIAEoCVIPY2FjaGVhYmxlQ3Vyc29y');
+final $typed_data.Uint8List listNotificationsRequestDescriptor = $convert.base64Decode(
+    'ChhMaXN0Tm90aWZpY2F0aW9uc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG'
+    '9idWYuSW50MzJWYWx1ZVIFbGltaXQSKQoQY2FjaGVhYmxlX2N1cnNvchgCIAEoCVIPY2FjaGVh'
+    'YmxlQ3Vyc29y');
+
 @$core.Deprecated('Use listStorageObjectsRequestDescriptor instead')
-const ListStorageObjectsRequest$json = const {
+const ListStorageObjectsRequest$json = {
   '1': 'ListStorageObjectsRequest',
-  '2': const [
-    const {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
-    const {'1': 'collection', '3': 2, '4': 1, '5': 9, '10': 'collection'},
-    const {
+  '2': [
+    {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
+    {'1': 'collection', '3': 2, '4': 1, '5': 9, '10': 'collection'},
+    {
       '1': 'limit',
       '3': 3,
       '4': 1,
@@ -1789,19 +2042,21 @@ const ListStorageObjectsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListStorageObjectsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listStorageObjectsRequestDescriptor =
-    $convert.base64Decode(
-        'ChlMaXN0U3RvcmFnZU9iamVjdHNSZXF1ZXN0EhcKB3VzZXJfaWQYASABKAlSBnVzZXJJZBIeCgpjb2xsZWN0aW9uGAIgASgJUgpjb2xsZWN0aW9uEjEKBWxpbWl0GAMgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhYKBmN1cnNvchgEIAEoCVIGY3Vyc29y');
+final $typed_data.Uint8List listStorageObjectsRequestDescriptor = $convert.base64Decode(
+    'ChlMaXN0U3RvcmFnZU9iamVjdHNSZXF1ZXN0EhcKB3VzZXJfaWQYASABKAlSBnVzZXJJZBIeCg'
+    'pjb2xsZWN0aW9uGAIgASgJUgpjb2xsZWN0aW9uEjEKBWxpbWl0GAMgASgLMhsuZ29vZ2xlLnBy'
+    'b3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhYKBmN1cnNvchgEIAEoCVIGY3Vyc29y');
+
 @$core.Deprecated('Use listSubscriptionsRequestDescriptor instead')
-const ListSubscriptionsRequest$json = const {
+const ListSubscriptionsRequest$json = {
   '1': 'ListSubscriptionsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'limit',
       '3': 1,
       '4': 1,
@@ -1809,21 +2064,23 @@ const ListSubscriptionsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListSubscriptionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List listSubscriptionsRequestDescriptor =
     $convert.base64Decode(
-        'ChhMaXN0U3Vic2NyaXB0aW9uc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFbGltaXQSFgoGY3Vyc29yGAIgASgJUgZjdXJzb3I=');
+        'ChhMaXN0U3Vic2NyaXB0aW9uc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG'
+        '9idWYuSW50MzJWYWx1ZVIFbGltaXQSFgoGY3Vyc29yGAIgASgJUgZjdXJzb3I=');
+
 @$core
     .Deprecated('Use listTournamentRecordsAroundOwnerRequestDescriptor instead')
-const ListTournamentRecordsAroundOwnerRequest$json = const {
+const ListTournamentRecordsAroundOwnerRequest$json = {
   '1': 'ListTournamentRecordsAroundOwnerRequest',
-  '2': const [
-    const {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
-    const {
+  '2': [
+    {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
+    {
       '1': 'limit',
       '3': 2,
       '4': 1,
@@ -1831,8 +2088,8 @@ const ListTournamentRecordsAroundOwnerRequest$json = const {
       '6': '.google.protobuf.UInt32Value',
       '10': 'limit'
     },
-    const {'1': 'owner_id', '3': 3, '4': 1, '5': 9, '10': 'ownerId'},
-    const {
+    {'1': 'owner_id', '3': 3, '4': 1, '5': 9, '10': 'ownerId'},
+    {
       '1': 'expiry',
       '3': 4,
       '4': 1,
@@ -1840,21 +2097,26 @@ const ListTournamentRecordsAroundOwnerRequest$json = const {
       '6': '.google.protobuf.Int64Value',
       '10': 'expiry'
     },
-    const {'1': 'cursor', '3': 5, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 5, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListTournamentRecordsAroundOwnerRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List listTournamentRecordsAroundOwnerRequestDescriptor =
     $convert.base64Decode(
-        'CidMaXN0VG91cm5hbWVudFJlY29yZHNBcm91bmRPd25lclJlcXVlc3QSIwoNdG91cm5hbWVudF9pZBgBIAEoCVIMdG91cm5hbWVudElkEjIKBWxpbWl0GAIgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlVJbnQzMlZhbHVlUgVsaW1pdBIZCghvd25lcl9pZBgDIAEoCVIHb3duZXJJZBIzCgZleHBpcnkYBCABKAsyGy5nb29nbGUucHJvdG9idWYuSW50NjRWYWx1ZVIGZXhwaXJ5EhYKBmN1cnNvchgFIAEoCVIGY3Vyc29y');
+        'CidMaXN0VG91cm5hbWVudFJlY29yZHNBcm91bmRPd25lclJlcXVlc3QSIwoNdG91cm5hbWVudF'
+        '9pZBgBIAEoCVIMdG91cm5hbWVudElkEjIKBWxpbWl0GAIgASgLMhwuZ29vZ2xlLnByb3RvYnVm'
+        'LlVJbnQzMlZhbHVlUgVsaW1pdBIZCghvd25lcl9pZBgDIAEoCVIHb3duZXJJZBIzCgZleHBpcn'
+        'kYBCABKAsyGy5nb29nbGUucHJvdG9idWYuSW50NjRWYWx1ZVIGZXhwaXJ5EhYKBmN1cnNvchgF'
+        'IAEoCVIGY3Vyc29y');
+
 @$core.Deprecated('Use listTournamentRecordsRequestDescriptor instead')
-const ListTournamentRecordsRequest$json = const {
+const ListTournamentRecordsRequest$json = {
   '1': 'ListTournamentRecordsRequest',
-  '2': const [
-    const {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
-    const {'1': 'owner_ids', '3': 2, '4': 3, '5': 9, '10': 'ownerIds'},
-    const {
+  '2': [
+    {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
+    {'1': 'owner_ids', '3': 2, '4': 3, '5': 9, '10': 'ownerIds'},
+    {
       '1': 'limit',
       '3': 3,
       '4': 1,
@@ -1862,8 +2124,8 @@ const ListTournamentRecordsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
-    const {
+    {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
+    {
       '1': 'expiry',
       '3': 5,
       '4': 1,
@@ -1875,14 +2137,18 @@ const ListTournamentRecordsRequest$json = const {
 };
 
 /// Descriptor for `ListTournamentRecordsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listTournamentRecordsRequestDescriptor =
-    $convert.base64Decode(
-        'ChxMaXN0VG91cm5hbWVudFJlY29yZHNSZXF1ZXN0EiMKDXRvdXJuYW1lbnRfaWQYASABKAlSDHRvdXJuYW1lbnRJZBIbCglvd25lcl9pZHMYAiADKAlSCG93bmVySWRzEjEKBWxpbWl0GAMgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhYKBmN1cnNvchgEIAEoCVIGY3Vyc29yEjMKBmV4cGlyeRgFIAEoCzIbLmdvb2dsZS5wcm90b2J1Zi5JbnQ2NFZhbHVlUgZleHBpcnk=');
+final $typed_data.Uint8List listTournamentRecordsRequestDescriptor = $convert.base64Decode(
+    'ChxMaXN0VG91cm5hbWVudFJlY29yZHNSZXF1ZXN0EiMKDXRvdXJuYW1lbnRfaWQYASABKAlSDH'
+    'RvdXJuYW1lbnRJZBIbCglvd25lcl9pZHMYAiADKAlSCG93bmVySWRzEjEKBWxpbWl0GAMgASgL'
+    'MhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhYKBmN1cnNvchgEIAEoCVIGY3'
+    'Vyc29yEjMKBmV4cGlyeRgFIAEoCzIbLmdvb2dsZS5wcm90b2J1Zi5JbnQ2NFZhbHVlUgZleHBp'
+    'cnk=');
+
 @$core.Deprecated('Use listTournamentsRequestDescriptor instead')
-const ListTournamentsRequest$json = const {
+const ListTournamentsRequest$json = {
   '1': 'ListTournamentsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'category_start',
       '3': 1,
       '4': 1,
@@ -1890,7 +2156,7 @@ const ListTournamentsRequest$json = const {
       '6': '.google.protobuf.UInt32Value',
       '10': 'categoryStart'
     },
-    const {
+    {
       '1': 'category_end',
       '3': 2,
       '4': 1,
@@ -1898,7 +2164,7 @@ const ListTournamentsRequest$json = const {
       '6': '.google.protobuf.UInt32Value',
       '10': 'categoryEnd'
     },
-    const {
+    {
       '1': 'start_time',
       '3': 3,
       '4': 1,
@@ -1906,7 +2172,7 @@ const ListTournamentsRequest$json = const {
       '6': '.google.protobuf.UInt32Value',
       '10': 'startTime'
     },
-    const {
+    {
       '1': 'end_time',
       '3': 4,
       '4': 1,
@@ -1914,7 +2180,7 @@ const ListTournamentsRequest$json = const {
       '6': '.google.protobuf.UInt32Value',
       '10': 'endTime'
     },
-    const {
+    {
       '1': 'limit',
       '3': 6,
       '4': 1,
@@ -1922,20 +2188,26 @@ const ListTournamentsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {'1': 'cursor', '3': 8, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 8, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListTournamentsRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List listTournamentsRequestDescriptor =
-    $convert.base64Decode(
-        'ChZMaXN0VG91cm5hbWVudHNSZXF1ZXN0EkMKDmNhdGVnb3J5X3N0YXJ0GAEgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlVJbnQzMlZhbHVlUg1jYXRlZ29yeVN0YXJ0Ej8KDGNhdGVnb3J5X2VuZBgCIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5VSW50MzJWYWx1ZVILY2F0ZWdvcnlFbmQSOwoKc3RhcnRfdGltZRgDIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5VSW50MzJWYWx1ZVIJc3RhcnRUaW1lEjcKCGVuZF90aW1lGAQgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlVJbnQzMlZhbHVlUgdlbmRUaW1lEjEKBWxpbWl0GAYgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhYKBmN1cnNvchgIIAEoCVIGY3Vyc29y');
+final $typed_data.Uint8List listTournamentsRequestDescriptor = $convert.base64Decode(
+    'ChZMaXN0VG91cm5hbWVudHNSZXF1ZXN0EkMKDmNhdGVnb3J5X3N0YXJ0GAEgASgLMhwuZ29vZ2'
+    'xlLnByb3RvYnVmLlVJbnQzMlZhbHVlUg1jYXRlZ29yeVN0YXJ0Ej8KDGNhdGVnb3J5X2VuZBgC'
+    'IAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5VSW50MzJWYWx1ZVILY2F0ZWdvcnlFbmQSOwoKc3Rhcn'
+    'RfdGltZRgDIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5VSW50MzJWYWx1ZVIJc3RhcnRUaW1lEjcK'
+    'CGVuZF90aW1lGAQgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlVJbnQzMlZhbHVlUgdlbmRUaW1lEj'
+    'EKBWxpbWl0GAYgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EhYKBmN1'
+    'cnNvchgIIAEoCVIGY3Vyc29y');
+
 @$core.Deprecated('Use listUserGroupsRequestDescriptor instead')
-const ListUserGroupsRequest$json = const {
+const ListUserGroupsRequest$json = {
   '1': 'ListUserGroupsRequest',
-  '2': const [
-    const {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
-    const {
+  '2': [
+    {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
+    {
       '1': 'limit',
       '3': 2,
       '4': 1,
@@ -1943,7 +2215,7 @@ const ListUserGroupsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'limit'
     },
-    const {
+    {
       '1': 'state',
       '3': 3,
       '4': 1,
@@ -1951,20 +2223,24 @@ const ListUserGroupsRequest$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'state'
     },
-    const {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 4, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `ListUserGroupsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List listUserGroupsRequestDescriptor = $convert.base64Decode(
-    'ChVMaXN0VXNlckdyb3Vwc1JlcXVlc3QSFwoHdXNlcl9pZBgBIAEoCVIGdXNlcklkEjEKBWxpbWl0GAIgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EjEKBXN0YXRlGAMgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBXN0YXRlEhYKBmN1cnNvchgEIAEoCVIGY3Vyc29y');
+    'ChVMaXN0VXNlckdyb3Vwc1JlcXVlc3QSFwoHdXNlcl9pZBgBIAEoCVIGdXNlcklkEjEKBWxpbW'
+    'l0GAIgASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBWxpbWl0EjEKBXN0YXRlGAMg'
+    'ASgLMhsuZ29vZ2xlLnByb3RvYnVmLkludDMyVmFsdWVSBXN0YXRlEhYKBmN1cnNvchgEIAEoCV'
+    'IGY3Vyc29y');
+
 @$core.Deprecated('Use matchDescriptor instead')
-const Match$json = const {
+const Match$json = {
   '1': 'Match',
-  '2': const [
-    const {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
-    const {'1': 'authoritative', '3': 2, '4': 1, '5': 8, '10': 'authoritative'},
-    const {
+  '2': [
+    {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
+    {'1': 'authoritative', '3': 2, '4': 1, '5': 8, '10': 'authoritative'},
+    {
       '1': 'label',
       '3': 3,
       '4': 1,
@@ -1972,20 +2248,24 @@ const Match$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'label'
     },
-    const {'1': 'size', '3': 4, '4': 1, '5': 5, '10': 'size'},
-    const {'1': 'tick_rate', '3': 5, '4': 1, '5': 5, '10': 'tickRate'},
-    const {'1': 'handler_name', '3': 6, '4': 1, '5': 9, '10': 'handlerName'},
+    {'1': 'size', '3': 4, '4': 1, '5': 5, '10': 'size'},
+    {'1': 'tick_rate', '3': 5, '4': 1, '5': 5, '10': 'tickRate'},
+    {'1': 'handler_name', '3': 6, '4': 1, '5': 9, '10': 'handlerName'},
   ],
 };
 
 /// Descriptor for `Match`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchDescriptor = $convert.base64Decode(
-    'CgVNYXRjaBIZCghtYXRjaF9pZBgBIAEoCVIHbWF0Y2hJZBIkCg1hdXRob3JpdGF0aXZlGAIgASgIUg1hdXRob3JpdGF0aXZlEjIKBWxhYmVsGAMgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1ZhbHVlUgVsYWJlbBISCgRzaXplGAQgASgFUgRzaXplEhsKCXRpY2tfcmF0ZRgFIAEoBVIIdGlja1JhdGUSIQoMaGFuZGxlcl9uYW1lGAYgASgJUgtoYW5kbGVyTmFtZQ==');
+    'CgVNYXRjaBIZCghtYXRjaF9pZBgBIAEoCVIHbWF0Y2hJZBIkCg1hdXRob3JpdGF0aXZlGAIgAS'
+    'gIUg1hdXRob3JpdGF0aXZlEjIKBWxhYmVsGAMgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmlu'
+    'Z1ZhbHVlUgVsYWJlbBISCgRzaXplGAQgASgFUgRzaXplEhsKCXRpY2tfcmF0ZRgFIAEoBVIIdG'
+    'lja1JhdGUSIQoMaGFuZGxlcl9uYW1lGAYgASgJUgtoYW5kbGVyTmFtZQ==');
+
 @$core.Deprecated('Use matchListDescriptor instead')
-const MatchList$json = const {
+const MatchList$json = {
   '1': 'MatchList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'matches',
       '3': 1,
       '4': 3,
@@ -1998,17 +2278,79 @@ const MatchList$json = const {
 
 /// Descriptor for `MatchList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchListDescriptor = $convert.base64Decode(
-    'CglNYXRjaExpc3QSKwoHbWF0Y2hlcxgBIAMoCzIRLm5ha2FtYS5hcGkuTWF0Y2hSB21hdGNoZXM=');
+    'CglNYXRjaExpc3QSKwoHbWF0Y2hlcxgBIAMoCzIRLm5ha2FtYS5hcGkuTWF0Y2hSB21hdGNoZX'
+    'M=');
+
+@$core.Deprecated('Use matchmakerCompletionStatsDescriptor instead')
+const MatchmakerCompletionStats$json = {
+  '1': 'MatchmakerCompletionStats',
+  '2': [
+    {
+      '1': 'create_time',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Timestamp',
+      '10': 'createTime'
+    },
+    {
+      '1': 'complete_time',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Timestamp',
+      '10': 'completeTime'
+    },
+  ],
+};
+
+/// Descriptor for `MatchmakerCompletionStats`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List matchmakerCompletionStatsDescriptor = $convert.base64Decode(
+    'ChlNYXRjaG1ha2VyQ29tcGxldGlvblN0YXRzEjsKC2NyZWF0ZV90aW1lGAEgASgLMhouZ29vZ2'
+    'xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI/Cg1jb21wbGV0ZV90aW1lGAIgASgL'
+    'MhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIMY29tcGxldGVUaW1l');
+
+@$core.Deprecated('Use matchmakerStatsDescriptor instead')
+const MatchmakerStats$json = {
+  '1': 'MatchmakerStats',
+  '2': [
+    {'1': 'ticket_count', '3': 1, '4': 1, '5': 5, '10': 'ticketCount'},
+    {
+      '1': 'oldest_ticket_create_time',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Timestamp',
+      '10': 'oldestTicketCreateTime'
+    },
+    {
+      '1': 'completions',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.nakama.api.MatchmakerCompletionStats',
+      '10': 'completions'
+    },
+  ],
+};
+
+/// Descriptor for `MatchmakerStats`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List matchmakerStatsDescriptor = $convert.base64Decode(
+    'Cg9NYXRjaG1ha2VyU3RhdHMSIQoMdGlja2V0X2NvdW50GAEgASgFUgt0aWNrZXRDb3VudBJVCh'
+    'lvbGRlc3RfdGlja2V0X2NyZWF0ZV90aW1lGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVz'
+    'dGFtcFIWb2xkZXN0VGlja2V0Q3JlYXRlVGltZRJHCgtjb21wbGV0aW9ucxgDIAMoCzIlLm5ha2'
+    'FtYS5hcGkuTWF0Y2htYWtlckNvbXBsZXRpb25TdGF0c1ILY29tcGxldGlvbnM=');
+
 @$core.Deprecated('Use notificationDescriptor instead')
-const Notification$json = const {
+const Notification$json = {
   '1': 'Notification',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {'1': 'subject', '3': 2, '4': 1, '5': 9, '10': 'subject'},
-    const {'1': 'content', '3': 3, '4': 1, '5': 9, '10': 'content'},
-    const {'1': 'code', '3': 4, '4': 1, '5': 5, '10': 'code'},
-    const {'1': 'sender_id', '3': 5, '4': 1, '5': 9, '10': 'senderId'},
-    const {
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {'1': 'subject', '3': 2, '4': 1, '5': 9, '10': 'subject'},
+    {'1': 'content', '3': 3, '4': 1, '5': 9, '10': 'content'},
+    {'1': 'code', '3': 4, '4': 1, '5': 5, '10': 'code'},
+    {'1': 'sender_id', '3': 5, '4': 1, '5': 9, '10': 'senderId'},
+    {
       '1': 'create_time',
       '3': 6,
       '4': 1,
@@ -2016,18 +2358,23 @@ const Notification$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {'1': 'persistent', '3': 7, '4': 1, '5': 8, '10': 'persistent'},
+    {'1': 'persistent', '3': 7, '4': 1, '5': 8, '10': 'persistent'},
   ],
 };
 
 /// Descriptor for `Notification`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List notificationDescriptor = $convert.base64Decode(
-    'CgxOb3RpZmljYXRpb24SDgoCaWQYASABKAlSAmlkEhgKB3N1YmplY3QYAiABKAlSB3N1YmplY3QSGAoHY29udGVudBgDIAEoCVIHY29udGVudBISCgRjb2RlGAQgASgFUgRjb2RlEhsKCXNlbmRlcl9pZBgFIAEoCVIIc2VuZGVySWQSOwoLY3JlYXRlX3RpbWUYBiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgpjcmVhdGVUaW1lEh4KCnBlcnNpc3RlbnQYByABKAhSCnBlcnNpc3RlbnQ=');
+    'CgxOb3RpZmljYXRpb24SDgoCaWQYASABKAlSAmlkEhgKB3N1YmplY3QYAiABKAlSB3N1YmplY3'
+    'QSGAoHY29udGVudBgDIAEoCVIHY29udGVudBISCgRjb2RlGAQgASgFUgRjb2RlEhsKCXNlbmRl'
+    'cl9pZBgFIAEoCVIIc2VuZGVySWQSOwoLY3JlYXRlX3RpbWUYBiABKAsyGi5nb29nbGUucHJvdG'
+    '9idWYuVGltZXN0YW1wUgpjcmVhdGVUaW1lEh4KCnBlcnNpc3RlbnQYByABKAhSCnBlcnNpc3Rl'
+    'bnQ=');
+
 @$core.Deprecated('Use notificationListDescriptor instead')
-const NotificationList$json = const {
+const NotificationList$json = {
   '1': 'NotificationList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'notifications',
       '3': 1,
       '4': 3,
@@ -2035,63 +2382,66 @@ const NotificationList$json = const {
       '6': '.nakama.api.Notification',
       '10': 'notifications'
     },
-    const {
-      '1': 'cacheable_cursor',
-      '3': 2,
-      '4': 1,
-      '5': 9,
-      '10': 'cacheableCursor'
-    },
+    {'1': 'cacheable_cursor', '3': 2, '4': 1, '5': 9, '10': 'cacheableCursor'},
   ],
 };
 
 /// Descriptor for `NotificationList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List notificationListDescriptor = $convert.base64Decode(
-    'ChBOb3RpZmljYXRpb25MaXN0Ej4KDW5vdGlmaWNhdGlvbnMYASADKAsyGC5uYWthbWEuYXBpLk5vdGlmaWNhdGlvblINbm90aWZpY2F0aW9ucxIpChBjYWNoZWFibGVfY3Vyc29yGAIgASgJUg9jYWNoZWFibGVDdXJzb3I=');
+    'ChBOb3RpZmljYXRpb25MaXN0Ej4KDW5vdGlmaWNhdGlvbnMYASADKAsyGC5uYWthbWEuYXBpLk'
+    '5vdGlmaWNhdGlvblINbm90aWZpY2F0aW9ucxIpChBjYWNoZWFibGVfY3Vyc29yGAIgASgJUg9j'
+    'YWNoZWFibGVDdXJzb3I=');
+
 @$core.Deprecated('Use promoteGroupUsersRequestDescriptor instead')
-const PromoteGroupUsersRequest$json = const {
+const PromoteGroupUsersRequest$json = {
   '1': 'PromoteGroupUsersRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
   ],
 };
 
 /// Descriptor for `PromoteGroupUsersRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List promoteGroupUsersRequestDescriptor =
     $convert.base64Decode(
-        'ChhQcm9tb3RlR3JvdXBVc2Vyc1JlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQSGQoIdXNlcl9pZHMYAiADKAlSB3VzZXJJZHM=');
+        'ChhQcm9tb3RlR3JvdXBVc2Vyc1JlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQSGQ'
+        'oIdXNlcl9pZHMYAiADKAlSB3VzZXJJZHM=');
+
 @$core.Deprecated('Use demoteGroupUsersRequestDescriptor instead')
-const DemoteGroupUsersRequest$json = const {
+const DemoteGroupUsersRequest$json = {
   '1': 'DemoteGroupUsersRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_ids', '3': 2, '4': 3, '5': 9, '10': 'userIds'},
   ],
 };
 
 /// Descriptor for `DemoteGroupUsersRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List demoteGroupUsersRequestDescriptor =
     $convert.base64Decode(
-        'ChdEZW1vdGVHcm91cFVzZXJzUmVxdWVzdBIZCghncm91cF9pZBgBIAEoCVIHZ3JvdXBJZBIZCgh1c2VyX2lkcxgCIAMoCVIHdXNlcklkcw==');
+        'ChdEZW1vdGVHcm91cFVzZXJzUmVxdWVzdBIZCghncm91cF9pZBgBIAEoCVIHZ3JvdXBJZBIZCg'
+        'h1c2VyX2lkcxgCIAMoCVIHdXNlcklkcw==');
+
 @$core.Deprecated('Use readStorageObjectIdDescriptor instead')
-const ReadStorageObjectId$json = const {
+const ReadStorageObjectId$json = {
   '1': 'ReadStorageObjectId',
-  '2': const [
-    const {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
-    const {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'user_id', '3': 3, '4': 1, '5': 9, '10': 'userId'},
+  '2': [
+    {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
+    {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'user_id', '3': 3, '4': 1, '5': 9, '10': 'userId'},
   ],
 };
 
 /// Descriptor for `ReadStorageObjectId`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List readStorageObjectIdDescriptor = $convert.base64Decode(
-    'ChNSZWFkU3RvcmFnZU9iamVjdElkEh4KCmNvbGxlY3Rpb24YASABKAlSCmNvbGxlY3Rpb24SEAoDa2V5GAIgASgJUgNrZXkSFwoHdXNlcl9pZBgDIAEoCVIGdXNlcklk');
+    'ChNSZWFkU3RvcmFnZU9iamVjdElkEh4KCmNvbGxlY3Rpb24YASABKAlSCmNvbGxlY3Rpb24SEA'
+    'oDa2V5GAIgASgJUgNrZXkSFwoHdXNlcl9pZBgDIAEoCVIGdXNlcklk');
+
 @$core.Deprecated('Use readStorageObjectsRequestDescriptor instead')
-const ReadStorageObjectsRequest$json = const {
+const ReadStorageObjectsRequest$json = {
   '1': 'ReadStorageObjectsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'object_ids',
       '3': 1,
       '4': 3,
@@ -2105,57 +2455,51 @@ const ReadStorageObjectsRequest$json = const {
 /// Descriptor for `ReadStorageObjectsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List readStorageObjectsRequestDescriptor =
     $convert.base64Decode(
-        'ChlSZWFkU3RvcmFnZU9iamVjdHNSZXF1ZXN0Ej4KCm9iamVjdF9pZHMYASADKAsyHy5uYWthbWEuYXBpLlJlYWRTdG9yYWdlT2JqZWN0SWRSCW9iamVjdElkcw==');
+        'ChlSZWFkU3RvcmFnZU9iamVjdHNSZXF1ZXN0Ej4KCm9iamVjdF9pZHMYASADKAsyHy5uYWthbW'
+        'EuYXBpLlJlYWRTdG9yYWdlT2JqZWN0SWRSCW9iamVjdElkcw==');
+
 @$core.Deprecated('Use rpcDescriptor instead')
-const Rpc$json = const {
+const Rpc$json = {
   '1': 'Rpc',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {'1': 'payload', '3': 2, '4': 1, '5': 9, '10': 'payload'},
-    const {'1': 'http_key', '3': 3, '4': 1, '5': 9, '10': 'httpKey'},
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {'1': 'payload', '3': 2, '4': 1, '5': 9, '10': 'payload'},
+    {'1': 'http_key', '3': 3, '4': 1, '5': 9, '10': 'httpKey'},
   ],
 };
 
 /// Descriptor for `Rpc`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List rpcDescriptor = $convert.base64Decode(
-    'CgNScGMSDgoCaWQYASABKAlSAmlkEhgKB3BheWxvYWQYAiABKAlSB3BheWxvYWQSGQoIaHR0cF9rZXkYAyABKAlSB2h0dHBLZXk=');
+    'CgNScGMSDgoCaWQYASABKAlSAmlkEhgKB3BheWxvYWQYAiABKAlSB3BheWxvYWQSGQoIaHR0cF'
+    '9rZXkYAyABKAlSB2h0dHBLZXk=');
+
 @$core.Deprecated('Use sessionDescriptor instead')
-const Session$json = const {
+const Session$json = {
   '1': 'Session',
-  '2': const [
-    const {'1': 'created', '3': 1, '4': 1, '5': 8, '10': 'created'},
-    const {'1': 'token', '3': 2, '4': 1, '5': 9, '10': 'token'},
-    const {'1': 'refresh_token', '3': 3, '4': 1, '5': 9, '10': 'refreshToken'},
+  '2': [
+    {'1': 'created', '3': 1, '4': 1, '5': 8, '10': 'created'},
+    {'1': 'token', '3': 2, '4': 1, '5': 9, '10': 'token'},
+    {'1': 'refresh_token', '3': 3, '4': 1, '5': 9, '10': 'refreshToken'},
   ],
 };
 
 /// Descriptor for `Session`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List sessionDescriptor = $convert.base64Decode(
-    'CgdTZXNzaW9uEhgKB2NyZWF0ZWQYASABKAhSB2NyZWF0ZWQSFAoFdG9rZW4YAiABKAlSBXRva2VuEiMKDXJlZnJlc2hfdG9rZW4YAyABKAlSDHJlZnJlc2hUb2tlbg==');
+    'CgdTZXNzaW9uEhgKB2NyZWF0ZWQYASABKAhSB2NyZWF0ZWQSFAoFdG9rZW4YAiABKAlSBXRva2'
+    'VuEiMKDXJlZnJlc2hfdG9rZW4YAyABKAlSDHJlZnJlc2hUb2tlbg==');
+
 @$core.Deprecated('Use storageObjectDescriptor instead')
-const StorageObject$json = const {
+const StorageObject$json = {
   '1': 'StorageObject',
-  '2': const [
-    const {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
-    const {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'user_id', '3': 3, '4': 1, '5': 9, '10': 'userId'},
-    const {'1': 'value', '3': 4, '4': 1, '5': 9, '10': 'value'},
-    const {'1': 'version', '3': 5, '4': 1, '5': 9, '10': 'version'},
-    const {
-      '1': 'permission_read',
-      '3': 6,
-      '4': 1,
-      '5': 5,
-      '10': 'permissionRead'
-    },
-    const {
-      '1': 'permission_write',
-      '3': 7,
-      '4': 1,
-      '5': 5,
-      '10': 'permissionWrite'
-    },
-    const {
+  '2': [
+    {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
+    {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'user_id', '3': 3, '4': 1, '5': 9, '10': 'userId'},
+    {'1': 'value', '3': 4, '4': 1, '5': 9, '10': 'value'},
+    {'1': 'version', '3': 5, '4': 1, '5': 9, '10': 'version'},
+    {'1': 'permission_read', '3': 6, '4': 1, '5': 5, '10': 'permissionRead'},
+    {'1': 'permission_write', '3': 7, '4': 1, '5': 5, '10': 'permissionWrite'},
+    {
       '1': 'create_time',
       '3': 8,
       '4': 1,
@@ -2163,7 +2507,7 @@ const StorageObject$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 9,
       '4': 1,
@@ -2176,26 +2520,54 @@ const StorageObject$json = const {
 
 /// Descriptor for `StorageObject`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List storageObjectDescriptor = $convert.base64Decode(
-    'Cg1TdG9yYWdlT2JqZWN0Eh4KCmNvbGxlY3Rpb24YASABKAlSCmNvbGxlY3Rpb24SEAoDa2V5GAIgASgJUgNrZXkSFwoHdXNlcl9pZBgDIAEoCVIGdXNlcklkEhQKBXZhbHVlGAQgASgJUgV2YWx1ZRIYCgd2ZXJzaW9uGAUgASgJUgd2ZXJzaW9uEicKD3Blcm1pc3Npb25fcmVhZBgGIAEoBVIOcGVybWlzc2lvblJlYWQSKQoQcGVybWlzc2lvbl93cml0ZRgHIAEoBVIPcGVybWlzc2lvbldyaXRlEjsKC2NyZWF0ZV90aW1lGAggASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI7Cgt1cGRhdGVfdGltZRgJIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWU=');
+    'Cg1TdG9yYWdlT2JqZWN0Eh4KCmNvbGxlY3Rpb24YASABKAlSCmNvbGxlY3Rpb24SEAoDa2V5GA'
+    'IgASgJUgNrZXkSFwoHdXNlcl9pZBgDIAEoCVIGdXNlcklkEhQKBXZhbHVlGAQgASgJUgV2YWx1'
+    'ZRIYCgd2ZXJzaW9uGAUgASgJUgd2ZXJzaW9uEicKD3Blcm1pc3Npb25fcmVhZBgGIAEoBVIOcG'
+    'VybWlzc2lvblJlYWQSKQoQcGVybWlzc2lvbl93cml0ZRgHIAEoBVIPcGVybWlzc2lvbldyaXRl'
+    'EjsKC2NyZWF0ZV90aW1lGAggASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYX'
+    'RlVGltZRI7Cgt1cGRhdGVfdGltZRgJIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBS'
+    'CnVwZGF0ZVRpbWU=');
+
 @$core.Deprecated('Use storageObjectAckDescriptor instead')
-const StorageObjectAck$json = const {
+const StorageObjectAck$json = {
   '1': 'StorageObjectAck',
-  '2': const [
-    const {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
-    const {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'version', '3': 3, '4': 1, '5': 9, '10': 'version'},
-    const {'1': 'user_id', '3': 4, '4': 1, '5': 9, '10': 'userId'},
+  '2': [
+    {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
+    {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'version', '3': 3, '4': 1, '5': 9, '10': 'version'},
+    {'1': 'user_id', '3': 4, '4': 1, '5': 9, '10': 'userId'},
+    {
+      '1': 'create_time',
+      '3': 5,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Timestamp',
+      '10': 'createTime'
+    },
+    {
+      '1': 'update_time',
+      '3': 6,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Timestamp',
+      '10': 'updateTime'
+    },
   ],
 };
 
 /// Descriptor for `StorageObjectAck`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List storageObjectAckDescriptor = $convert.base64Decode(
-    'ChBTdG9yYWdlT2JqZWN0QWNrEh4KCmNvbGxlY3Rpb24YASABKAlSCmNvbGxlY3Rpb24SEAoDa2V5GAIgASgJUgNrZXkSGAoHdmVyc2lvbhgDIAEoCVIHdmVyc2lvbhIXCgd1c2VyX2lkGAQgASgJUgZ1c2VySWQ=');
+    'ChBTdG9yYWdlT2JqZWN0QWNrEh4KCmNvbGxlY3Rpb24YASABKAlSCmNvbGxlY3Rpb24SEAoDa2'
+    'V5GAIgASgJUgNrZXkSGAoHdmVyc2lvbhgDIAEoCVIHdmVyc2lvbhIXCgd1c2VyX2lkGAQgASgJ'
+    'UgZ1c2VySWQSOwoLY3JlYXRlX3RpbWUYBSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW'
+    '1wUgpjcmVhdGVUaW1lEjsKC3VwZGF0ZV90aW1lGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRp'
+    'bWVzdGFtcFIKdXBkYXRlVGltZQ==');
+
 @$core.Deprecated('Use storageObjectAcksDescriptor instead')
-const StorageObjectAcks$json = const {
+const StorageObjectAcks$json = {
   '1': 'StorageObjectAcks',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'acks',
       '3': 1,
       '4': 3,
@@ -2208,12 +2580,14 @@ const StorageObjectAcks$json = const {
 
 /// Descriptor for `StorageObjectAcks`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List storageObjectAcksDescriptor = $convert.base64Decode(
-    'ChFTdG9yYWdlT2JqZWN0QWNrcxIwCgRhY2tzGAEgAygLMhwubmFrYW1hLmFwaS5TdG9yYWdlT2JqZWN0QWNrUgRhY2tz');
+    'ChFTdG9yYWdlT2JqZWN0QWNrcxIwCgRhY2tzGAEgAygLMhwubmFrYW1hLmFwaS5TdG9yYWdlT2'
+    'JqZWN0QWNrUgRhY2tz');
+
 @$core.Deprecated('Use storageObjectsDescriptor instead')
-const StorageObjects$json = const {
+const StorageObjects$json = {
   '1': 'StorageObjects',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'objects',
       '3': 1,
       '4': 3,
@@ -2226,12 +2600,14 @@ const StorageObjects$json = const {
 
 /// Descriptor for `StorageObjects`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List storageObjectsDescriptor = $convert.base64Decode(
-    'Cg5TdG9yYWdlT2JqZWN0cxIzCgdvYmplY3RzGAEgAygLMhkubmFrYW1hLmFwaS5TdG9yYWdlT2JqZWN0UgdvYmplY3Rz');
+    'Cg5TdG9yYWdlT2JqZWN0cxIzCgdvYmplY3RzGAEgAygLMhkubmFrYW1hLmFwaS5TdG9yYWdlT2'
+    'JqZWN0UgdvYmplY3Rz');
+
 @$core.Deprecated('Use storageObjectListDescriptor instead')
-const StorageObjectList$json = const {
+const StorageObjectList$json = {
   '1': 'StorageObjectList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'objects',
       '3': 1,
       '4': 3,
@@ -2239,30 +2615,32 @@ const StorageObjectList$json = const {
       '6': '.nakama.api.StorageObject',
       '10': 'objects'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `StorageObjectList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List storageObjectListDescriptor = $convert.base64Decode(
-    'ChFTdG9yYWdlT2JqZWN0TGlzdBIzCgdvYmplY3RzGAEgAygLMhkubmFrYW1hLmFwaS5TdG9yYWdlT2JqZWN0UgdvYmplY3RzEhYKBmN1cnNvchgCIAEoCVIGY3Vyc29y');
+    'ChFTdG9yYWdlT2JqZWN0TGlzdBIzCgdvYmplY3RzGAEgAygLMhkubmFrYW1hLmFwaS5TdG9yYW'
+    'dlT2JqZWN0UgdvYmplY3RzEhYKBmN1cnNvchgCIAEoCVIGY3Vyc29y');
+
 @$core.Deprecated('Use tournamentDescriptor instead')
-const Tournament$json = const {
+const Tournament$json = {
   '1': 'Tournament',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {'1': 'title', '3': 2, '4': 1, '5': 9, '10': 'title'},
-    const {'1': 'description', '3': 3, '4': 1, '5': 9, '10': 'description'},
-    const {'1': 'category', '3': 4, '4': 1, '5': 13, '10': 'category'},
-    const {'1': 'sort_order', '3': 5, '4': 1, '5': 13, '10': 'sortOrder'},
-    const {'1': 'size', '3': 6, '4': 1, '5': 13, '10': 'size'},
-    const {'1': 'max_size', '3': 7, '4': 1, '5': 13, '10': 'maxSize'},
-    const {'1': 'max_num_score', '3': 8, '4': 1, '5': 13, '10': 'maxNumScore'},
-    const {'1': 'can_enter', '3': 9, '4': 1, '5': 8, '10': 'canEnter'},
-    const {'1': 'end_active', '3': 10, '4': 1, '5': 13, '10': 'endActive'},
-    const {'1': 'next_reset', '3': 11, '4': 1, '5': 13, '10': 'nextReset'},
-    const {'1': 'metadata', '3': 12, '4': 1, '5': 9, '10': 'metadata'},
-    const {
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {'1': 'title', '3': 2, '4': 1, '5': 9, '10': 'title'},
+    {'1': 'description', '3': 3, '4': 1, '5': 9, '10': 'description'},
+    {'1': 'category', '3': 4, '4': 1, '5': 13, '10': 'category'},
+    {'1': 'sort_order', '3': 5, '4': 1, '5': 13, '10': 'sortOrder'},
+    {'1': 'size', '3': 6, '4': 1, '5': 13, '10': 'size'},
+    {'1': 'max_size', '3': 7, '4': 1, '5': 13, '10': 'maxSize'},
+    {'1': 'max_num_score', '3': 8, '4': 1, '5': 13, '10': 'maxNumScore'},
+    {'1': 'can_enter', '3': 9, '4': 1, '5': 8, '10': 'canEnter'},
+    {'1': 'end_active', '3': 10, '4': 1, '5': 13, '10': 'endActive'},
+    {'1': 'next_reset', '3': 11, '4': 1, '5': 13, '10': 'nextReset'},
+    {'1': 'metadata', '3': 12, '4': 1, '5': 9, '10': 'metadata'},
+    {
       '1': 'create_time',
       '3': 13,
       '4': 1,
@@ -2270,7 +2648,7 @@ const Tournament$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'start_time',
       '3': 14,
       '4': 1,
@@ -2278,7 +2656,7 @@ const Tournament$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'startTime'
     },
-    const {
+    {
       '1': 'end_time',
       '3': 15,
       '4': 1,
@@ -2286,10 +2664,10 @@ const Tournament$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'endTime'
     },
-    const {'1': 'duration', '3': 16, '4': 1, '5': 13, '10': 'duration'},
-    const {'1': 'start_active', '3': 17, '4': 1, '5': 13, '10': 'startActive'},
-    const {'1': 'prev_reset', '3': 18, '4': 1, '5': 13, '10': 'prevReset'},
-    const {
+    {'1': 'duration', '3': 16, '4': 1, '5': 13, '10': 'duration'},
+    {'1': 'start_active', '3': 17, '4': 1, '5': 13, '10': 'startActive'},
+    {'1': 'prev_reset', '3': 18, '4': 1, '5': 13, '10': 'prevReset'},
+    {
       '1': 'operator',
       '3': 19,
       '4': 1,
@@ -2297,24 +2675,33 @@ const Tournament$json = const {
       '6': '.nakama.api.Operator',
       '10': 'operator'
     },
-    const {
-      '1': 'authoritative',
-      '3': 20,
-      '4': 1,
-      '5': 8,
-      '10': 'authoritative'
-    },
+    {'1': 'authoritative', '3': 20, '4': 1, '5': 8, '10': 'authoritative'},
+    {'1': 'join_required', '3': 21, '4': 1, '5': 8, '10': 'joinRequired'},
   ],
 };
 
 /// Descriptor for `Tournament`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List tournamentDescriptor = $convert.base64Decode(
-    'CgpUb3VybmFtZW50Eg4KAmlkGAEgASgJUgJpZBIUCgV0aXRsZRgCIAEoCVIFdGl0bGUSIAoLZGVzY3JpcHRpb24YAyABKAlSC2Rlc2NyaXB0aW9uEhoKCGNhdGVnb3J5GAQgASgNUghjYXRlZ29yeRIdCgpzb3J0X29yZGVyGAUgASgNUglzb3J0T3JkZXISEgoEc2l6ZRgGIAEoDVIEc2l6ZRIZCghtYXhfc2l6ZRgHIAEoDVIHbWF4U2l6ZRIiCg1tYXhfbnVtX3Njb3JlGAggASgNUgttYXhOdW1TY29yZRIbCgljYW5fZW50ZXIYCSABKAhSCGNhbkVudGVyEh0KCmVuZF9hY3RpdmUYCiABKA1SCWVuZEFjdGl2ZRIdCgpuZXh0X3Jlc2V0GAsgASgNUgluZXh0UmVzZXQSGgoIbWV0YWRhdGEYDCABKAlSCG1ldGFkYXRhEjsKC2NyZWF0ZV90aW1lGA0gASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI5CgpzdGFydF90aW1lGA4gASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIJc3RhcnRUaW1lEjUKCGVuZF90aW1lGA8gASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIHZW5kVGltZRIaCghkdXJhdGlvbhgQIAEoDVIIZHVyYXRpb24SIQoMc3RhcnRfYWN0aXZlGBEgASgNUgtzdGFydEFjdGl2ZRIdCgpwcmV2X3Jlc2V0GBIgASgNUglwcmV2UmVzZXQSMAoIb3BlcmF0b3IYEyABKA4yFC5uYWthbWEuYXBpLk9wZXJhdG9yUghvcGVyYXRvchIkCg1hdXRob3JpdGF0aXZlGBQgASgIUg1hdXRob3JpdGF0aXZl');
+    'CgpUb3VybmFtZW50Eg4KAmlkGAEgASgJUgJpZBIUCgV0aXRsZRgCIAEoCVIFdGl0bGUSIAoLZG'
+    'VzY3JpcHRpb24YAyABKAlSC2Rlc2NyaXB0aW9uEhoKCGNhdGVnb3J5GAQgASgNUghjYXRlZ29y'
+    'eRIdCgpzb3J0X29yZGVyGAUgASgNUglzb3J0T3JkZXISEgoEc2l6ZRgGIAEoDVIEc2l6ZRIZCg'
+    'htYXhfc2l6ZRgHIAEoDVIHbWF4U2l6ZRIiCg1tYXhfbnVtX3Njb3JlGAggASgNUgttYXhOdW1T'
+    'Y29yZRIbCgljYW5fZW50ZXIYCSABKAhSCGNhbkVudGVyEh0KCmVuZF9hY3RpdmUYCiABKA1SCW'
+    'VuZEFjdGl2ZRIdCgpuZXh0X3Jlc2V0GAsgASgNUgluZXh0UmVzZXQSGgoIbWV0YWRhdGEYDCAB'
+    'KAlSCG1ldGFkYXRhEjsKC2NyZWF0ZV90aW1lGA0gASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbW'
+    'VzdGFtcFIKY3JlYXRlVGltZRI5CgpzdGFydF90aW1lGA4gASgLMhouZ29vZ2xlLnByb3RvYnVm'
+    'LlRpbWVzdGFtcFIJc3RhcnRUaW1lEjUKCGVuZF90aW1lGA8gASgLMhouZ29vZ2xlLnByb3RvYn'
+    'VmLlRpbWVzdGFtcFIHZW5kVGltZRIaCghkdXJhdGlvbhgQIAEoDVIIZHVyYXRpb24SIQoMc3Rh'
+    'cnRfYWN0aXZlGBEgASgNUgtzdGFydEFjdGl2ZRIdCgpwcmV2X3Jlc2V0GBIgASgNUglwcmV2Um'
+    'VzZXQSMAoIb3BlcmF0b3IYEyABKA4yFC5uYWthbWEuYXBpLk9wZXJhdG9yUghvcGVyYXRvchIk'
+    'Cg1hdXRob3JpdGF0aXZlGBQgASgIUg1hdXRob3JpdGF0aXZlEiMKDWpvaW5fcmVxdWlyZWQYFS'
+    'ABKAhSDGpvaW5SZXF1aXJlZA==');
+
 @$core.Deprecated('Use tournamentListDescriptor instead')
-const TournamentList$json = const {
+const TournamentList$json = {
   '1': 'TournamentList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'tournaments',
       '3': 1,
       '4': 3,
@@ -2322,18 +2709,20 @@ const TournamentList$json = const {
       '6': '.nakama.api.Tournament',
       '10': 'tournaments'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
   ],
 };
 
 /// Descriptor for `TournamentList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List tournamentListDescriptor = $convert.base64Decode(
-    'Cg5Ub3VybmFtZW50TGlzdBI4Cgt0b3VybmFtZW50cxgBIAMoCzIWLm5ha2FtYS5hcGkuVG91cm5hbWVudFILdG91cm5hbWVudHMSFgoGY3Vyc29yGAIgASgJUgZjdXJzb3I=');
+    'Cg5Ub3VybmFtZW50TGlzdBI4Cgt0b3VybmFtZW50cxgBIAMoCzIWLm5ha2FtYS5hcGkuVG91cm'
+    '5hbWVudFILdG91cm5hbWVudHMSFgoGY3Vyc29yGAIgASgJUgZjdXJzb3I=');
+
 @$core.Deprecated('Use tournamentRecordListDescriptor instead')
-const TournamentRecordList$json = const {
+const TournamentRecordList$json = {
   '1': 'TournamentRecordList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'records',
       '3': 1,
       '4': 3,
@@ -2341,7 +2730,7 @@ const TournamentRecordList$json = const {
       '6': '.nakama.api.LeaderboardRecord',
       '10': 'records'
     },
-    const {
+    {
       '1': 'owner_records',
       '3': 2,
       '4': 3,
@@ -2349,19 +2738,25 @@ const TournamentRecordList$json = const {
       '6': '.nakama.api.LeaderboardRecord',
       '10': 'ownerRecords'
     },
-    const {'1': 'next_cursor', '3': 3, '4': 1, '5': 9, '10': 'nextCursor'},
-    const {'1': 'prev_cursor', '3': 4, '4': 1, '5': 9, '10': 'prevCursor'},
+    {'1': 'next_cursor', '3': 3, '4': 1, '5': 9, '10': 'nextCursor'},
+    {'1': 'prev_cursor', '3': 4, '4': 1, '5': 9, '10': 'prevCursor'},
+    {'1': 'rank_count', '3': 5, '4': 1, '5': 3, '10': 'rankCount'},
   ],
 };
 
 /// Descriptor for `TournamentRecordList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List tournamentRecordListDescriptor = $convert.base64Decode(
-    'ChRUb3VybmFtZW50UmVjb3JkTGlzdBI3CgdyZWNvcmRzGAEgAygLMh0ubmFrYW1hLmFwaS5MZWFkZXJib2FyZFJlY29yZFIHcmVjb3JkcxJCCg1vd25lcl9yZWNvcmRzGAIgAygLMh0ubmFrYW1hLmFwaS5MZWFkZXJib2FyZFJlY29yZFIMb3duZXJSZWNvcmRzEh8KC25leHRfY3Vyc29yGAMgASgJUgpuZXh0Q3Vyc29yEh8KC3ByZXZfY3Vyc29yGAQgASgJUgpwcmV2Q3Vyc29y');
+    'ChRUb3VybmFtZW50UmVjb3JkTGlzdBI3CgdyZWNvcmRzGAEgAygLMh0ubmFrYW1hLmFwaS5MZW'
+    'FkZXJib2FyZFJlY29yZFIHcmVjb3JkcxJCCg1vd25lcl9yZWNvcmRzGAIgAygLMh0ubmFrYW1h'
+    'LmFwaS5MZWFkZXJib2FyZFJlY29yZFIMb3duZXJSZWNvcmRzEh8KC25leHRfY3Vyc29yGAMgAS'
+    'gJUgpuZXh0Q3Vyc29yEh8KC3ByZXZfY3Vyc29yGAQgASgJUgpwcmV2Q3Vyc29yEh0KCnJhbmtf'
+    'Y291bnQYBSABKANSCXJhbmtDb3VudA==');
+
 @$core.Deprecated('Use updateAccountRequestDescriptor instead')
-const UpdateAccountRequest$json = const {
+const UpdateAccountRequest$json = {
   '1': 'UpdateAccountRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'username',
       '3': 1,
       '4': 1,
@@ -2369,7 +2764,7 @@ const UpdateAccountRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'username'
     },
-    const {
+    {
       '1': 'display_name',
       '3': 2,
       '4': 1,
@@ -2377,7 +2772,7 @@ const UpdateAccountRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'displayName'
     },
-    const {
+    {
       '1': 'avatar_url',
       '3': 3,
       '4': 1,
@@ -2385,7 +2780,7 @@ const UpdateAccountRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'avatarUrl'
     },
-    const {
+    {
       '1': 'lang_tag',
       '3': 4,
       '4': 1,
@@ -2393,7 +2788,7 @@ const UpdateAccountRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'langTag'
     },
-    const {
+    {
       '1': 'location',
       '3': 5,
       '4': 1,
@@ -2401,7 +2796,7 @@ const UpdateAccountRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'location'
     },
-    const {
+    {
       '1': 'timezone',
       '3': 6,
       '4': 1,
@@ -2414,13 +2809,20 @@ const UpdateAccountRequest$json = const {
 
 /// Descriptor for `UpdateAccountRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List updateAccountRequestDescriptor = $convert.base64Decode(
-    'ChRVcGRhdGVBY2NvdW50UmVxdWVzdBI4Cgh1c2VybmFtZRgBIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIIdXNlcm5hbWUSPwoMZGlzcGxheV9uYW1lGAIgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1ZhbHVlUgtkaXNwbGF5TmFtZRI7CgphdmF0YXJfdXJsGAMgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1ZhbHVlUglhdmF0YXJVcmwSNwoIbGFuZ190YWcYBCABKAsyHC5nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWVSB2xhbmdUYWcSOAoIbG9jYXRpb24YBSABKAsyHC5nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWVSCGxvY2F0aW9uEjgKCHRpbWV6b25lGAYgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1ZhbHVlUgh0aW1lem9uZQ==');
+    'ChRVcGRhdGVBY2NvdW50UmVxdWVzdBI4Cgh1c2VybmFtZRgBIAEoCzIcLmdvb2dsZS5wcm90b2'
+    'J1Zi5TdHJpbmdWYWx1ZVIIdXNlcm5hbWUSPwoMZGlzcGxheV9uYW1lGAIgASgLMhwuZ29vZ2xl'
+    'LnByb3RvYnVmLlN0cmluZ1ZhbHVlUgtkaXNwbGF5TmFtZRI7CgphdmF0YXJfdXJsGAMgASgLMh'
+    'wuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1ZhbHVlUglhdmF0YXJVcmwSNwoIbGFuZ190YWcYBCAB'
+    'KAsyHC5nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWVSB2xhbmdUYWcSOAoIbG9jYXRpb24YBS'
+    'ABKAsyHC5nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWVSCGxvY2F0aW9uEjgKCHRpbWV6b25l'
+    'GAYgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1ZhbHVlUgh0aW1lem9uZQ==');
+
 @$core.Deprecated('Use updateGroupRequestDescriptor instead')
-const UpdateGroupRequest$json = const {
+const UpdateGroupRequest$json = {
   '1': 'UpdateGroupRequest',
-  '2': const [
-    const {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
-    const {
+  '2': [
+    {'1': 'group_id', '3': 1, '4': 1, '5': 9, '10': 'groupId'},
+    {
       '1': 'name',
       '3': 2,
       '4': 1,
@@ -2428,7 +2830,7 @@ const UpdateGroupRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'name'
     },
-    const {
+    {
       '1': 'description',
       '3': 3,
       '4': 1,
@@ -2436,7 +2838,7 @@ const UpdateGroupRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'description'
     },
-    const {
+    {
       '1': 'lang_tag',
       '3': 4,
       '4': 1,
@@ -2444,7 +2846,7 @@ const UpdateGroupRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'langTag'
     },
-    const {
+    {
       '1': 'avatar_url',
       '3': 5,
       '4': 1,
@@ -2452,7 +2854,7 @@ const UpdateGroupRequest$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'avatarUrl'
     },
-    const {
+    {
       '1': 'open',
       '3': 6,
       '4': 1,
@@ -2465,26 +2867,32 @@ const UpdateGroupRequest$json = const {
 
 /// Descriptor for `UpdateGroupRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List updateGroupRequestDescriptor = $convert.base64Decode(
-    'ChJVcGRhdGVHcm91cFJlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQSMAoEbmFtZRgCIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIEbmFtZRI+CgtkZXNjcmlwdGlvbhgDIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVILZGVzY3JpcHRpb24SNwoIbGFuZ190YWcYBCABKAsyHC5nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWVSB2xhbmdUYWcSOwoKYXZhdGFyX3VybBgFIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIJYXZhdGFyVXJsEi4KBG9wZW4YBiABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZhbHVlUgRvcGVu');
+    'ChJVcGRhdGVHcm91cFJlcXVlc3QSGQoIZ3JvdXBfaWQYASABKAlSB2dyb3VwSWQSMAoEbmFtZR'
+    'gCIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIEbmFtZRI+CgtkZXNjcmlwdGlv'
+    'bhgDIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVILZGVzY3JpcHRpb24SNwoIbG'
+    'FuZ190YWcYBCABKAsyHC5nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWVSB2xhbmdUYWcSOwoK'
+    'YXZhdGFyX3VybBgFIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIJYXZhdGFyVX'
+    'JsEi4KBG9wZW4YBiABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZhbHVlUgRvcGVu');
+
 @$core.Deprecated('Use userDescriptor instead')
-const User$json = const {
+const User$json = {
   '1': 'User',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {'1': 'username', '3': 2, '4': 1, '5': 9, '10': 'username'},
-    const {'1': 'display_name', '3': 3, '4': 1, '5': 9, '10': 'displayName'},
-    const {'1': 'avatar_url', '3': 4, '4': 1, '5': 9, '10': 'avatarUrl'},
-    const {'1': 'lang_tag', '3': 5, '4': 1, '5': 9, '10': 'langTag'},
-    const {'1': 'location', '3': 6, '4': 1, '5': 9, '10': 'location'},
-    const {'1': 'timezone', '3': 7, '4': 1, '5': 9, '10': 'timezone'},
-    const {'1': 'metadata', '3': 8, '4': 1, '5': 9, '10': 'metadata'},
-    const {'1': 'facebook_id', '3': 9, '4': 1, '5': 9, '10': 'facebookId'},
-    const {'1': 'google_id', '3': 10, '4': 1, '5': 9, '10': 'googleId'},
-    const {'1': 'gamecenter_id', '3': 11, '4': 1, '5': 9, '10': 'gamecenterId'},
-    const {'1': 'steam_id', '3': 12, '4': 1, '5': 9, '10': 'steamId'},
-    const {'1': 'online', '3': 13, '4': 1, '5': 8, '10': 'online'},
-    const {'1': 'edge_count', '3': 14, '4': 1, '5': 5, '10': 'edgeCount'},
-    const {
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {'1': 'username', '3': 2, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'display_name', '3': 3, '4': 1, '5': 9, '10': 'displayName'},
+    {'1': 'avatar_url', '3': 4, '4': 1, '5': 9, '10': 'avatarUrl'},
+    {'1': 'lang_tag', '3': 5, '4': 1, '5': 9, '10': 'langTag'},
+    {'1': 'location', '3': 6, '4': 1, '5': 9, '10': 'location'},
+    {'1': 'timezone', '3': 7, '4': 1, '5': 9, '10': 'timezone'},
+    {'1': 'metadata', '3': 8, '4': 1, '5': 9, '10': 'metadata'},
+    {'1': 'facebook_id', '3': 9, '4': 1, '5': 9, '10': 'facebookId'},
+    {'1': 'google_id', '3': 10, '4': 1, '5': 9, '10': 'googleId'},
+    {'1': 'gamecenter_id', '3': 11, '4': 1, '5': 9, '10': 'gamecenterId'},
+    {'1': 'steam_id', '3': 12, '4': 1, '5': 9, '10': 'steamId'},
+    {'1': 'online', '3': 13, '4': 1, '5': 8, '10': 'online'},
+    {'1': 'edge_count', '3': 14, '4': 1, '5': 5, '10': 'edgeCount'},
+    {
       '1': 'create_time',
       '3': 15,
       '4': 1,
@@ -2492,7 +2900,7 @@ const User$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 16,
       '4': 1,
@@ -2500,25 +2908,37 @@ const User$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'updateTime'
     },
-    const {
+    {
       '1': 'facebook_instant_game_id',
       '3': 17,
       '4': 1,
       '5': 9,
       '10': 'facebookInstantGameId'
     },
-    const {'1': 'apple_id', '3': 18, '4': 1, '5': 9, '10': 'appleId'},
+    {'1': 'apple_id', '3': 18, '4': 1, '5': 9, '10': 'appleId'},
   ],
 };
 
 /// Descriptor for `User`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List userDescriptor = $convert.base64Decode(
-    'CgRVc2VyEg4KAmlkGAEgASgJUgJpZBIaCgh1c2VybmFtZRgCIAEoCVIIdXNlcm5hbWUSIQoMZGlzcGxheV9uYW1lGAMgASgJUgtkaXNwbGF5TmFtZRIdCgphdmF0YXJfdXJsGAQgASgJUglhdmF0YXJVcmwSGQoIbGFuZ190YWcYBSABKAlSB2xhbmdUYWcSGgoIbG9jYXRpb24YBiABKAlSCGxvY2F0aW9uEhoKCHRpbWV6b25lGAcgASgJUgh0aW1lem9uZRIaCghtZXRhZGF0YRgIIAEoCVIIbWV0YWRhdGESHwoLZmFjZWJvb2tfaWQYCSABKAlSCmZhY2Vib29rSWQSGwoJZ29vZ2xlX2lkGAogASgJUghnb29nbGVJZBIjCg1nYW1lY2VudGVyX2lkGAsgASgJUgxnYW1lY2VudGVySWQSGQoIc3RlYW1faWQYDCABKAlSB3N0ZWFtSWQSFgoGb25saW5lGA0gASgIUgZvbmxpbmUSHQoKZWRnZV9jb3VudBgOIAEoBVIJZWRnZUNvdW50EjsKC2NyZWF0ZV90aW1lGA8gASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI7Cgt1cGRhdGVfdGltZRgQIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUSNwoYZmFjZWJvb2tfaW5zdGFudF9nYW1lX2lkGBEgASgJUhVmYWNlYm9va0luc3RhbnRHYW1lSWQSGQoIYXBwbGVfaWQYEiABKAlSB2FwcGxlSWQ=');
+    'CgRVc2VyEg4KAmlkGAEgASgJUgJpZBIaCgh1c2VybmFtZRgCIAEoCVIIdXNlcm5hbWUSIQoMZG'
+    'lzcGxheV9uYW1lGAMgASgJUgtkaXNwbGF5TmFtZRIdCgphdmF0YXJfdXJsGAQgASgJUglhdmF0'
+    'YXJVcmwSGQoIbGFuZ190YWcYBSABKAlSB2xhbmdUYWcSGgoIbG9jYXRpb24YBiABKAlSCGxvY2'
+    'F0aW9uEhoKCHRpbWV6b25lGAcgASgJUgh0aW1lem9uZRIaCghtZXRhZGF0YRgIIAEoCVIIbWV0'
+    'YWRhdGESHwoLZmFjZWJvb2tfaWQYCSABKAlSCmZhY2Vib29rSWQSGwoJZ29vZ2xlX2lkGAogAS'
+    'gJUghnb29nbGVJZBIjCg1nYW1lY2VudGVyX2lkGAsgASgJUgxnYW1lY2VudGVySWQSGQoIc3Rl'
+    'YW1faWQYDCABKAlSB3N0ZWFtSWQSFgoGb25saW5lGA0gASgIUgZvbmxpbmUSHQoKZWRnZV9jb3'
+    'VudBgOIAEoBVIJZWRnZUNvdW50EjsKC2NyZWF0ZV90aW1lGA8gASgLMhouZ29vZ2xlLnByb3Rv'
+    'YnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI7Cgt1cGRhdGVfdGltZRgQIAEoCzIaLmdvb2dsZS'
+    '5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUSNwoYZmFjZWJvb2tfaW5zdGFudF9nYW1l'
+    'X2lkGBEgASgJUhVmYWNlYm9va0luc3RhbnRHYW1lSWQSGQoIYXBwbGVfaWQYEiABKAlSB2FwcG'
+    'xlSWQ=');
+
 @$core.Deprecated('Use userGroupListDescriptor instead')
-const UserGroupList$json = const {
+const UserGroupList$json = {
   '1': 'UserGroupList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'user_groups',
       '3': 1,
       '4': 3,
@@ -2526,16 +2946,16 @@ const UserGroupList$json = const {
       '6': '.nakama.api.UserGroupList.UserGroup',
       '10': 'userGroups'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
   ],
-  '3': const [UserGroupList_UserGroup$json],
+  '3': [UserGroupList_UserGroup$json],
 };
 
 @$core.Deprecated('Use userGroupListDescriptor instead')
-const UserGroupList_UserGroup$json = const {
+const UserGroupList_UserGroup$json = {
   '1': 'UserGroup',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'group',
       '3': 1,
       '4': 1,
@@ -2543,7 +2963,7 @@ const UserGroupList_UserGroup$json = const {
       '6': '.nakama.api.Group',
       '10': 'group'
     },
-    const {
+    {
       '1': 'state',
       '3': 2,
       '4': 1,
@@ -2552,28 +2972,34 @@ const UserGroupList_UserGroup$json = const {
       '10': 'state'
     },
   ],
-  '4': const [UserGroupList_UserGroup_State$json],
+  '4': [UserGroupList_UserGroup_State$json],
 };
 
 @$core.Deprecated('Use userGroupListDescriptor instead')
-const UserGroupList_UserGroup_State$json = const {
+const UserGroupList_UserGroup_State$json = {
   '1': 'State',
-  '2': const [
-    const {'1': 'SUPERADMIN', '2': 0},
-    const {'1': 'ADMIN', '2': 1},
-    const {'1': 'MEMBER', '2': 2},
-    const {'1': 'JOIN_REQUEST', '2': 3},
+  '2': [
+    {'1': 'SUPERADMIN', '2': 0},
+    {'1': 'ADMIN', '2': 1},
+    {'1': 'MEMBER', '2': 2},
+    {'1': 'JOIN_REQUEST', '2': 3},
   ],
 };
 
 /// Descriptor for `UserGroupList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List userGroupListDescriptor = $convert.base64Decode(
-    'Cg1Vc2VyR3JvdXBMaXN0EkQKC3VzZXJfZ3JvdXBzGAEgAygLMiMubmFrYW1hLmFwaS5Vc2VyR3JvdXBMaXN0LlVzZXJHcm91cFIKdXNlckdyb3VwcxIWCgZjdXJzb3IYAiABKAlSBmN1cnNvchqpAQoJVXNlckdyb3VwEicKBWdyb3VwGAEgASgLMhEubmFrYW1hLmFwaS5Hcm91cFIFZ3JvdXASMQoFc3RhdGUYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFc3RhdGUiQAoFU3RhdGUSDgoKU1VQRVJBRE1JThAAEgkKBUFETUlOEAESCgoGTUVNQkVSEAISEAoMSk9JTl9SRVFVRVNUEAM=');
+    'Cg1Vc2VyR3JvdXBMaXN0EkQKC3VzZXJfZ3JvdXBzGAEgAygLMiMubmFrYW1hLmFwaS5Vc2VyR3'
+    'JvdXBMaXN0LlVzZXJHcm91cFIKdXNlckdyb3VwcxIWCgZjdXJzb3IYAiABKAlSBmN1cnNvchqp'
+    'AQoJVXNlckdyb3VwEicKBWdyb3VwGAEgASgLMhEubmFrYW1hLmFwaS5Hcm91cFIFZ3JvdXASMQ'
+    'oFc3RhdGUYAiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIFc3RhdGUiQAoFU3Rh'
+    'dGUSDgoKU1VQRVJBRE1JThAAEgkKBUFETUlOEAESCgoGTUVNQkVSEAISEAoMSk9JTl9SRVFVRV'
+    'NUEAM=');
+
 @$core.Deprecated('Use usersDescriptor instead')
-const Users$json = const {
+const Users$json = {
   '1': 'Users',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'users',
       '3': 1,
       '4': 3,
@@ -2587,12 +3013,13 @@ const Users$json = const {
 /// Descriptor for `Users`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List usersDescriptor = $convert.base64Decode(
     'CgVVc2VycxImCgV1c2VycxgBIAMoCzIQLm5ha2FtYS5hcGkuVXNlclIFdXNlcnM=');
+
 @$core.Deprecated('Use validatePurchaseAppleRequestDescriptor instead')
-const ValidatePurchaseAppleRequest$json = const {
+const ValidatePurchaseAppleRequest$json = {
   '1': 'ValidatePurchaseAppleRequest',
-  '2': const [
-    const {'1': 'receipt', '3': 1, '4': 1, '5': 9, '10': 'receipt'},
-    const {
+  '2': [
+    {'1': 'receipt', '3': 1, '4': 1, '5': 9, '10': 'receipt'},
+    {
       '1': 'persist',
       '3': 2,
       '4': 1,
@@ -2606,13 +3033,15 @@ const ValidatePurchaseAppleRequest$json = const {
 /// Descriptor for `ValidatePurchaseAppleRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validatePurchaseAppleRequestDescriptor =
     $convert.base64Decode(
-        'ChxWYWxpZGF0ZVB1cmNoYXNlQXBwbGVSZXF1ZXN0EhgKB3JlY2VpcHQYASABKAlSB3JlY2VpcHQSNAoHcGVyc2lzdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSB3BlcnNpc3Q=');
+        'ChxWYWxpZGF0ZVB1cmNoYXNlQXBwbGVSZXF1ZXN0EhgKB3JlY2VpcHQYASABKAlSB3JlY2VpcH'
+        'QSNAoHcGVyc2lzdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSB3BlcnNpc3Q=');
+
 @$core.Deprecated('Use validateSubscriptionAppleRequestDescriptor instead')
-const ValidateSubscriptionAppleRequest$json = const {
+const ValidateSubscriptionAppleRequest$json = {
   '1': 'ValidateSubscriptionAppleRequest',
-  '2': const [
-    const {'1': 'receipt', '3': 1, '4': 1, '5': 9, '10': 'receipt'},
-    const {
+  '2': [
+    {'1': 'receipt', '3': 1, '4': 1, '5': 9, '10': 'receipt'},
+    {
       '1': 'persist',
       '3': 2,
       '4': 1,
@@ -2626,13 +3055,16 @@ const ValidateSubscriptionAppleRequest$json = const {
 /// Descriptor for `ValidateSubscriptionAppleRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validateSubscriptionAppleRequestDescriptor =
     $convert.base64Decode(
-        'CiBWYWxpZGF0ZVN1YnNjcmlwdGlvbkFwcGxlUmVxdWVzdBIYCgdyZWNlaXB0GAEgASgJUgdyZWNlaXB0EjQKB3BlcnNpc3QYAiABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZhbHVlUgdwZXJzaXN0');
+        'CiBWYWxpZGF0ZVN1YnNjcmlwdGlvbkFwcGxlUmVxdWVzdBIYCgdyZWNlaXB0GAEgASgJUgdyZW'
+        'NlaXB0EjQKB3BlcnNpc3QYAiABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZhbHVlUgdwZXJz'
+        'aXN0');
+
 @$core.Deprecated('Use validatePurchaseGoogleRequestDescriptor instead')
-const ValidatePurchaseGoogleRequest$json = const {
+const ValidatePurchaseGoogleRequest$json = {
   '1': 'ValidatePurchaseGoogleRequest',
-  '2': const [
-    const {'1': 'purchase', '3': 1, '4': 1, '5': 9, '10': 'purchase'},
-    const {
+  '2': [
+    {'1': 'purchase', '3': 1, '4': 1, '5': 9, '10': 'purchase'},
+    {
       '1': 'persist',
       '3': 2,
       '4': 1,
@@ -2646,13 +3078,16 @@ const ValidatePurchaseGoogleRequest$json = const {
 /// Descriptor for `ValidatePurchaseGoogleRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validatePurchaseGoogleRequestDescriptor =
     $convert.base64Decode(
-        'Ch1WYWxpZGF0ZVB1cmNoYXNlR29vZ2xlUmVxdWVzdBIaCghwdXJjaGFzZRgBIAEoCVIIcHVyY2hhc2USNAoHcGVyc2lzdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSB3BlcnNpc3Q=');
+        'Ch1WYWxpZGF0ZVB1cmNoYXNlR29vZ2xlUmVxdWVzdBIaCghwdXJjaGFzZRgBIAEoCVIIcHVyY2'
+        'hhc2USNAoHcGVyc2lzdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSB3BlcnNp'
+        'c3Q=');
+
 @$core.Deprecated('Use validateSubscriptionGoogleRequestDescriptor instead')
-const ValidateSubscriptionGoogleRequest$json = const {
+const ValidateSubscriptionGoogleRequest$json = {
   '1': 'ValidateSubscriptionGoogleRequest',
-  '2': const [
-    const {'1': 'receipt', '3': 1, '4': 1, '5': 9, '10': 'receipt'},
-    const {
+  '2': [
+    {'1': 'receipt', '3': 1, '4': 1, '5': 9, '10': 'receipt'},
+    {
       '1': 'persist',
       '3': 2,
       '4': 1,
@@ -2666,14 +3101,17 @@ const ValidateSubscriptionGoogleRequest$json = const {
 /// Descriptor for `ValidateSubscriptionGoogleRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validateSubscriptionGoogleRequestDescriptor =
     $convert.base64Decode(
-        'CiFWYWxpZGF0ZVN1YnNjcmlwdGlvbkdvb2dsZVJlcXVlc3QSGAoHcmVjZWlwdBgBIAEoCVIHcmVjZWlwdBI0CgdwZXJzaXN0GAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIHcGVyc2lzdA==');
+        'CiFWYWxpZGF0ZVN1YnNjcmlwdGlvbkdvb2dsZVJlcXVlc3QSGAoHcmVjZWlwdBgBIAEoCVIHcm'
+        'VjZWlwdBI0CgdwZXJzaXN0GAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIHcGVy'
+        'c2lzdA==');
+
 @$core.Deprecated('Use validatePurchaseHuaweiRequestDescriptor instead')
-const ValidatePurchaseHuaweiRequest$json = const {
+const ValidatePurchaseHuaweiRequest$json = {
   '1': 'ValidatePurchaseHuaweiRequest',
-  '2': const [
-    const {'1': 'purchase', '3': 1, '4': 1, '5': 9, '10': 'purchase'},
-    const {'1': 'signature', '3': 2, '4': 1, '5': 9, '10': 'signature'},
-    const {
+  '2': [
+    {'1': 'purchase', '3': 1, '4': 1, '5': 9, '10': 'purchase'},
+    {'1': 'signature', '3': 2, '4': 1, '5': 9, '10': 'signature'},
+    {
       '1': 'persist',
       '3': 3,
       '4': 1,
@@ -2687,21 +3125,42 @@ const ValidatePurchaseHuaweiRequest$json = const {
 /// Descriptor for `ValidatePurchaseHuaweiRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validatePurchaseHuaweiRequestDescriptor =
     $convert.base64Decode(
-        'Ch1WYWxpZGF0ZVB1cmNoYXNlSHVhd2VpUmVxdWVzdBIaCghwdXJjaGFzZRgBIAEoCVIIcHVyY2hhc2USHAoJc2lnbmF0dXJlGAIgASgJUglzaWduYXR1cmUSNAoHcGVyc2lzdBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSB3BlcnNpc3Q=');
-@$core.Deprecated('Use validatedPurchaseDescriptor instead')
-const ValidatedPurchase$json = const {
-  '1': 'ValidatedPurchase',
-  '2': const [
-    const {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
-    const {'1': 'product_id', '3': 2, '4': 1, '5': 9, '10': 'productId'},
-    const {
-      '1': 'transaction_id',
-      '3': 3,
+        'Ch1WYWxpZGF0ZVB1cmNoYXNlSHVhd2VpUmVxdWVzdBIaCghwdXJjaGFzZRgBIAEoCVIIcHVyY2'
+        'hhc2USHAoJc2lnbmF0dXJlGAIgASgJUglzaWduYXR1cmUSNAoHcGVyc2lzdBgDIAEoCzIaLmdv'
+        'b2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVSB3BlcnNpc3Q=');
+
+@$core
+    .Deprecated('Use validatePurchaseFacebookInstantRequestDescriptor instead')
+const ValidatePurchaseFacebookInstantRequest$json = {
+  '1': 'ValidatePurchaseFacebookInstantRequest',
+  '2': [
+    {'1': 'signed_request', '3': 1, '4': 1, '5': 9, '10': 'signedRequest'},
+    {
+      '1': 'persist',
+      '3': 2,
       '4': 1,
-      '5': 9,
-      '10': 'transactionId'
+      '5': 11,
+      '6': '.google.protobuf.BoolValue',
+      '10': 'persist'
     },
-    const {
+  ],
+};
+
+/// Descriptor for `ValidatePurchaseFacebookInstantRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List validatePurchaseFacebookInstantRequestDescriptor =
+    $convert.base64Decode(
+        'CiZWYWxpZGF0ZVB1cmNoYXNlRmFjZWJvb2tJbnN0YW50UmVxdWVzdBIlCg5zaWduZWRfcmVxdW'
+        'VzdBgBIAEoCVINc2lnbmVkUmVxdWVzdBI0CgdwZXJzaXN0GAIgASgLMhouZ29vZ2xlLnByb3Rv'
+        'YnVmLkJvb2xWYWx1ZVIHcGVyc2lzdA==');
+
+@$core.Deprecated('Use validatedPurchaseDescriptor instead')
+const ValidatedPurchase$json = {
+  '1': 'ValidatedPurchase',
+  '2': [
+    {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
+    {'1': 'product_id', '3': 2, '4': 1, '5': 9, '10': 'productId'},
+    {'1': 'transaction_id', '3': 3, '4': 1, '5': 9, '10': 'transactionId'},
+    {
       '1': 'store',
       '3': 4,
       '4': 1,
@@ -2709,7 +3168,7 @@ const ValidatedPurchase$json = const {
       '6': '.nakama.api.StoreProvider',
       '10': 'store'
     },
-    const {
+    {
       '1': 'purchase_time',
       '3': 5,
       '4': 1,
@@ -2717,7 +3176,7 @@ const ValidatedPurchase$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'purchaseTime'
     },
-    const {
+    {
       '1': 'create_time',
       '3': 6,
       '4': 1,
@@ -2725,7 +3184,7 @@ const ValidatedPurchase$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 7,
       '4': 1,
@@ -2733,7 +3192,7 @@ const ValidatedPurchase$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'updateTime'
     },
-    const {
+    {
       '1': 'refund_time',
       '3': 8,
       '4': 1,
@@ -2741,14 +3200,14 @@ const ValidatedPurchase$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'refundTime'
     },
-    const {
+    {
       '1': 'provider_response',
       '3': 9,
       '4': 1,
       '5': 9,
       '10': 'providerResponse'
     },
-    const {
+    {
       '1': 'environment',
       '3': 10,
       '4': 1,
@@ -2756,18 +3215,28 @@ const ValidatedPurchase$json = const {
       '6': '.nakama.api.StoreEnvironment',
       '10': 'environment'
     },
-    const {'1': 'seen_before', '3': 11, '4': 1, '5': 8, '10': 'seenBefore'},
+    {'1': 'seen_before', '3': 11, '4': 1, '5': 8, '10': 'seenBefore'},
   ],
 };
 
 /// Descriptor for `ValidatedPurchase`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validatedPurchaseDescriptor = $convert.base64Decode(
-    'ChFWYWxpZGF0ZWRQdXJjaGFzZRIXCgd1c2VyX2lkGAEgASgJUgZ1c2VySWQSHQoKcHJvZHVjdF9pZBgCIAEoCVIJcHJvZHVjdElkEiUKDnRyYW5zYWN0aW9uX2lkGAMgASgJUg10cmFuc2FjdGlvbklkEi8KBXN0b3JlGAQgASgOMhkubmFrYW1hLmFwaS5TdG9yZVByb3ZpZGVyUgVzdG9yZRI/Cg1wdXJjaGFzZV90aW1lGAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIMcHVyY2hhc2VUaW1lEjsKC2NyZWF0ZV90aW1lGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI7Cgt1cGRhdGVfdGltZRgHIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUSOwoLcmVmdW5kX3RpbWUYCCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgpyZWZ1bmRUaW1lEisKEXByb3ZpZGVyX3Jlc3BvbnNlGAkgASgJUhBwcm92aWRlclJlc3BvbnNlEj4KC2Vudmlyb25tZW50GAogASgOMhwubmFrYW1hLmFwaS5TdG9yZUVudmlyb25tZW50UgtlbnZpcm9ubWVudBIfCgtzZWVuX2JlZm9yZRgLIAEoCFIKc2VlbkJlZm9yZQ==');
+    'ChFWYWxpZGF0ZWRQdXJjaGFzZRIXCgd1c2VyX2lkGAEgASgJUgZ1c2VySWQSHQoKcHJvZHVjdF'
+    '9pZBgCIAEoCVIJcHJvZHVjdElkEiUKDnRyYW5zYWN0aW9uX2lkGAMgASgJUg10cmFuc2FjdGlv'
+    'bklkEi8KBXN0b3JlGAQgASgOMhkubmFrYW1hLmFwaS5TdG9yZVByb3ZpZGVyUgVzdG9yZRI/Cg'
+    '1wdXJjaGFzZV90aW1lGAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIMcHVyY2hh'
+    'c2VUaW1lEjsKC2NyZWF0ZV90aW1lGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcF'
+    'IKY3JlYXRlVGltZRI7Cgt1cGRhdGVfdGltZRgHIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1l'
+    'c3RhbXBSCnVwZGF0ZVRpbWUSOwoLcmVmdW5kX3RpbWUYCCABKAsyGi5nb29nbGUucHJvdG9idW'
+    'YuVGltZXN0YW1wUgpyZWZ1bmRUaW1lEisKEXByb3ZpZGVyX3Jlc3BvbnNlGAkgASgJUhBwcm92'
+    'aWRlclJlc3BvbnNlEj4KC2Vudmlyb25tZW50GAogASgOMhwubmFrYW1hLmFwaS5TdG9yZUVudm'
+    'lyb25tZW50UgtlbnZpcm9ubWVudBIfCgtzZWVuX2JlZm9yZRgLIAEoCFIKc2VlbkJlZm9yZQ==');
+
 @$core.Deprecated('Use validatePurchaseResponseDescriptor instead')
-const ValidatePurchaseResponse$json = const {
+const ValidatePurchaseResponse$json = {
   '1': 'ValidatePurchaseResponse',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'validated_purchases',
       '3': 1,
       '4': 3,
@@ -2781,12 +3250,14 @@ const ValidatePurchaseResponse$json = const {
 /// Descriptor for `ValidatePurchaseResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validatePurchaseResponseDescriptor =
     $convert.base64Decode(
-        'ChhWYWxpZGF0ZVB1cmNoYXNlUmVzcG9uc2USTgoTdmFsaWRhdGVkX3B1cmNoYXNlcxgBIAMoCzIdLm5ha2FtYS5hcGkuVmFsaWRhdGVkUHVyY2hhc2VSEnZhbGlkYXRlZFB1cmNoYXNlcw==');
+        'ChhWYWxpZGF0ZVB1cmNoYXNlUmVzcG9uc2USTgoTdmFsaWRhdGVkX3B1cmNoYXNlcxgBIAMoCz'
+        'IdLm5ha2FtYS5hcGkuVmFsaWRhdGVkUHVyY2hhc2VSEnZhbGlkYXRlZFB1cmNoYXNlcw==');
+
 @$core.Deprecated('Use validateSubscriptionResponseDescriptor instead')
-const ValidateSubscriptionResponse$json = const {
+const ValidateSubscriptionResponse$json = {
   '1': 'ValidateSubscriptionResponse',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'validated_subscription',
       '3': 1,
       '4': 1,
@@ -2800,21 +3271,24 @@ const ValidateSubscriptionResponse$json = const {
 /// Descriptor for `ValidateSubscriptionResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validateSubscriptionResponseDescriptor =
     $convert.base64Decode(
-        'ChxWYWxpZGF0ZVN1YnNjcmlwdGlvblJlc3BvbnNlElgKFnZhbGlkYXRlZF9zdWJzY3JpcHRpb24YASABKAsyIS5uYWthbWEuYXBpLlZhbGlkYXRlZFN1YnNjcmlwdGlvblIVdmFsaWRhdGVkU3Vic2NyaXB0aW9u');
+        'ChxWYWxpZGF0ZVN1YnNjcmlwdGlvblJlc3BvbnNlElgKFnZhbGlkYXRlZF9zdWJzY3JpcHRpb2'
+        '4YASABKAsyIS5uYWthbWEuYXBpLlZhbGlkYXRlZFN1YnNjcmlwdGlvblIVdmFsaWRhdGVkU3Vi'
+        'c2NyaXB0aW9u');
+
 @$core.Deprecated('Use validatedSubscriptionDescriptor instead')
-const ValidatedSubscription$json = const {
+const ValidatedSubscription$json = {
   '1': 'ValidatedSubscription',
-  '2': const [
-    const {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
-    const {'1': 'product_id', '3': 2, '4': 1, '5': 9, '10': 'productId'},
-    const {
+  '2': [
+    {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
+    {'1': 'product_id', '3': 2, '4': 1, '5': 9, '10': 'productId'},
+    {
       '1': 'original_transaction_id',
       '3': 3,
       '4': 1,
       '5': 9,
       '10': 'originalTransactionId'
     },
-    const {
+    {
       '1': 'store',
       '3': 4,
       '4': 1,
@@ -2822,7 +3296,7 @@ const ValidatedSubscription$json = const {
       '6': '.nakama.api.StoreProvider',
       '10': 'store'
     },
-    const {
+    {
       '1': 'purchase_time',
       '3': 5,
       '4': 1,
@@ -2830,7 +3304,7 @@ const ValidatedSubscription$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'purchaseTime'
     },
-    const {
+    {
       '1': 'create_time',
       '3': 6,
       '4': 1,
@@ -2838,7 +3312,7 @@ const ValidatedSubscription$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 7,
       '4': 1,
@@ -2846,7 +3320,7 @@ const ValidatedSubscription$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'updateTime'
     },
-    const {
+    {
       '1': 'environment',
       '3': 8,
       '4': 1,
@@ -2854,7 +3328,7 @@ const ValidatedSubscription$json = const {
       '6': '.nakama.api.StoreEnvironment',
       '10': 'environment'
     },
-    const {
+    {
       '1': 'expiry_time',
       '3': 9,
       '4': 1,
@@ -2862,7 +3336,7 @@ const ValidatedSubscription$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'expiryTime'
     },
-    const {
+    {
       '1': 'refund_time',
       '3': 10,
       '4': 1,
@@ -2870,32 +3344,45 @@ const ValidatedSubscription$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'refundTime'
     },
-    const {
+    {
       '1': 'provider_response',
       '3': 11,
       '4': 1,
       '5': 9,
       '10': 'providerResponse'
     },
-    const {
+    {
       '1': 'provider_notification',
       '3': 12,
       '4': 1,
       '5': 9,
       '10': 'providerNotification'
     },
-    const {'1': 'active', '3': 13, '4': 1, '5': 8, '10': 'active'},
+    {'1': 'active', '3': 13, '4': 1, '5': 8, '10': 'active'},
   ],
 };
 
 /// Descriptor for `ValidatedSubscription`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List validatedSubscriptionDescriptor = $convert.base64Decode(
-    'ChVWYWxpZGF0ZWRTdWJzY3JpcHRpb24SFwoHdXNlcl9pZBgBIAEoCVIGdXNlcklkEh0KCnByb2R1Y3RfaWQYAiABKAlSCXByb2R1Y3RJZBI2ChdvcmlnaW5hbF90cmFuc2FjdGlvbl9pZBgDIAEoCVIVb3JpZ2luYWxUcmFuc2FjdGlvbklkEi8KBXN0b3JlGAQgASgOMhkubmFrYW1hLmFwaS5TdG9yZVByb3ZpZGVyUgVzdG9yZRI/Cg1wdXJjaGFzZV90aW1lGAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIMcHVyY2hhc2VUaW1lEjsKC2NyZWF0ZV90aW1lGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI7Cgt1cGRhdGVfdGltZRgHIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUSPgoLZW52aXJvbm1lbnQYCCABKA4yHC5uYWthbWEuYXBpLlN0b3JlRW52aXJvbm1lbnRSC2Vudmlyb25tZW50EjsKC2V4cGlyeV90aW1lGAkgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKZXhwaXJ5VGltZRI7CgtyZWZ1bmRfdGltZRgKIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnJlZnVuZFRpbWUSKwoRcHJvdmlkZXJfcmVzcG9uc2UYCyABKAlSEHByb3ZpZGVyUmVzcG9uc2USMwoVcHJvdmlkZXJfbm90aWZpY2F0aW9uGAwgASgJUhRwcm92aWRlck5vdGlmaWNhdGlvbhIWCgZhY3RpdmUYDSABKAhSBmFjdGl2ZQ==');
+    'ChVWYWxpZGF0ZWRTdWJzY3JpcHRpb24SFwoHdXNlcl9pZBgBIAEoCVIGdXNlcklkEh0KCnByb2'
+    'R1Y3RfaWQYAiABKAlSCXByb2R1Y3RJZBI2ChdvcmlnaW5hbF90cmFuc2FjdGlvbl9pZBgDIAEo'
+    'CVIVb3JpZ2luYWxUcmFuc2FjdGlvbklkEi8KBXN0b3JlGAQgASgOMhkubmFrYW1hLmFwaS5TdG'
+    '9yZVByb3ZpZGVyUgVzdG9yZRI/Cg1wdXJjaGFzZV90aW1lGAUgASgLMhouZ29vZ2xlLnByb3Rv'
+    'YnVmLlRpbWVzdGFtcFIMcHVyY2hhc2VUaW1lEjsKC2NyZWF0ZV90aW1lGAYgASgLMhouZ29vZ2'
+    'xlLnByb3RvYnVmLlRpbWVzdGFtcFIKY3JlYXRlVGltZRI7Cgt1cGRhdGVfdGltZRgHIAEoCzIa'
+    'Lmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnVwZGF0ZVRpbWUSPgoLZW52aXJvbm1lbnQYCC'
+    'ABKA4yHC5uYWthbWEuYXBpLlN0b3JlRW52aXJvbm1lbnRSC2Vudmlyb25tZW50EjsKC2V4cGly'
+    'eV90aW1lGAkgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKZXhwaXJ5VGltZRI7Cg'
+    'tyZWZ1bmRfdGltZRgKIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCnJlZnVuZFRp'
+    'bWUSKwoRcHJvdmlkZXJfcmVzcG9uc2UYCyABKAlSEHByb3ZpZGVyUmVzcG9uc2USMwoVcHJvdm'
+    'lkZXJfbm90aWZpY2F0aW9uGAwgASgJUhRwcm92aWRlck5vdGlmaWNhdGlvbhIWCgZhY3RpdmUY'
+    'DSABKAhSBmFjdGl2ZQ==');
+
 @$core.Deprecated('Use purchaseListDescriptor instead')
-const PurchaseList$json = const {
+const PurchaseList$json = {
   '1': 'PurchaseList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'validated_purchases',
       '3': 1,
       '4': 3,
@@ -2903,19 +3390,22 @@ const PurchaseList$json = const {
       '6': '.nakama.api.ValidatedPurchase',
       '10': 'validatedPurchases'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
-    const {'1': 'prev_cursor', '3': 3, '4': 1, '5': 9, '10': 'prevCursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'prev_cursor', '3': 3, '4': 1, '5': 9, '10': 'prevCursor'},
   ],
 };
 
 /// Descriptor for `PurchaseList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List purchaseListDescriptor = $convert.base64Decode(
-    'CgxQdXJjaGFzZUxpc3QSTgoTdmFsaWRhdGVkX3B1cmNoYXNlcxgBIAMoCzIdLm5ha2FtYS5hcGkuVmFsaWRhdGVkUHVyY2hhc2VSEnZhbGlkYXRlZFB1cmNoYXNlcxIWCgZjdXJzb3IYAiABKAlSBmN1cnNvchIfCgtwcmV2X2N1cnNvchgDIAEoCVIKcHJldkN1cnNvcg==');
+    'CgxQdXJjaGFzZUxpc3QSTgoTdmFsaWRhdGVkX3B1cmNoYXNlcxgBIAMoCzIdLm5ha2FtYS5hcG'
+    'kuVmFsaWRhdGVkUHVyY2hhc2VSEnZhbGlkYXRlZFB1cmNoYXNlcxIWCgZjdXJzb3IYAiABKAlS'
+    'BmN1cnNvchIfCgtwcmV2X2N1cnNvchgDIAEoCVIKcHJldkN1cnNvcg==');
+
 @$core.Deprecated('Use subscriptionListDescriptor instead')
-const SubscriptionList$json = const {
+const SubscriptionList$json = {
   '1': 'SubscriptionList',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'validated_subscriptions',
       '3': 1,
       '4': 3,
@@ -2923,26 +3413,24 @@ const SubscriptionList$json = const {
       '6': '.nakama.api.ValidatedSubscription',
       '10': 'validatedSubscriptions'
     },
-    const {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
-    const {'1': 'prev_cursor', '3': 3, '4': 1, '5': 9, '10': 'prevCursor'},
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+    {'1': 'prev_cursor', '3': 3, '4': 1, '5': 9, '10': 'prevCursor'},
   ],
 };
 
 /// Descriptor for `SubscriptionList`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List subscriptionListDescriptor = $convert.base64Decode(
-    'ChBTdWJzY3JpcHRpb25MaXN0EloKF3ZhbGlkYXRlZF9zdWJzY3JpcHRpb25zGAEgAygLMiEubmFrYW1hLmFwaS5WYWxpZGF0ZWRTdWJzY3JpcHRpb25SFnZhbGlkYXRlZFN1YnNjcmlwdGlvbnMSFgoGY3Vyc29yGAIgASgJUgZjdXJzb3ISHwoLcHJldl9jdXJzb3IYAyABKAlSCnByZXZDdXJzb3I=');
+    'ChBTdWJzY3JpcHRpb25MaXN0EloKF3ZhbGlkYXRlZF9zdWJzY3JpcHRpb25zGAEgAygLMiEubm'
+    'FrYW1hLmFwaS5WYWxpZGF0ZWRTdWJzY3JpcHRpb25SFnZhbGlkYXRlZFN1YnNjcmlwdGlvbnMS'
+    'FgoGY3Vyc29yGAIgASgJUgZjdXJzb3ISHwoLcHJldl9jdXJzb3IYAyABKAlSCnByZXZDdXJzb3'
+    'I=');
+
 @$core.Deprecated('Use writeLeaderboardRecordRequestDescriptor instead')
-const WriteLeaderboardRecordRequest$json = const {
+const WriteLeaderboardRecordRequest$json = {
   '1': 'WriteLeaderboardRecordRequest',
-  '2': const [
-    const {
-      '1': 'leaderboard_id',
-      '3': 1,
-      '4': 1,
-      '5': 9,
-      '10': 'leaderboardId'
-    },
-    const {
+  '2': [
+    {'1': 'leaderboard_id', '3': 1, '4': 1, '5': 9, '10': 'leaderboardId'},
+    {
       '1': 'record',
       '3': 2,
       '4': 1,
@@ -2951,17 +3439,17 @@ const WriteLeaderboardRecordRequest$json = const {
       '10': 'record'
     },
   ],
-  '3': const [WriteLeaderboardRecordRequest_LeaderboardRecordWrite$json],
+  '3': [WriteLeaderboardRecordRequest_LeaderboardRecordWrite$json],
 };
 
 @$core.Deprecated('Use writeLeaderboardRecordRequestDescriptor instead')
-const WriteLeaderboardRecordRequest_LeaderboardRecordWrite$json = const {
+const WriteLeaderboardRecordRequest_LeaderboardRecordWrite$json = {
   '1': 'LeaderboardRecordWrite',
-  '2': const [
-    const {'1': 'score', '3': 1, '4': 1, '5': 3, '10': 'score'},
-    const {'1': 'subscore', '3': 2, '4': 1, '5': 3, '10': 'subscore'},
-    const {'1': 'metadata', '3': 3, '4': 1, '5': 9, '10': 'metadata'},
-    const {
+  '2': [
+    {'1': 'score', '3': 1, '4': 1, '5': 3, '10': 'score'},
+    {'1': 'subscore', '3': 2, '4': 1, '5': 3, '10': 'subscore'},
+    {'1': 'metadata', '3': 3, '4': 1, '5': 9, '10': 'metadata'},
+    {
       '1': 'operator',
       '3': 4,
       '4': 1,
@@ -2973,18 +3461,23 @@ const WriteLeaderboardRecordRequest_LeaderboardRecordWrite$json = const {
 };
 
 /// Descriptor for `WriteLeaderboardRecordRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeLeaderboardRecordRequestDescriptor =
-    $convert.base64Decode(
-        'Ch1Xcml0ZUxlYWRlcmJvYXJkUmVjb3JkUmVxdWVzdBIlCg5sZWFkZXJib2FyZF9pZBgBIAEoCVINbGVhZGVyYm9hcmRJZBJYCgZyZWNvcmQYAiABKAsyQC5uYWthbWEuYXBpLldyaXRlTGVhZGVyYm9hcmRSZWNvcmRSZXF1ZXN0LkxlYWRlcmJvYXJkUmVjb3JkV3JpdGVSBnJlY29yZBqYAQoWTGVhZGVyYm9hcmRSZWNvcmRXcml0ZRIUCgVzY29yZRgBIAEoA1IFc2NvcmUSGgoIc3Vic2NvcmUYAiABKANSCHN1YnNjb3JlEhoKCG1ldGFkYXRhGAMgASgJUghtZXRhZGF0YRIwCghvcGVyYXRvchgEIAEoDjIULm5ha2FtYS5hcGkuT3BlcmF0b3JSCG9wZXJhdG9y');
+final $typed_data.Uint8List writeLeaderboardRecordRequestDescriptor = $convert.base64Decode(
+    'Ch1Xcml0ZUxlYWRlcmJvYXJkUmVjb3JkUmVxdWVzdBIlCg5sZWFkZXJib2FyZF9pZBgBIAEoCV'
+    'INbGVhZGVyYm9hcmRJZBJYCgZyZWNvcmQYAiABKAsyQC5uYWthbWEuYXBpLldyaXRlTGVhZGVy'
+    'Ym9hcmRSZWNvcmRSZXF1ZXN0LkxlYWRlcmJvYXJkUmVjb3JkV3JpdGVSBnJlY29yZBqYAQoWTG'
+    'VhZGVyYm9hcmRSZWNvcmRXcml0ZRIUCgVzY29yZRgBIAEoA1IFc2NvcmUSGgoIc3Vic2NvcmUY'
+    'AiABKANSCHN1YnNjb3JlEhoKCG1ldGFkYXRhGAMgASgJUghtZXRhZGF0YRIwCghvcGVyYXRvch'
+    'gEIAEoDjIULm5ha2FtYS5hcGkuT3BlcmF0b3JSCG9wZXJhdG9y');
+
 @$core.Deprecated('Use writeStorageObjectDescriptor instead')
-const WriteStorageObject$json = const {
+const WriteStorageObject$json = {
   '1': 'WriteStorageObject',
-  '2': const [
-    const {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
-    const {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 3, '4': 1, '5': 9, '10': 'value'},
-    const {'1': 'version', '3': 4, '4': 1, '5': 9, '10': 'version'},
-    const {
+  '2': [
+    {'1': 'collection', '3': 1, '4': 1, '5': 9, '10': 'collection'},
+    {'1': 'key', '3': 2, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 3, '4': 1, '5': 9, '10': 'value'},
+    {'1': 'version', '3': 4, '4': 1, '5': 9, '10': 'version'},
+    {
       '1': 'permission_read',
       '3': 5,
       '4': 1,
@@ -2992,7 +3485,7 @@ const WriteStorageObject$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'permissionRead'
     },
-    const {
+    {
       '1': 'permission_write',
       '3': 6,
       '4': 1,
@@ -3005,12 +3498,17 @@ const WriteStorageObject$json = const {
 
 /// Descriptor for `WriteStorageObject`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List writeStorageObjectDescriptor = $convert.base64Decode(
-    'ChJXcml0ZVN0b3JhZ2VPYmplY3QSHgoKY29sbGVjdGlvbhgBIAEoCVIKY29sbGVjdGlvbhIQCgNrZXkYAiABKAlSA2tleRIUCgV2YWx1ZRgDIAEoCVIFdmFsdWUSGAoHdmVyc2lvbhgEIAEoCVIHdmVyc2lvbhJECg9wZXJtaXNzaW9uX3JlYWQYBSABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIOcGVybWlzc2lvblJlYWQSRgoQcGVybWlzc2lvbl93cml0ZRgGIAEoCzIbLmdvb2dsZS5wcm90b2J1Zi5JbnQzMlZhbHVlUg9wZXJtaXNzaW9uV3JpdGU=');
+    'ChJXcml0ZVN0b3JhZ2VPYmplY3QSHgoKY29sbGVjdGlvbhgBIAEoCVIKY29sbGVjdGlvbhIQCg'
+    'NrZXkYAiABKAlSA2tleRIUCgV2YWx1ZRgDIAEoCVIFdmFsdWUSGAoHdmVyc2lvbhgEIAEoCVIH'
+    'dmVyc2lvbhJECg9wZXJtaXNzaW9uX3JlYWQYBSABKAsyGy5nb29nbGUucHJvdG9idWYuSW50Mz'
+    'JWYWx1ZVIOcGVybWlzc2lvblJlYWQSRgoQcGVybWlzc2lvbl93cml0ZRgGIAEoCzIbLmdvb2ds'
+    'ZS5wcm90b2J1Zi5JbnQzMlZhbHVlUg9wZXJtaXNzaW9uV3JpdGU=');
+
 @$core.Deprecated('Use writeStorageObjectsRequestDescriptor instead')
-const WriteStorageObjectsRequest$json = const {
+const WriteStorageObjectsRequest$json = {
   '1': 'WriteStorageObjectsRequest',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'objects',
       '3': 1,
       '4': 3,
@@ -3024,13 +3522,15 @@ const WriteStorageObjectsRequest$json = const {
 /// Descriptor for `WriteStorageObjectsRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List writeStorageObjectsRequestDescriptor =
     $convert.base64Decode(
-        'ChpXcml0ZVN0b3JhZ2VPYmplY3RzUmVxdWVzdBI4CgdvYmplY3RzGAEgAygLMh4ubmFrYW1hLmFwaS5Xcml0ZVN0b3JhZ2VPYmplY3RSB29iamVjdHM=');
+        'ChpXcml0ZVN0b3JhZ2VPYmplY3RzUmVxdWVzdBI4CgdvYmplY3RzGAEgAygLMh4ubmFrYW1hLm'
+        'FwaS5Xcml0ZVN0b3JhZ2VPYmplY3RSB29iamVjdHM=');
+
 @$core.Deprecated('Use writeTournamentRecordRequestDescriptor instead')
-const WriteTournamentRecordRequest$json = const {
+const WriteTournamentRecordRequest$json = {
   '1': 'WriteTournamentRecordRequest',
-  '2': const [
-    const {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
-    const {
+  '2': [
+    {'1': 'tournament_id', '3': 1, '4': 1, '5': 9, '10': 'tournamentId'},
+    {
       '1': 'record',
       '3': 2,
       '4': 1,
@@ -3039,17 +3539,17 @@ const WriteTournamentRecordRequest$json = const {
       '10': 'record'
     },
   ],
-  '3': const [WriteTournamentRecordRequest_TournamentRecordWrite$json],
+  '3': [WriteTournamentRecordRequest_TournamentRecordWrite$json],
 };
 
 @$core.Deprecated('Use writeTournamentRecordRequestDescriptor instead')
-const WriteTournamentRecordRequest_TournamentRecordWrite$json = const {
+const WriteTournamentRecordRequest_TournamentRecordWrite$json = {
   '1': 'TournamentRecordWrite',
-  '2': const [
-    const {'1': 'score', '3': 1, '4': 1, '5': 3, '10': 'score'},
-    const {'1': 'subscore', '3': 2, '4': 1, '5': 3, '10': 'subscore'},
-    const {'1': 'metadata', '3': 3, '4': 1, '5': 9, '10': 'metadata'},
-    const {
+  '2': [
+    {'1': 'score', '3': 1, '4': 1, '5': 3, '10': 'score'},
+    {'1': 'subscore', '3': 2, '4': 1, '5': 3, '10': 'subscore'},
+    {'1': 'metadata', '3': 3, '4': 1, '5': 9, '10': 'metadata'},
+    {
       '1': 'operator',
       '3': 4,
       '4': 1,
@@ -3061,6 +3561,96 @@ const WriteTournamentRecordRequest_TournamentRecordWrite$json = const {
 };
 
 /// Descriptor for `WriteTournamentRecordRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List writeTournamentRecordRequestDescriptor =
-    $convert.base64Decode(
-        'ChxXcml0ZVRvdXJuYW1lbnRSZWNvcmRSZXF1ZXN0EiMKDXRvdXJuYW1lbnRfaWQYASABKAlSDHRvdXJuYW1lbnRJZBJWCgZyZWNvcmQYAiABKAsyPi5uYWthbWEuYXBpLldyaXRlVG91cm5hbWVudFJlY29yZFJlcXVlc3QuVG91cm5hbWVudFJlY29yZFdyaXRlUgZyZWNvcmQalwEKFVRvdXJuYW1lbnRSZWNvcmRXcml0ZRIUCgVzY29yZRgBIAEoA1IFc2NvcmUSGgoIc3Vic2NvcmUYAiABKANSCHN1YnNjb3JlEhoKCG1ldGFkYXRhGAMgASgJUghtZXRhZGF0YRIwCghvcGVyYXRvchgEIAEoDjIULm5ha2FtYS5hcGkuT3BlcmF0b3JSCG9wZXJhdG9y');
+final $typed_data.Uint8List writeTournamentRecordRequestDescriptor = $convert.base64Decode(
+    'ChxXcml0ZVRvdXJuYW1lbnRSZWNvcmRSZXF1ZXN0EiMKDXRvdXJuYW1lbnRfaWQYASABKAlSDH'
+    'RvdXJuYW1lbnRJZBJWCgZyZWNvcmQYAiABKAsyPi5uYWthbWEuYXBpLldyaXRlVG91cm5hbWVu'
+    'dFJlY29yZFJlcXVlc3QuVG91cm5hbWVudFJlY29yZFdyaXRlUgZyZWNvcmQalwEKFVRvdXJuYW'
+    '1lbnRSZWNvcmRXcml0ZRIUCgVzY29yZRgBIAEoA1IFc2NvcmUSGgoIc3Vic2NvcmUYAiABKANS'
+    'CHN1YnNjb3JlEhoKCG1ldGFkYXRhGAMgASgJUghtZXRhZGF0YRIwCghvcGVyYXRvchgEIAEoDj'
+    'IULm5ha2FtYS5hcGkuT3BlcmF0b3JSCG9wZXJhdG9y');
+
+@$core.Deprecated('Use listPartiesRequestDescriptor instead')
+const ListPartiesRequest$json = {
+  '1': 'ListPartiesRequest',
+  '2': [
+    {
+      '1': 'limit',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Int32Value',
+      '10': 'limit'
+    },
+    {
+      '1': 'open',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.BoolValue',
+      '10': 'open'
+    },
+    {
+      '1': 'query',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.StringValue',
+      '10': 'query'
+    },
+    {
+      '1': 'cursor',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.StringValue',
+      '10': 'cursor'
+    },
+  ],
+};
+
+/// Descriptor for `ListPartiesRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List listPartiesRequestDescriptor = $convert.base64Decode(
+    'ChJMaXN0UGFydGllc1JlcXVlc3QSMQoFbGltaXQYASABKAsyGy5nb29nbGUucHJvdG9idWYuSW'
+    '50MzJWYWx1ZVIFbGltaXQSLgoEb3BlbhgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFs'
+    'dWVSBG9wZW4SMgoFcXVlcnkYAyABKAsyHC5nb29nbGUucHJvdG9idWYuU3RyaW5nVmFsdWVSBX'
+    'F1ZXJ5EjQKBmN1cnNvchgEIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIGY3Vy'
+    'c29y');
+
+@$core.Deprecated('Use partyDescriptor instead')
+const Party$json = {
+  '1': 'Party',
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {'1': 'open', '3': 2, '4': 1, '5': 8, '10': 'open'},
+    {'1': 'hidden', '3': 3, '4': 1, '5': 8, '10': 'hidden'},
+    {'1': 'max_size', '3': 4, '4': 1, '5': 5, '10': 'maxSize'},
+    {'1': 'label', '3': 5, '4': 1, '5': 9, '10': 'label'},
+  ],
+};
+
+/// Descriptor for `Party`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List partyDescriptor = $convert.base64Decode(
+    'CgVQYXJ0eRIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBISCgRvcGVuGAIgASgIUgRvcGVuEh'
+    'YKBmhpZGRlbhgDIAEoCFIGaGlkZGVuEhkKCG1heF9zaXplGAQgASgFUgdtYXhTaXplEhQKBWxh'
+    'YmVsGAUgASgJUgVsYWJlbA==');
+
+@$core.Deprecated('Use partyListDescriptor instead')
+const PartyList$json = {
+  '1': 'PartyList',
+  '2': [
+    {
+      '1': 'parties',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.nakama.api.Party',
+      '10': 'parties'
+    },
+    {'1': 'cursor', '3': 2, '4': 1, '5': 9, '10': 'cursor'},
+  ],
+};
+
+/// Descriptor for `PartyList`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List partyListDescriptor = $convert.base64Decode(
+    'CglQYXJ0eUxpc3QSKwoHcGFydGllcxgBIAMoCzIRLm5ha2FtYS5hcGkuUGFydHlSB3BhcnRpZX'
+    'MSFgoGY3Vyc29yGAIgASgJUgZjdXJzb3I=');

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pb.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pb.dart
@@ -1,8 +1,15 @@
-///
-//  Generated code. Do not modify.
-//  source: apigrpc/apigrpc.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from apigrpc/apigrpc.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pbenum.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pbenum.dart
@@ -1,6 +1,11 @@
-///
-//  Generated code. Do not modify.
-//  source: apigrpc/apigrpc.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from apigrpc/apigrpc.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pbgrpc.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pbgrpc.dart
@@ -1,888 +1,1145 @@
-///
-//  Generated code. Do not modify.
-//  source: apigrpc/apigrpc.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from apigrpc/apigrpc.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:async' as $async;
-
 import 'dart:core' as $core;
 
 import 'package:grpc/service_api.dart' as $grpc;
+import 'package:protobuf/protobuf.dart' as $pb;
+
 import '../api/api.pb.dart' as $0;
 import '../google/protobuf/empty.pb.dart' as $1;
+
 export 'apigrpc.pb.dart';
 
+/// *
+///  The Nakama RPC protocol service built with GRPC.
+@$pb.GrpcServiceName('nakama.api.Nakama')
 class NakamaClient extends $grpc.Client {
+  /// The hostname for this service.
+  static const $core.String defaultHost = '';
+
+  /// OAuth scopes needed for the client.
+  static const $core.List<$core.String> oauthScopes = [
+    '',
+  ];
+
+  NakamaClient(super.channel, {super.options, super.interceptors});
+
+  /// Add friends by ID or username to a user's account.
+  $grpc.ResponseFuture<$1.Empty> addFriends(
+    $0.AddFriendsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$addFriends, request, options: options);
+  }
+
+  /// Add users to a group.
+  $grpc.ResponseFuture<$1.Empty> addGroupUsers(
+    $0.AddGroupUsersRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$addGroupUsers, request, options: options);
+  }
+
+  /// Refresh a user's session using a refresh token retrieved from a previous authentication request.
+  $grpc.ResponseFuture<$0.Session> sessionRefresh(
+    $0.SessionRefreshRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$sessionRefresh, request, options: options);
+  }
+
+  /// Log out a session, invalidate a refresh token, or log out all sessions/refresh tokens for a user.
+  $grpc.ResponseFuture<$1.Empty> sessionLogout(
+    $0.SessionLogoutRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$sessionLogout, request, options: options);
+  }
+
+  /// Authenticate a user with an Apple ID against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateApple(
+    $0.AuthenticateAppleRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateApple, request, options: options);
+  }
+
+  /// Authenticate a user with a custom id against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateCustom(
+    $0.AuthenticateCustomRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateCustom, request, options: options);
+  }
+
+  /// Authenticate a user with a device id against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateDevice(
+    $0.AuthenticateDeviceRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateDevice, request, options: options);
+  }
+
+  /// Authenticate a user with an email+password against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateEmail(
+    $0.AuthenticateEmailRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateEmail, request, options: options);
+  }
+
+  /// Authenticate a user with a Facebook OAuth token against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateFacebook(
+    $0.AuthenticateFacebookRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateFacebook, request, options: options);
+  }
+
+  /// Authenticate a user with a Facebook Instant Game token against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateFacebookInstantGame(
+    $0.AuthenticateFacebookInstantGameRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateFacebookInstantGame, request,
+        options: options);
+  }
+
+  /// Authenticate a user with Apple's GameCenter against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateGameCenter(
+    $0.AuthenticateGameCenterRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateGameCenter, request,
+        options: options);
+  }
+
+  /// Authenticate a user with Google against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateGoogle(
+    $0.AuthenticateGoogleRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateGoogle, request, options: options);
+  }
+
+  /// Authenticate a user with Steam against the server.
+  $grpc.ResponseFuture<$0.Session> authenticateSteam(
+    $0.AuthenticateSteamRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$authenticateSteam, request, options: options);
+  }
+
+  /// Ban a set of users from a group.
+  $grpc.ResponseFuture<$1.Empty> banGroupUsers(
+    $0.BanGroupUsersRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$banGroupUsers, request, options: options);
+  }
+
+  /// Block one or more users by ID or username.
+  $grpc.ResponseFuture<$1.Empty> blockFriends(
+    $0.BlockFriendsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$blockFriends, request, options: options);
+  }
+
+  /// Create a new group with the current user as the owner.
+  $grpc.ResponseFuture<$0.Group> createGroup(
+    $0.CreateGroupRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$createGroup, request, options: options);
+  }
+
+  /// Delete the current user's account.
+  $grpc.ResponseFuture<$1.Empty> deleteAccount(
+    $1.Empty request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$deleteAccount, request, options: options);
+  }
+
+  /// Delete one or more users by ID or username.
+  $grpc.ResponseFuture<$1.Empty> deleteFriends(
+    $0.DeleteFriendsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$deleteFriends, request, options: options);
+  }
+
+  /// Delete a group by ID.
+  $grpc.ResponseFuture<$1.Empty> deleteGroup(
+    $0.DeleteGroupRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$deleteGroup, request, options: options);
+  }
+
+  /// Delete a leaderboard record.
+  $grpc.ResponseFuture<$1.Empty> deleteLeaderboardRecord(
+    $0.DeleteLeaderboardRecordRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$deleteLeaderboardRecord, request,
+        options: options);
+  }
+
+  /// Delete one or more notifications for the current user.
+  $grpc.ResponseFuture<$1.Empty> deleteNotifications(
+    $0.DeleteNotificationsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$deleteNotifications, request, options: options);
+  }
+
+  /// Delete a tournament record.
+  $grpc.ResponseFuture<$1.Empty> deleteTournamentRecord(
+    $0.DeleteTournamentRecordRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$deleteTournamentRecord, request,
+        options: options);
+  }
+
+  /// Delete one or more objects by ID or username.
+  $grpc.ResponseFuture<$1.Empty> deleteStorageObjects(
+    $0.DeleteStorageObjectsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$deleteStorageObjects, request, options: options);
+  }
+
+  /// Submit an event for processing in the server's registered runtime custom events handler.
+  $grpc.ResponseFuture<$1.Empty> event(
+    $0.Event request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$event, request, options: options);
+  }
+
+  /// Fetch the current user's account.
+  $grpc.ResponseFuture<$0.Account> getAccount(
+    $1.Empty request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$getAccount, request, options: options);
+  }
+
+  /// Fetch zero or more users by ID and/or username.
+  $grpc.ResponseFuture<$0.Users> getUsers(
+    $0.GetUsersRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$getUsers, request, options: options);
+  }
+
+  /// Get subscription by product id.
+  $grpc.ResponseFuture<$0.ValidatedSubscription> getSubscription(
+    $0.GetSubscriptionRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$getSubscription, request, options: options);
+  }
+
+  /// Get matchmaker stats.
+  $grpc.ResponseFuture<$0.MatchmakerStats> getMatchmakerStats(
+    $1.Empty request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$getMatchmakerStats, request, options: options);
+  }
+
+  /// A healthcheck which load balancers can use to check the service.
+  $grpc.ResponseFuture<$1.Empty> healthcheck(
+    $1.Empty request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$healthcheck, request, options: options);
+  }
+
+  /// Import Facebook friends and add them to a user's account.
+  $grpc.ResponseFuture<$1.Empty> importFacebookFriends(
+    $0.ImportFacebookFriendsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$importFacebookFriends, request, options: options);
+  }
+
+  /// Import Steam friends and add them to a user's account.
+  $grpc.ResponseFuture<$1.Empty> importSteamFriends(
+    $0.ImportSteamFriendsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$importSteamFriends, request, options: options);
+  }
+
+  /// Immediately join an open group, or request to join a closed one.
+  $grpc.ResponseFuture<$1.Empty> joinGroup(
+    $0.JoinGroupRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$joinGroup, request, options: options);
+  }
+
+  /// Attempt to join an open and running tournament.
+  $grpc.ResponseFuture<$1.Empty> joinTournament(
+    $0.JoinTournamentRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$joinTournament, request, options: options);
+  }
+
+  /// Kick a set of users from a group.
+  $grpc.ResponseFuture<$1.Empty> kickGroupUsers(
+    $0.KickGroupUsersRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$kickGroupUsers, request, options: options);
+  }
+
+  /// Leave a group the user is a member of.
+  $grpc.ResponseFuture<$1.Empty> leaveGroup(
+    $0.LeaveGroupRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$leaveGroup, request, options: options);
+  }
+
+  /// Add an Apple ID to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkApple(
+    $0.AccountApple request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkApple, request, options: options);
+  }
+
+  /// Add a custom ID to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkCustom(
+    $0.AccountCustom request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkCustom, request, options: options);
+  }
+
+  /// Add a device ID to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkDevice(
+    $0.AccountDevice request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkDevice, request, options: options);
+  }
+
+  /// Add an email+password to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkEmail(
+    $0.AccountEmail request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkEmail, request, options: options);
+  }
+
+  /// Add Facebook to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkFacebook(
+    $0.LinkFacebookRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkFacebook, request, options: options);
+  }
+
+  /// Add Facebook Instant Game to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkFacebookInstantGame(
+    $0.AccountFacebookInstantGame request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkFacebookInstantGame, request,
+        options: options);
+  }
+
+  /// Add Apple's GameCenter to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkGameCenter(
+    $0.AccountGameCenter request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkGameCenter, request, options: options);
+  }
+
+  /// Add Google to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkGoogle(
+    $0.AccountGoogle request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkGoogle, request, options: options);
+  }
+
+  /// Add Steam to the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> linkSteam(
+    $0.LinkSteamRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$linkSteam, request, options: options);
+  }
+
+  /// List a channel's message history.
+  $grpc.ResponseFuture<$0.ChannelMessageList> listChannelMessages(
+    $0.ListChannelMessagesRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listChannelMessages, request, options: options);
+  }
+
+  /// List all friends for the current user.
+  $grpc.ResponseFuture<$0.FriendList> listFriends(
+    $0.ListFriendsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listFriends, request, options: options);
+  }
+
+  /// List friends of friends for the current user.
+  $grpc.ResponseFuture<$0.FriendsOfFriendsList> listFriendsOfFriends(
+    $0.ListFriendsOfFriendsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listFriendsOfFriends, request, options: options);
+  }
+
+  /// List groups based on given filters.
+  $grpc.ResponseFuture<$0.GroupList> listGroups(
+    $0.ListGroupsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listGroups, request, options: options);
+  }
+
+  /// List all users that are part of a group.
+  $grpc.ResponseFuture<$0.GroupUserList> listGroupUsers(
+    $0.ListGroupUsersRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listGroupUsers, request, options: options);
+  }
+
+  /// List leaderboard records.
+  $grpc.ResponseFuture<$0.LeaderboardRecordList> listLeaderboardRecords(
+    $0.ListLeaderboardRecordsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listLeaderboardRecords, request,
+        options: options);
+  }
+
+  /// List leaderboard records around the target ownerId.
+  $grpc.ResponseFuture<$0.LeaderboardRecordList>
+      listLeaderboardRecordsAroundOwner(
+    $0.ListLeaderboardRecordsAroundOwnerRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listLeaderboardRecordsAroundOwner, request,
+        options: options);
+  }
+
+  /// List running matches and optionally filter by matching criteria.
+  $grpc.ResponseFuture<$0.MatchList> listMatches(
+    $0.ListMatchesRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listMatches, request, options: options);
+  }
+
+  /// List parties and optionally filter by matching criteria.
+  $grpc.ResponseFuture<$0.PartyList> listParties(
+    $0.ListPartiesRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listParties, request, options: options);
+  }
+
+  /// Fetch list of notifications.
+  $grpc.ResponseFuture<$0.NotificationList> listNotifications(
+    $0.ListNotificationsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listNotifications, request, options: options);
+  }
+
+  /// List publicly readable storage objects in a given collection.
+  $grpc.ResponseFuture<$0.StorageObjectList> listStorageObjects(
+    $0.ListStorageObjectsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listStorageObjects, request, options: options);
+  }
+
+  /// List user's subscriptions.
+  $grpc.ResponseFuture<$0.SubscriptionList> listSubscriptions(
+    $0.ListSubscriptionsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listSubscriptions, request, options: options);
+  }
+
+  /// List current or upcoming tournaments.
+  $grpc.ResponseFuture<$0.TournamentList> listTournaments(
+    $0.ListTournamentsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listTournaments, request, options: options);
+  }
+
+  /// List tournament records.
+  $grpc.ResponseFuture<$0.TournamentRecordList> listTournamentRecords(
+    $0.ListTournamentRecordsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listTournamentRecords, request, options: options);
+  }
+
+  /// List tournament records for a given owner.
+  $grpc.ResponseFuture<$0.TournamentRecordList>
+      listTournamentRecordsAroundOwner(
+    $0.ListTournamentRecordsAroundOwnerRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listTournamentRecordsAroundOwner, request,
+        options: options);
+  }
+
+  /// List groups the current user belongs to.
+  $grpc.ResponseFuture<$0.UserGroupList> listUserGroups(
+    $0.ListUserGroupsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$listUserGroups, request, options: options);
+  }
+
+  /// Promote a set of users in a group to the next role up.
+  $grpc.ResponseFuture<$1.Empty> promoteGroupUsers(
+    $0.PromoteGroupUsersRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$promoteGroupUsers, request, options: options);
+  }
+
+  /// Demote a set of users in a group to the next role down.
+  $grpc.ResponseFuture<$1.Empty> demoteGroupUsers(
+    $0.DemoteGroupUsersRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$demoteGroupUsers, request, options: options);
+  }
+
+  /// Get storage objects.
+  $grpc.ResponseFuture<$0.StorageObjects> readStorageObjects(
+    $0.ReadStorageObjectsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$readStorageObjects, request, options: options);
+  }
+
+  /// Execute a Lua function on the server.
+  $grpc.ResponseFuture<$0.Rpc> rpcFunc(
+    $0.Rpc request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$rpcFunc, request, options: options);
+  }
+
+  /// Remove the Apple ID from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkApple(
+    $0.AccountApple request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkApple, request, options: options);
+  }
+
+  /// Remove the custom ID from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkCustom(
+    $0.AccountCustom request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkCustom, request, options: options);
+  }
+
+  /// Remove the device ID from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkDevice(
+    $0.AccountDevice request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkDevice, request, options: options);
+  }
+
+  /// Remove the email+password from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkEmail(
+    $0.AccountEmail request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkEmail, request, options: options);
+  }
+
+  /// Remove Facebook from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkFacebook(
+    $0.AccountFacebook request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkFacebook, request, options: options);
+  }
+
+  /// Remove Facebook Instant Game profile from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkFacebookInstantGame(
+    $0.AccountFacebookInstantGame request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkFacebookInstantGame, request,
+        options: options);
+  }
+
+  /// Remove Apple's GameCenter from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkGameCenter(
+    $0.AccountGameCenter request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkGameCenter, request, options: options);
+  }
+
+  /// Remove Google from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkGoogle(
+    $0.AccountGoogle request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkGoogle, request, options: options);
+  }
+
+  /// Remove Steam from the social profiles on the current user's account.
+  $grpc.ResponseFuture<$1.Empty> unlinkSteam(
+    $0.AccountSteam request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$unlinkSteam, request, options: options);
+  }
+
+  /// Update fields in the current user's account.
+  $grpc.ResponseFuture<$1.Empty> updateAccount(
+    $0.UpdateAccountRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$updateAccount, request, options: options);
+  }
+
+  /// Update fields in a given group.
+  $grpc.ResponseFuture<$1.Empty> updateGroup(
+    $0.UpdateGroupRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$updateGroup, request, options: options);
+  }
+
+  /// Validate Apple IAP Receipt
+  $grpc.ResponseFuture<$0.ValidatePurchaseResponse> validatePurchaseApple(
+    $0.ValidatePurchaseAppleRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$validatePurchaseApple, request, options: options);
+  }
+
+  /// Validate Apple Subscription Receipt
+  $grpc.ResponseFuture<$0.ValidateSubscriptionResponse>
+      validateSubscriptionApple(
+    $0.ValidateSubscriptionAppleRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$validateSubscriptionApple, request,
+        options: options);
+  }
+
+  /// Validate Google IAP Receipt
+  $grpc.ResponseFuture<$0.ValidatePurchaseResponse> validatePurchaseGoogle(
+    $0.ValidatePurchaseGoogleRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$validatePurchaseGoogle, request,
+        options: options);
+  }
+
+  /// Validate Google Subscription Receipt
+  $grpc.ResponseFuture<$0.ValidateSubscriptionResponse>
+      validateSubscriptionGoogle(
+    $0.ValidateSubscriptionGoogleRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$validateSubscriptionGoogle, request,
+        options: options);
+  }
+
+  /// Validate Huawei IAP Receipt
+  $grpc.ResponseFuture<$0.ValidatePurchaseResponse> validatePurchaseHuawei(
+    $0.ValidatePurchaseHuaweiRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$validatePurchaseHuawei, request,
+        options: options);
+  }
+
+  /// Validate FB Instant IAP Receipt
+  $grpc.ResponseFuture<$0.ValidatePurchaseResponse>
+      validatePurchaseFacebookInstant(
+    $0.ValidatePurchaseFacebookInstantRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$validatePurchaseFacebookInstant, request,
+        options: options);
+  }
+
+  /// Write a record to a leaderboard.
+  $grpc.ResponseFuture<$0.LeaderboardRecord> writeLeaderboardRecord(
+    $0.WriteLeaderboardRecordRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$writeLeaderboardRecord, request,
+        options: options);
+  }
+
+  /// Write objects into the storage engine.
+  $grpc.ResponseFuture<$0.StorageObjectAcks> writeStorageObjects(
+    $0.WriteStorageObjectsRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$writeStorageObjects, request, options: options);
+  }
+
+  /// Write a record to a tournament.
+  $grpc.ResponseFuture<$0.LeaderboardRecord> writeTournamentRecord(
+    $0.WriteTournamentRecordRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$writeTournamentRecord, request, options: options);
+  }
+
+  // method descriptors
+
   static final _$addFriends =
       $grpc.ClientMethod<$0.AddFriendsRequest, $1.Empty>(
           '/nakama.api.Nakama/AddFriends',
           ($0.AddFriendsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$addGroupUsers =
       $grpc.ClientMethod<$0.AddGroupUsersRequest, $1.Empty>(
           '/nakama.api.Nakama/AddGroupUsers',
           ($0.AddGroupUsersRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$sessionRefresh =
       $grpc.ClientMethod<$0.SessionRefreshRequest, $0.Session>(
           '/nakama.api.Nakama/SessionRefresh',
           ($0.SessionRefreshRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$sessionLogout =
       $grpc.ClientMethod<$0.SessionLogoutRequest, $1.Empty>(
           '/nakama.api.Nakama/SessionLogout',
           ($0.SessionLogoutRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$authenticateApple =
       $grpc.ClientMethod<$0.AuthenticateAppleRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateApple',
           ($0.AuthenticateAppleRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$authenticateCustom =
       $grpc.ClientMethod<$0.AuthenticateCustomRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateCustom',
           ($0.AuthenticateCustomRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$authenticateDevice =
       $grpc.ClientMethod<$0.AuthenticateDeviceRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateDevice',
           ($0.AuthenticateDeviceRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$authenticateEmail =
       $grpc.ClientMethod<$0.AuthenticateEmailRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateEmail',
           ($0.AuthenticateEmailRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$authenticateFacebook =
       $grpc.ClientMethod<$0.AuthenticateFacebookRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateFacebook',
           ($0.AuthenticateFacebookRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$authenticateFacebookInstantGame =
       $grpc.ClientMethod<$0.AuthenticateFacebookInstantGameRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateFacebookInstantGame',
           ($0.AuthenticateFacebookInstantGameRequest value) =>
               value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$authenticateGameCenter =
       $grpc.ClientMethod<$0.AuthenticateGameCenterRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateGameCenter',
           ($0.AuthenticateGameCenterRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$authenticateGoogle =
       $grpc.ClientMethod<$0.AuthenticateGoogleRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateGoogle',
           ($0.AuthenticateGoogleRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$authenticateSteam =
       $grpc.ClientMethod<$0.AuthenticateSteamRequest, $0.Session>(
           '/nakama.api.Nakama/AuthenticateSteam',
           ($0.AuthenticateSteamRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Session.fromBuffer(value));
+          $0.Session.fromBuffer);
   static final _$banGroupUsers =
       $grpc.ClientMethod<$0.BanGroupUsersRequest, $1.Empty>(
           '/nakama.api.Nakama/BanGroupUsers',
           ($0.BanGroupUsersRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$blockFriends =
       $grpc.ClientMethod<$0.BlockFriendsRequest, $1.Empty>(
           '/nakama.api.Nakama/BlockFriends',
           ($0.BlockFriendsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$createGroup =
       $grpc.ClientMethod<$0.CreateGroupRequest, $0.Group>(
           '/nakama.api.Nakama/CreateGroup',
           ($0.CreateGroupRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Group.fromBuffer(value));
+          $0.Group.fromBuffer);
   static final _$deleteAccount = $grpc.ClientMethod<$1.Empty, $1.Empty>(
       '/nakama.api.Nakama/DeleteAccount',
       ($1.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$deleteFriends =
       $grpc.ClientMethod<$0.DeleteFriendsRequest, $1.Empty>(
           '/nakama.api.Nakama/DeleteFriends',
           ($0.DeleteFriendsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$deleteGroup =
       $grpc.ClientMethod<$0.DeleteGroupRequest, $1.Empty>(
           '/nakama.api.Nakama/DeleteGroup',
           ($0.DeleteGroupRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$deleteLeaderboardRecord =
       $grpc.ClientMethod<$0.DeleteLeaderboardRecordRequest, $1.Empty>(
           '/nakama.api.Nakama/DeleteLeaderboardRecord',
           ($0.DeleteLeaderboardRecordRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$deleteNotifications =
       $grpc.ClientMethod<$0.DeleteNotificationsRequest, $1.Empty>(
           '/nakama.api.Nakama/DeleteNotifications',
           ($0.DeleteNotificationsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$deleteTournamentRecord =
       $grpc.ClientMethod<$0.DeleteTournamentRecordRequest, $1.Empty>(
           '/nakama.api.Nakama/DeleteTournamentRecord',
           ($0.DeleteTournamentRecordRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$deleteStorageObjects =
       $grpc.ClientMethod<$0.DeleteStorageObjectsRequest, $1.Empty>(
           '/nakama.api.Nakama/DeleteStorageObjects',
           ($0.DeleteStorageObjectsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$event = $grpc.ClientMethod<$0.Event, $1.Empty>(
       '/nakama.api.Nakama/Event',
       ($0.Event value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$getAccount = $grpc.ClientMethod<$1.Empty, $0.Account>(
       '/nakama.api.Nakama/GetAccount',
       ($1.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Account.fromBuffer(value));
+      $0.Account.fromBuffer);
   static final _$getUsers = $grpc.ClientMethod<$0.GetUsersRequest, $0.Users>(
       '/nakama.api.Nakama/GetUsers',
       ($0.GetUsersRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Users.fromBuffer(value));
+      $0.Users.fromBuffer);
   static final _$getSubscription =
       $grpc.ClientMethod<$0.GetSubscriptionRequest, $0.ValidatedSubscription>(
           '/nakama.api.Nakama/GetSubscription',
           ($0.GetSubscriptionRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.ValidatedSubscription.fromBuffer(value));
+          $0.ValidatedSubscription.fromBuffer);
+  static final _$getMatchmakerStats =
+      $grpc.ClientMethod<$1.Empty, $0.MatchmakerStats>(
+          '/nakama.api.Nakama/GetMatchmakerStats',
+          ($1.Empty value) => value.writeToBuffer(),
+          $0.MatchmakerStats.fromBuffer);
   static final _$healthcheck = $grpc.ClientMethod<$1.Empty, $1.Empty>(
       '/nakama.api.Nakama/Healthcheck',
       ($1.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$importFacebookFriends =
       $grpc.ClientMethod<$0.ImportFacebookFriendsRequest, $1.Empty>(
           '/nakama.api.Nakama/ImportFacebookFriends',
           ($0.ImportFacebookFriendsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$importSteamFriends =
       $grpc.ClientMethod<$0.ImportSteamFriendsRequest, $1.Empty>(
           '/nakama.api.Nakama/ImportSteamFriends',
           ($0.ImportSteamFriendsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$joinGroup = $grpc.ClientMethod<$0.JoinGroupRequest, $1.Empty>(
       '/nakama.api.Nakama/JoinGroup',
       ($0.JoinGroupRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$joinTournament =
       $grpc.ClientMethod<$0.JoinTournamentRequest, $1.Empty>(
           '/nakama.api.Nakama/JoinTournament',
           ($0.JoinTournamentRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$kickGroupUsers =
       $grpc.ClientMethod<$0.KickGroupUsersRequest, $1.Empty>(
           '/nakama.api.Nakama/KickGroupUsers',
           ($0.KickGroupUsersRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$leaveGroup =
       $grpc.ClientMethod<$0.LeaveGroupRequest, $1.Empty>(
           '/nakama.api.Nakama/LeaveGroup',
           ($0.LeaveGroupRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$linkApple = $grpc.ClientMethod<$0.AccountApple, $1.Empty>(
       '/nakama.api.Nakama/LinkApple',
       ($0.AccountApple value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$linkCustom = $grpc.ClientMethod<$0.AccountCustom, $1.Empty>(
       '/nakama.api.Nakama/LinkCustom',
       ($0.AccountCustom value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$linkDevice = $grpc.ClientMethod<$0.AccountDevice, $1.Empty>(
       '/nakama.api.Nakama/LinkDevice',
       ($0.AccountDevice value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$linkEmail = $grpc.ClientMethod<$0.AccountEmail, $1.Empty>(
       '/nakama.api.Nakama/LinkEmail',
       ($0.AccountEmail value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$linkFacebook =
       $grpc.ClientMethod<$0.LinkFacebookRequest, $1.Empty>(
           '/nakama.api.Nakama/LinkFacebook',
           ($0.LinkFacebookRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$linkFacebookInstantGame =
       $grpc.ClientMethod<$0.AccountFacebookInstantGame, $1.Empty>(
           '/nakama.api.Nakama/LinkFacebookInstantGame',
           ($0.AccountFacebookInstantGame value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$linkGameCenter =
       $grpc.ClientMethod<$0.AccountGameCenter, $1.Empty>(
           '/nakama.api.Nakama/LinkGameCenter',
           ($0.AccountGameCenter value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$linkGoogle = $grpc.ClientMethod<$0.AccountGoogle, $1.Empty>(
       '/nakama.api.Nakama/LinkGoogle',
       ($0.AccountGoogle value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$linkSteam = $grpc.ClientMethod<$0.LinkSteamRequest, $1.Empty>(
       '/nakama.api.Nakama/LinkSteam',
       ($0.LinkSteamRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$listChannelMessages =
       $grpc.ClientMethod<$0.ListChannelMessagesRequest, $0.ChannelMessageList>(
           '/nakama.api.Nakama/ListChannelMessages',
           ($0.ListChannelMessagesRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.ChannelMessageList.fromBuffer(value));
+          $0.ChannelMessageList.fromBuffer);
   static final _$listFriends =
       $grpc.ClientMethod<$0.ListFriendsRequest, $0.FriendList>(
           '/nakama.api.Nakama/ListFriends',
           ($0.ListFriendsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.FriendList.fromBuffer(value));
+          $0.FriendList.fromBuffer);
+  static final _$listFriendsOfFriends = $grpc.ClientMethod<
+          $0.ListFriendsOfFriendsRequest, $0.FriendsOfFriendsList>(
+      '/nakama.api.Nakama/ListFriendsOfFriends',
+      ($0.ListFriendsOfFriendsRequest value) => value.writeToBuffer(),
+      $0.FriendsOfFriendsList.fromBuffer);
   static final _$listGroups =
       $grpc.ClientMethod<$0.ListGroupsRequest, $0.GroupList>(
           '/nakama.api.Nakama/ListGroups',
           ($0.ListGroupsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.GroupList.fromBuffer(value));
+          $0.GroupList.fromBuffer);
   static final _$listGroupUsers =
       $grpc.ClientMethod<$0.ListGroupUsersRequest, $0.GroupUserList>(
           '/nakama.api.Nakama/ListGroupUsers',
           ($0.ListGroupUsersRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.GroupUserList.fromBuffer(value));
+          $0.GroupUserList.fromBuffer);
   static final _$listLeaderboardRecords = $grpc.ClientMethod<
           $0.ListLeaderboardRecordsRequest, $0.LeaderboardRecordList>(
       '/nakama.api.Nakama/ListLeaderboardRecords',
       ($0.ListLeaderboardRecordsRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.LeaderboardRecordList.fromBuffer(value));
+      $0.LeaderboardRecordList.fromBuffer);
   static final _$listLeaderboardRecordsAroundOwner = $grpc.ClientMethod<
           $0.ListLeaderboardRecordsAroundOwnerRequest,
           $0.LeaderboardRecordList>(
       '/nakama.api.Nakama/ListLeaderboardRecordsAroundOwner',
       ($0.ListLeaderboardRecordsAroundOwnerRequest value) =>
           value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.LeaderboardRecordList.fromBuffer(value));
+      $0.LeaderboardRecordList.fromBuffer);
   static final _$listMatches =
       $grpc.ClientMethod<$0.ListMatchesRequest, $0.MatchList>(
           '/nakama.api.Nakama/ListMatches',
           ($0.ListMatchesRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.MatchList.fromBuffer(value));
+          $0.MatchList.fromBuffer);
+  static final _$listParties =
+      $grpc.ClientMethod<$0.ListPartiesRequest, $0.PartyList>(
+          '/nakama.api.Nakama/ListParties',
+          ($0.ListPartiesRequest value) => value.writeToBuffer(),
+          $0.PartyList.fromBuffer);
   static final _$listNotifications =
       $grpc.ClientMethod<$0.ListNotificationsRequest, $0.NotificationList>(
           '/nakama.api.Nakama/ListNotifications',
           ($0.ListNotificationsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.NotificationList.fromBuffer(value));
+          $0.NotificationList.fromBuffer);
   static final _$listStorageObjects =
       $grpc.ClientMethod<$0.ListStorageObjectsRequest, $0.StorageObjectList>(
           '/nakama.api.Nakama/ListStorageObjects',
           ($0.ListStorageObjectsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.StorageObjectList.fromBuffer(value));
+          $0.StorageObjectList.fromBuffer);
   static final _$listSubscriptions =
       $grpc.ClientMethod<$0.ListSubscriptionsRequest, $0.SubscriptionList>(
           '/nakama.api.Nakama/ListSubscriptions',
           ($0.ListSubscriptionsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.SubscriptionList.fromBuffer(value));
+          $0.SubscriptionList.fromBuffer);
   static final _$listTournaments =
       $grpc.ClientMethod<$0.ListTournamentsRequest, $0.TournamentList>(
           '/nakama.api.Nakama/ListTournaments',
           ($0.ListTournamentsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.TournamentList.fromBuffer(value));
+          $0.TournamentList.fromBuffer);
   static final _$listTournamentRecords = $grpc.ClientMethod<
           $0.ListTournamentRecordsRequest, $0.TournamentRecordList>(
       '/nakama.api.Nakama/ListTournamentRecords',
       ($0.ListTournamentRecordsRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.TournamentRecordList.fromBuffer(value));
+      $0.TournamentRecordList.fromBuffer);
   static final _$listTournamentRecordsAroundOwner = $grpc.ClientMethod<
           $0.ListTournamentRecordsAroundOwnerRequest, $0.TournamentRecordList>(
       '/nakama.api.Nakama/ListTournamentRecordsAroundOwner',
       ($0.ListTournamentRecordsAroundOwnerRequest value) =>
           value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.TournamentRecordList.fromBuffer(value));
+      $0.TournamentRecordList.fromBuffer);
   static final _$listUserGroups =
       $grpc.ClientMethod<$0.ListUserGroupsRequest, $0.UserGroupList>(
           '/nakama.api.Nakama/ListUserGroups',
           ($0.ListUserGroupsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.UserGroupList.fromBuffer(value));
+          $0.UserGroupList.fromBuffer);
   static final _$promoteGroupUsers =
       $grpc.ClientMethod<$0.PromoteGroupUsersRequest, $1.Empty>(
           '/nakama.api.Nakama/PromoteGroupUsers',
           ($0.PromoteGroupUsersRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$demoteGroupUsers =
       $grpc.ClientMethod<$0.DemoteGroupUsersRequest, $1.Empty>(
           '/nakama.api.Nakama/DemoteGroupUsers',
           ($0.DemoteGroupUsersRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$readStorageObjects =
       $grpc.ClientMethod<$0.ReadStorageObjectsRequest, $0.StorageObjects>(
           '/nakama.api.Nakama/ReadStorageObjects',
           ($0.ReadStorageObjectsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.StorageObjects.fromBuffer(value));
+          $0.StorageObjects.fromBuffer);
   static final _$rpcFunc = $grpc.ClientMethod<$0.Rpc, $0.Rpc>(
       '/nakama.api.Nakama/RpcFunc',
       ($0.Rpc value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Rpc.fromBuffer(value));
+      $0.Rpc.fromBuffer);
   static final _$unlinkApple = $grpc.ClientMethod<$0.AccountApple, $1.Empty>(
       '/nakama.api.Nakama/UnlinkApple',
       ($0.AccountApple value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$unlinkCustom = $grpc.ClientMethod<$0.AccountCustom, $1.Empty>(
       '/nakama.api.Nakama/UnlinkCustom',
       ($0.AccountCustom value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$unlinkDevice = $grpc.ClientMethod<$0.AccountDevice, $1.Empty>(
       '/nakama.api.Nakama/UnlinkDevice',
       ($0.AccountDevice value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$unlinkEmail = $grpc.ClientMethod<$0.AccountEmail, $1.Empty>(
       '/nakama.api.Nakama/UnlinkEmail',
       ($0.AccountEmail value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$unlinkFacebook =
       $grpc.ClientMethod<$0.AccountFacebook, $1.Empty>(
           '/nakama.api.Nakama/UnlinkFacebook',
           ($0.AccountFacebook value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$unlinkFacebookInstantGame =
       $grpc.ClientMethod<$0.AccountFacebookInstantGame, $1.Empty>(
           '/nakama.api.Nakama/UnlinkFacebookInstantGame',
           ($0.AccountFacebookInstantGame value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$unlinkGameCenter =
       $grpc.ClientMethod<$0.AccountGameCenter, $1.Empty>(
           '/nakama.api.Nakama/UnlinkGameCenter',
           ($0.AccountGameCenter value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$unlinkGoogle = $grpc.ClientMethod<$0.AccountGoogle, $1.Empty>(
       '/nakama.api.Nakama/UnlinkGoogle',
       ($0.AccountGoogle value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$unlinkSteam = $grpc.ClientMethod<$0.AccountSteam, $1.Empty>(
       '/nakama.api.Nakama/UnlinkSteam',
       ($0.AccountSteam value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+      $1.Empty.fromBuffer);
   static final _$updateAccount =
       $grpc.ClientMethod<$0.UpdateAccountRequest, $1.Empty>(
           '/nakama.api.Nakama/UpdateAccount',
           ($0.UpdateAccountRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$updateGroup =
       $grpc.ClientMethod<$0.UpdateGroupRequest, $1.Empty>(
           '/nakama.api.Nakama/UpdateGroup',
           ($0.UpdateGroupRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $1.Empty.fromBuffer(value));
+          $1.Empty.fromBuffer);
   static final _$validatePurchaseApple = $grpc.ClientMethod<
           $0.ValidatePurchaseAppleRequest, $0.ValidatePurchaseResponse>(
       '/nakama.api.Nakama/ValidatePurchaseApple',
       ($0.ValidatePurchaseAppleRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.ValidatePurchaseResponse.fromBuffer(value));
+      $0.ValidatePurchaseResponse.fromBuffer);
   static final _$validateSubscriptionApple = $grpc.ClientMethod<
           $0.ValidateSubscriptionAppleRequest, $0.ValidateSubscriptionResponse>(
       '/nakama.api.Nakama/ValidateSubscriptionApple',
       ($0.ValidateSubscriptionAppleRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.ValidateSubscriptionResponse.fromBuffer(value));
+      $0.ValidateSubscriptionResponse.fromBuffer);
   static final _$validatePurchaseGoogle = $grpc.ClientMethod<
           $0.ValidatePurchaseGoogleRequest, $0.ValidatePurchaseResponse>(
       '/nakama.api.Nakama/ValidatePurchaseGoogle',
       ($0.ValidatePurchaseGoogleRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.ValidatePurchaseResponse.fromBuffer(value));
+      $0.ValidatePurchaseResponse.fromBuffer);
   static final _$validateSubscriptionGoogle = $grpc.ClientMethod<
           $0.ValidateSubscriptionGoogleRequest,
           $0.ValidateSubscriptionResponse>(
       '/nakama.api.Nakama/ValidateSubscriptionGoogle',
       ($0.ValidateSubscriptionGoogleRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.ValidateSubscriptionResponse.fromBuffer(value));
+      $0.ValidateSubscriptionResponse.fromBuffer);
   static final _$validatePurchaseHuawei = $grpc.ClientMethod<
           $0.ValidatePurchaseHuaweiRequest, $0.ValidatePurchaseResponse>(
       '/nakama.api.Nakama/ValidatePurchaseHuawei',
       ($0.ValidatePurchaseHuaweiRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.ValidatePurchaseResponse.fromBuffer(value));
+      $0.ValidatePurchaseResponse.fromBuffer);
+  static final _$validatePurchaseFacebookInstant = $grpc.ClientMethod<
+          $0.ValidatePurchaseFacebookInstantRequest,
+          $0.ValidatePurchaseResponse>(
+      '/nakama.api.Nakama/ValidatePurchaseFacebookInstant',
+      ($0.ValidatePurchaseFacebookInstantRequest value) =>
+          value.writeToBuffer(),
+      $0.ValidatePurchaseResponse.fromBuffer);
   static final _$writeLeaderboardRecord = $grpc.ClientMethod<
           $0.WriteLeaderboardRecordRequest, $0.LeaderboardRecord>(
       '/nakama.api.Nakama/WriteLeaderboardRecord',
       ($0.WriteLeaderboardRecordRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.LeaderboardRecord.fromBuffer(value));
+      $0.LeaderboardRecord.fromBuffer);
   static final _$writeStorageObjects =
       $grpc.ClientMethod<$0.WriteStorageObjectsRequest, $0.StorageObjectAcks>(
           '/nakama.api.Nakama/WriteStorageObjects',
           ($0.WriteStorageObjectsRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.StorageObjectAcks.fromBuffer(value));
+          $0.StorageObjectAcks.fromBuffer);
   static final _$writeTournamentRecord =
       $grpc.ClientMethod<$0.WriteTournamentRecordRequest, $0.LeaderboardRecord>(
           '/nakama.api.Nakama/WriteTournamentRecord',
           ($0.WriteTournamentRecordRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.LeaderboardRecord.fromBuffer(value));
-
-  NakamaClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
-      : super(channel, options: options, interceptors: interceptors);
-
-  $grpc.ResponseFuture<$1.Empty> addFriends($0.AddFriendsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$addFriends, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> addGroupUsers($0.AddGroupUsersRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$addGroupUsers, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> sessionRefresh(
-      $0.SessionRefreshRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$sessionRefresh, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> sessionLogout($0.SessionLogoutRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$sessionLogout, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateApple(
-      $0.AuthenticateAppleRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateApple, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateCustom(
-      $0.AuthenticateCustomRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateCustom, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateDevice(
-      $0.AuthenticateDeviceRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateDevice, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateEmail(
-      $0.AuthenticateEmailRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateEmail, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateFacebook(
-      $0.AuthenticateFacebookRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateFacebook, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateFacebookInstantGame(
-      $0.AuthenticateFacebookInstantGameRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateFacebookInstantGame, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateGameCenter(
-      $0.AuthenticateGameCenterRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateGameCenter, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateGoogle(
-      $0.AuthenticateGoogleRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateGoogle, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Session> authenticateSteam(
-      $0.AuthenticateSteamRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$authenticateSteam, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> banGroupUsers($0.BanGroupUsersRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$banGroupUsers, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> blockFriends($0.BlockFriendsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$blockFriends, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Group> createGroup($0.CreateGroupRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$createGroup, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> deleteAccount($1.Empty request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$deleteAccount, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> deleteFriends($0.DeleteFriendsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$deleteFriends, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> deleteGroup($0.DeleteGroupRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$deleteGroup, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> deleteLeaderboardRecord(
-      $0.DeleteLeaderboardRecordRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$deleteLeaderboardRecord, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> deleteNotifications(
-      $0.DeleteNotificationsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$deleteNotifications, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> deleteTournamentRecord(
-      $0.DeleteTournamentRecordRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$deleteTournamentRecord, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> deleteStorageObjects(
-      $0.DeleteStorageObjectsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$deleteStorageObjects, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> event($0.Event request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$event, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Account> getAccount($1.Empty request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$getAccount, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Users> getUsers($0.GetUsersRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$getUsers, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.ValidatedSubscription> getSubscription(
-      $0.GetSubscriptionRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$getSubscription, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> healthcheck($1.Empty request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$healthcheck, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> importFacebookFriends(
-      $0.ImportFacebookFriendsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$importFacebookFriends, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> importSteamFriends(
-      $0.ImportSteamFriendsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$importSteamFriends, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> joinGroup($0.JoinGroupRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$joinGroup, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> joinTournament(
-      $0.JoinTournamentRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$joinTournament, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> kickGroupUsers(
-      $0.KickGroupUsersRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$kickGroupUsers, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> leaveGroup($0.LeaveGroupRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$leaveGroup, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkApple($0.AccountApple request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkApple, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkCustom($0.AccountCustom request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkCustom, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkDevice($0.AccountDevice request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkDevice, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkEmail($0.AccountEmail request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkEmail, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkFacebook($0.LinkFacebookRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkFacebook, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkFacebookInstantGame(
-      $0.AccountFacebookInstantGame request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkFacebookInstantGame, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkGameCenter($0.AccountGameCenter request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkGameCenter, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkGoogle($0.AccountGoogle request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkGoogle, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> linkSteam($0.LinkSteamRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$linkSteam, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.ChannelMessageList> listChannelMessages(
-      $0.ListChannelMessagesRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listChannelMessages, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.FriendList> listFriends($0.ListFriendsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listFriends, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.GroupList> listGroups($0.ListGroupsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listGroups, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.GroupUserList> listGroupUsers(
-      $0.ListGroupUsersRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listGroupUsers, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.LeaderboardRecordList> listLeaderboardRecords(
-      $0.ListLeaderboardRecordsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listLeaderboardRecords, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.LeaderboardRecordList>
-      listLeaderboardRecordsAroundOwner(
-          $0.ListLeaderboardRecordsAroundOwnerRequest request,
-          {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listLeaderboardRecordsAroundOwner, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.MatchList> listMatches($0.ListMatchesRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listMatches, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.NotificationList> listNotifications(
-      $0.ListNotificationsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listNotifications, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.StorageObjectList> listStorageObjects(
-      $0.ListStorageObjectsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listStorageObjects, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.SubscriptionList> listSubscriptions(
-      $0.ListSubscriptionsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listSubscriptions, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.TournamentList> listTournaments(
-      $0.ListTournamentsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listTournaments, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.TournamentRecordList> listTournamentRecords(
-      $0.ListTournamentRecordsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listTournamentRecords, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.TournamentRecordList>
-      listTournamentRecordsAroundOwner(
-          $0.ListTournamentRecordsAroundOwnerRequest request,
-          {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listTournamentRecordsAroundOwner, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.UserGroupList> listUserGroups(
-      $0.ListUserGroupsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$listUserGroups, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> promoteGroupUsers(
-      $0.PromoteGroupUsersRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$promoteGroupUsers, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> demoteGroupUsers(
-      $0.DemoteGroupUsersRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$demoteGroupUsers, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.StorageObjects> readStorageObjects(
-      $0.ReadStorageObjectsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$readStorageObjects, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Rpc> rpcFunc($0.Rpc request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$rpcFunc, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkApple($0.AccountApple request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkApple, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkCustom($0.AccountCustom request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkCustom, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkDevice($0.AccountDevice request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkDevice, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkEmail($0.AccountEmail request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkEmail, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkFacebook($0.AccountFacebook request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkFacebook, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkFacebookInstantGame(
-      $0.AccountFacebookInstantGame request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkFacebookInstantGame, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkGameCenter($0.AccountGameCenter request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkGameCenter, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkGoogle($0.AccountGoogle request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkGoogle, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> unlinkSteam($0.AccountSteam request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$unlinkSteam, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> updateAccount($0.UpdateAccountRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$updateAccount, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$1.Empty> updateGroup($0.UpdateGroupRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$updateGroup, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.ValidatePurchaseResponse> validatePurchaseApple(
-      $0.ValidatePurchaseAppleRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$validatePurchaseApple, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.ValidateSubscriptionResponse>
-      validateSubscriptionApple($0.ValidateSubscriptionAppleRequest request,
-          {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$validateSubscriptionApple, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.ValidatePurchaseResponse> validatePurchaseGoogle(
-      $0.ValidatePurchaseGoogleRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$validatePurchaseGoogle, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.ValidateSubscriptionResponse>
-      validateSubscriptionGoogle($0.ValidateSubscriptionGoogleRequest request,
-          {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$validateSubscriptionGoogle, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.ValidatePurchaseResponse> validatePurchaseHuawei(
-      $0.ValidatePurchaseHuaweiRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$validatePurchaseHuawei, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.LeaderboardRecord> writeLeaderboardRecord(
-      $0.WriteLeaderboardRecordRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$writeLeaderboardRecord, request,
-        options: options);
-  }
-
-  $grpc.ResponseFuture<$0.StorageObjectAcks> writeStorageObjects(
-      $0.WriteStorageObjectsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$writeStorageObjects, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.LeaderboardRecord> writeTournamentRecord(
-      $0.WriteTournamentRecordRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$writeTournamentRecord, request, options: options);
-  }
+          $0.LeaderboardRecord.fromBuffer);
 }
 
+@$pb.GrpcServiceName('nakama.api.Nakama')
 abstract class NakamaServiceBase extends $grpc.Service {
   $core.String get $name => 'nakama.api.Nakama';
 
@@ -1101,6 +1358,13 @@ abstract class NakamaServiceBase extends $grpc.Service {
         ($core.List<$core.int> value) =>
             $0.GetSubscriptionRequest.fromBuffer(value),
         ($0.ValidatedSubscription value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$1.Empty, $0.MatchmakerStats>(
+        'GetMatchmakerStats',
+        getMatchmakerStats_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $1.Empty.fromBuffer(value),
+        ($0.MatchmakerStats value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$1.Empty, $1.Empty>(
         'Healthcheck',
         healthcheck_Pre,
@@ -1236,6 +1500,15 @@ abstract class NakamaServiceBase extends $grpc.Service {
         ($core.List<$core.int> value) =>
             $0.ListFriendsRequest.fromBuffer(value),
         ($0.FriendList value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ListFriendsOfFriendsRequest,
+            $0.FriendsOfFriendsList>(
+        'ListFriendsOfFriends',
+        listFriendsOfFriends_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) =>
+            $0.ListFriendsOfFriendsRequest.fromBuffer(value),
+        ($0.FriendsOfFriendsList value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.ListGroupsRequest, $0.GroupList>(
         'ListGroups',
         listGroups_Pre,
@@ -1277,6 +1550,14 @@ abstract class NakamaServiceBase extends $grpc.Service {
         ($core.List<$core.int> value) =>
             $0.ListMatchesRequest.fromBuffer(value),
         ($0.MatchList value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ListPartiesRequest, $0.PartyList>(
+        'ListParties',
+        listParties_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) =>
+            $0.ListPartiesRequest.fromBuffer(value),
+        ($0.PartyList value) => value.writeToBuffer()));
     $addMethod(
         $grpc.ServiceMethod<$0.ListNotificationsRequest, $0.NotificationList>(
             'ListNotifications',
@@ -1496,6 +1777,15 @@ abstract class NakamaServiceBase extends $grpc.Service {
         ($core.List<$core.int> value) =>
             $0.ValidatePurchaseHuaweiRequest.fromBuffer(value),
         ($0.ValidatePurchaseResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ValidatePurchaseFacebookInstantRequest,
+            $0.ValidatePurchaseResponse>(
+        'ValidatePurchaseFacebookInstant',
+        validatePurchaseFacebookInstant_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) =>
+            $0.ValidatePurchaseFacebookInstantRequest.fromBuffer(value),
+        ($0.ValidatePurchaseResponse value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.WriteLeaderboardRecordRequest,
             $0.LeaderboardRecord>(
         'WriteLeaderboardRecord',
@@ -1525,584 +1815,701 @@ abstract class NakamaServiceBase extends $grpc.Service {
         ($0.LeaderboardRecord value) => value.writeToBuffer()));
   }
 
-  $async.Future<$1.Empty> addFriends_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AddFriendsRequest> request) async {
-    return addFriends(call, await request);
-  }
-
-  $async.Future<$1.Empty> addGroupUsers_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AddGroupUsersRequest> request) async {
-    return addGroupUsers(call, await request);
-  }
-
-  $async.Future<$0.Session> sessionRefresh_Pre($grpc.ServiceCall call,
-      $async.Future<$0.SessionRefreshRequest> request) async {
-    return sessionRefresh(call, await request);
-  }
-
-  $async.Future<$1.Empty> sessionLogout_Pre($grpc.ServiceCall call,
-      $async.Future<$0.SessionLogoutRequest> request) async {
-    return sessionLogout(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateApple_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateAppleRequest> request) async {
-    return authenticateApple(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateCustom_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateCustomRequest> request) async {
-    return authenticateCustom(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateDevice_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateDeviceRequest> request) async {
-    return authenticateDevice(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateEmail_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateEmailRequest> request) async {
-    return authenticateEmail(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateFacebook_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateFacebookRequest> request) async {
-    return authenticateFacebook(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateFacebookInstantGame_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateFacebookInstantGameRequest> request) async {
-    return authenticateFacebookInstantGame(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateGameCenter_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateGameCenterRequest> request) async {
-    return authenticateGameCenter(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateGoogle_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateGoogleRequest> request) async {
-    return authenticateGoogle(call, await request);
-  }
-
-  $async.Future<$0.Session> authenticateSteam_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AuthenticateSteamRequest> request) async {
-    return authenticateSteam(call, await request);
-  }
-
-  $async.Future<$1.Empty> banGroupUsers_Pre($grpc.ServiceCall call,
-      $async.Future<$0.BanGroupUsersRequest> request) async {
-    return banGroupUsers(call, await request);
-  }
-
-  $async.Future<$1.Empty> blockFriends_Pre($grpc.ServiceCall call,
-      $async.Future<$0.BlockFriendsRequest> request) async {
-    return blockFriends(call, await request);
-  }
-
-  $async.Future<$0.Group> createGroup_Pre($grpc.ServiceCall call,
-      $async.Future<$0.CreateGroupRequest> request) async {
-    return createGroup(call, await request);
-  }
-
-  $async.Future<$1.Empty> deleteAccount_Pre(
-      $grpc.ServiceCall call, $async.Future<$1.Empty> request) async {
-    return deleteAccount(call, await request);
-  }
-
-  $async.Future<$1.Empty> deleteFriends_Pre($grpc.ServiceCall call,
-      $async.Future<$0.DeleteFriendsRequest> request) async {
-    return deleteFriends(call, await request);
-  }
-
-  $async.Future<$1.Empty> deleteGroup_Pre($grpc.ServiceCall call,
-      $async.Future<$0.DeleteGroupRequest> request) async {
-    return deleteGroup(call, await request);
-  }
-
-  $async.Future<$1.Empty> deleteLeaderboardRecord_Pre($grpc.ServiceCall call,
-      $async.Future<$0.DeleteLeaderboardRecordRequest> request) async {
-    return deleteLeaderboardRecord(call, await request);
-  }
-
-  $async.Future<$1.Empty> deleteNotifications_Pre($grpc.ServiceCall call,
-      $async.Future<$0.DeleteNotificationsRequest> request) async {
-    return deleteNotifications(call, await request);
-  }
-
-  $async.Future<$1.Empty> deleteTournamentRecord_Pre($grpc.ServiceCall call,
-      $async.Future<$0.DeleteTournamentRecordRequest> request) async {
-    return deleteTournamentRecord(call, await request);
-  }
-
-  $async.Future<$1.Empty> deleteStorageObjects_Pre($grpc.ServiceCall call,
-      $async.Future<$0.DeleteStorageObjectsRequest> request) async {
-    return deleteStorageObjects(call, await request);
-  }
-
-  $async.Future<$1.Empty> event_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.Event> request) async {
-    return event(call, await request);
-  }
-
-  $async.Future<$0.Account> getAccount_Pre(
-      $grpc.ServiceCall call, $async.Future<$1.Empty> request) async {
-    return getAccount(call, await request);
-  }
-
-  $async.Future<$0.Users> getUsers_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.GetUsersRequest> request) async {
-    return getUsers(call, await request);
-  }
-
-  $async.Future<$0.ValidatedSubscription> getSubscription_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.GetSubscriptionRequest> request) async {
-    return getSubscription(call, await request);
-  }
-
-  $async.Future<$1.Empty> healthcheck_Pre(
-      $grpc.ServiceCall call, $async.Future<$1.Empty> request) async {
-    return healthcheck(call, await request);
-  }
-
-  $async.Future<$1.Empty> importFacebookFriends_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ImportFacebookFriendsRequest> request) async {
-    return importFacebookFriends(call, await request);
-  }
-
-  $async.Future<$1.Empty> importSteamFriends_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ImportSteamFriendsRequest> request) async {
-    return importSteamFriends(call, await request);
-  }
-
-  $async.Future<$1.Empty> joinGroup_Pre($grpc.ServiceCall call,
-      $async.Future<$0.JoinGroupRequest> request) async {
-    return joinGroup(call, await request);
-  }
-
-  $async.Future<$1.Empty> joinTournament_Pre($grpc.ServiceCall call,
-      $async.Future<$0.JoinTournamentRequest> request) async {
-    return joinTournament(call, await request);
-  }
-
-  $async.Future<$1.Empty> kickGroupUsers_Pre($grpc.ServiceCall call,
-      $async.Future<$0.KickGroupUsersRequest> request) async {
-    return kickGroupUsers(call, await request);
-  }
-
-  $async.Future<$1.Empty> leaveGroup_Pre($grpc.ServiceCall call,
-      $async.Future<$0.LeaveGroupRequest> request) async {
-    return leaveGroup(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkApple_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountApple> request) async {
-    return linkApple(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkCustom_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountCustom> request) async {
-    return linkCustom(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkDevice_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountDevice> request) async {
-    return linkDevice(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkEmail_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountEmail> request) async {
-    return linkEmail(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkFacebook_Pre($grpc.ServiceCall call,
-      $async.Future<$0.LinkFacebookRequest> request) async {
-    return linkFacebook(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkFacebookInstantGame_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AccountFacebookInstantGame> request) async {
-    return linkFacebookInstantGame(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkGameCenter_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AccountGameCenter> request) async {
-    return linkGameCenter(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkGoogle_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountGoogle> request) async {
-    return linkGoogle(call, await request);
-  }
-
-  $async.Future<$1.Empty> linkSteam_Pre($grpc.ServiceCall call,
-      $async.Future<$0.LinkSteamRequest> request) async {
-    return linkSteam(call, await request);
-  }
-
-  $async.Future<$0.ChannelMessageList> listChannelMessages_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ListChannelMessagesRequest> request) async {
-    return listChannelMessages(call, await request);
-  }
-
-  $async.Future<$0.FriendList> listFriends_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ListFriendsRequest> request) async {
-    return listFriends(call, await request);
-  }
-
-  $async.Future<$0.GroupList> listGroups_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ListGroupsRequest> request) async {
-    return listGroups(call, await request);
-  }
-
-  $async.Future<$0.GroupUserList> listGroupUsers_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ListGroupUsersRequest> request) async {
-    return listGroupUsers(call, await request);
-  }
-
-  $async.Future<$0.LeaderboardRecordList> listLeaderboardRecords_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ListLeaderboardRecordsRequest> request) async {
-    return listLeaderboardRecords(call, await request);
-  }
-
-  $async.Future<$0.LeaderboardRecordList> listLeaderboardRecordsAroundOwner_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ListLeaderboardRecordsAroundOwnerRequest>
-          request) async {
-    return listLeaderboardRecordsAroundOwner(call, await request);
-  }
-
-  $async.Future<$0.MatchList> listMatches_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ListMatchesRequest> request) async {
-    return listMatches(call, await request);
-  }
-
-  $async.Future<$0.NotificationList> listNotifications_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ListNotificationsRequest> request) async {
-    return listNotifications(call, await request);
-  }
-
-  $async.Future<$0.StorageObjectList> listStorageObjects_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ListStorageObjectsRequest> request) async {
-    return listStorageObjects(call, await request);
-  }
-
-  $async.Future<$0.SubscriptionList> listSubscriptions_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ListSubscriptionsRequest> request) async {
-    return listSubscriptions(call, await request);
-  }
-
-  $async.Future<$0.TournamentList> listTournaments_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ListTournamentsRequest> request) async {
-    return listTournaments(call, await request);
-  }
-
-  $async.Future<$0.TournamentRecordList> listTournamentRecords_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ListTournamentRecordsRequest> request) async {
-    return listTournamentRecords(call, await request);
-  }
-
-  $async.Future<$0.TournamentRecordList> listTournamentRecordsAroundOwner_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ListTournamentRecordsAroundOwnerRequest> request) async {
-    return listTournamentRecordsAroundOwner(call, await request);
-  }
-
-  $async.Future<$0.UserGroupList> listUserGroups_Pre($grpc.ServiceCall call,
-      $async.Future<$0.ListUserGroupsRequest> request) async {
-    return listUserGroups(call, await request);
-  }
-
-  $async.Future<$1.Empty> promoteGroupUsers_Pre($grpc.ServiceCall call,
-      $async.Future<$0.PromoteGroupUsersRequest> request) async {
-    return promoteGroupUsers(call, await request);
-  }
-
-  $async.Future<$1.Empty> demoteGroupUsers_Pre($grpc.ServiceCall call,
-      $async.Future<$0.DemoteGroupUsersRequest> request) async {
-    return demoteGroupUsers(call, await request);
-  }
-
-  $async.Future<$0.StorageObjects> readStorageObjects_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ReadStorageObjectsRequest> request) async {
-    return readStorageObjects(call, await request);
-  }
-
-  $async.Future<$0.Rpc> rpcFunc_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.Rpc> request) async {
-    return rpcFunc(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkApple_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountApple> request) async {
-    return unlinkApple(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkCustom_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountCustom> request) async {
-    return unlinkCustom(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkDevice_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountDevice> request) async {
-    return unlinkDevice(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkEmail_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountEmail> request) async {
-    return unlinkEmail(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkFacebook_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountFacebook> request) async {
-    return unlinkFacebook(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkFacebookInstantGame_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AccountFacebookInstantGame> request) async {
-    return unlinkFacebookInstantGame(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkGameCenter_Pre($grpc.ServiceCall call,
-      $async.Future<$0.AccountGameCenter> request) async {
-    return unlinkGameCenter(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkGoogle_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountGoogle> request) async {
-    return unlinkGoogle(call, await request);
-  }
-
-  $async.Future<$1.Empty> unlinkSteam_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.AccountSteam> request) async {
-    return unlinkSteam(call, await request);
-  }
-
-  $async.Future<$1.Empty> updateAccount_Pre($grpc.ServiceCall call,
-      $async.Future<$0.UpdateAccountRequest> request) async {
-    return updateAccount(call, await request);
-  }
-
-  $async.Future<$1.Empty> updateGroup_Pre($grpc.ServiceCall call,
-      $async.Future<$0.UpdateGroupRequest> request) async {
-    return updateGroup(call, await request);
-  }
-
-  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseApple_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ValidatePurchaseAppleRequest> request) async {
-    return validatePurchaseApple(call, await request);
-  }
-
-  $async.Future<$0.ValidateSubscriptionResponse> validateSubscriptionApple_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ValidateSubscriptionAppleRequest> request) async {
-    return validateSubscriptionApple(call, await request);
-  }
-
-  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseGoogle_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ValidatePurchaseGoogleRequest> request) async {
-    return validatePurchaseGoogle(call, await request);
-  }
-
-  $async.Future<$0.ValidateSubscriptionResponse> validateSubscriptionGoogle_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ValidateSubscriptionGoogleRequest> request) async {
-    return validateSubscriptionGoogle(call, await request);
-  }
-
-  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseHuawei_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ValidatePurchaseHuaweiRequest> request) async {
-    return validatePurchaseHuawei(call, await request);
-  }
-
-  $async.Future<$0.LeaderboardRecord> writeLeaderboardRecord_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.WriteLeaderboardRecordRequest> request) async {
-    return writeLeaderboardRecord(call, await request);
-  }
-
-  $async.Future<$0.StorageObjectAcks> writeStorageObjects_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.WriteStorageObjectsRequest> request) async {
-    return writeStorageObjects(call, await request);
-  }
-
-  $async.Future<$0.LeaderboardRecord> writeTournamentRecord_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.WriteTournamentRecordRequest> request) async {
-    return writeTournamentRecord(call, await request);
+  $async.Future<$1.Empty> addFriends_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AddFriendsRequest> $request) async {
+    return addFriends($call, await $request);
   }
 
   $async.Future<$1.Empty> addFriends(
       $grpc.ServiceCall call, $0.AddFriendsRequest request);
+
+  $async.Future<$1.Empty> addGroupUsers_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AddGroupUsersRequest> $request) async {
+    return addGroupUsers($call, await $request);
+  }
+
   $async.Future<$1.Empty> addGroupUsers(
       $grpc.ServiceCall call, $0.AddGroupUsersRequest request);
+
+  $async.Future<$0.Session> sessionRefresh_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.SessionRefreshRequest> $request) async {
+    return sessionRefresh($call, await $request);
+  }
+
   $async.Future<$0.Session> sessionRefresh(
       $grpc.ServiceCall call, $0.SessionRefreshRequest request);
+
+  $async.Future<$1.Empty> sessionLogout_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.SessionLogoutRequest> $request) async {
+    return sessionLogout($call, await $request);
+  }
+
   $async.Future<$1.Empty> sessionLogout(
       $grpc.ServiceCall call, $0.SessionLogoutRequest request);
+
+  $async.Future<$0.Session> authenticateApple_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateAppleRequest> $request) async {
+    return authenticateApple($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateApple(
       $grpc.ServiceCall call, $0.AuthenticateAppleRequest request);
+
+  $async.Future<$0.Session> authenticateCustom_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateCustomRequest> $request) async {
+    return authenticateCustom($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateCustom(
       $grpc.ServiceCall call, $0.AuthenticateCustomRequest request);
+
+  $async.Future<$0.Session> authenticateDevice_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateDeviceRequest> $request) async {
+    return authenticateDevice($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateDevice(
       $grpc.ServiceCall call, $0.AuthenticateDeviceRequest request);
+
+  $async.Future<$0.Session> authenticateEmail_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateEmailRequest> $request) async {
+    return authenticateEmail($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateEmail(
       $grpc.ServiceCall call, $0.AuthenticateEmailRequest request);
+
+  $async.Future<$0.Session> authenticateFacebook_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateFacebookRequest> $request) async {
+    return authenticateFacebook($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateFacebook(
       $grpc.ServiceCall call, $0.AuthenticateFacebookRequest request);
+
+  $async.Future<$0.Session> authenticateFacebookInstantGame_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateFacebookInstantGameRequest> $request) async {
+    return authenticateFacebookInstantGame($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateFacebookInstantGame(
       $grpc.ServiceCall call,
       $0.AuthenticateFacebookInstantGameRequest request);
+
+  $async.Future<$0.Session> authenticateGameCenter_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateGameCenterRequest> $request) async {
+    return authenticateGameCenter($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateGameCenter(
       $grpc.ServiceCall call, $0.AuthenticateGameCenterRequest request);
+
+  $async.Future<$0.Session> authenticateGoogle_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateGoogleRequest> $request) async {
+    return authenticateGoogle($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateGoogle(
       $grpc.ServiceCall call, $0.AuthenticateGoogleRequest request);
+
+  $async.Future<$0.Session> authenticateSteam_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AuthenticateSteamRequest> $request) async {
+    return authenticateSteam($call, await $request);
+  }
+
   $async.Future<$0.Session> authenticateSteam(
       $grpc.ServiceCall call, $0.AuthenticateSteamRequest request);
+
+  $async.Future<$1.Empty> banGroupUsers_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.BanGroupUsersRequest> $request) async {
+    return banGroupUsers($call, await $request);
+  }
+
   $async.Future<$1.Empty> banGroupUsers(
       $grpc.ServiceCall call, $0.BanGroupUsersRequest request);
+
+  $async.Future<$1.Empty> blockFriends_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.BlockFriendsRequest> $request) async {
+    return blockFriends($call, await $request);
+  }
+
   $async.Future<$1.Empty> blockFriends(
       $grpc.ServiceCall call, $0.BlockFriendsRequest request);
+
+  $async.Future<$0.Group> createGroup_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.CreateGroupRequest> $request) async {
+    return createGroup($call, await $request);
+  }
+
   $async.Future<$0.Group> createGroup(
       $grpc.ServiceCall call, $0.CreateGroupRequest request);
+
+  $async.Future<$1.Empty> deleteAccount_Pre(
+      $grpc.ServiceCall $call, $async.Future<$1.Empty> $request) async {
+    return deleteAccount($call, await $request);
+  }
+
   $async.Future<$1.Empty> deleteAccount(
       $grpc.ServiceCall call, $1.Empty request);
+
+  $async.Future<$1.Empty> deleteFriends_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.DeleteFriendsRequest> $request) async {
+    return deleteFriends($call, await $request);
+  }
+
   $async.Future<$1.Empty> deleteFriends(
       $grpc.ServiceCall call, $0.DeleteFriendsRequest request);
+
+  $async.Future<$1.Empty> deleteGroup_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.DeleteGroupRequest> $request) async {
+    return deleteGroup($call, await $request);
+  }
+
   $async.Future<$1.Empty> deleteGroup(
       $grpc.ServiceCall call, $0.DeleteGroupRequest request);
+
+  $async.Future<$1.Empty> deleteLeaderboardRecord_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.DeleteLeaderboardRecordRequest> $request) async {
+    return deleteLeaderboardRecord($call, await $request);
+  }
+
   $async.Future<$1.Empty> deleteLeaderboardRecord(
       $grpc.ServiceCall call, $0.DeleteLeaderboardRecordRequest request);
+
+  $async.Future<$1.Empty> deleteNotifications_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.DeleteNotificationsRequest> $request) async {
+    return deleteNotifications($call, await $request);
+  }
+
   $async.Future<$1.Empty> deleteNotifications(
       $grpc.ServiceCall call, $0.DeleteNotificationsRequest request);
+
+  $async.Future<$1.Empty> deleteTournamentRecord_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.DeleteTournamentRecordRequest> $request) async {
+    return deleteTournamentRecord($call, await $request);
+  }
+
   $async.Future<$1.Empty> deleteTournamentRecord(
       $grpc.ServiceCall call, $0.DeleteTournamentRecordRequest request);
+
+  $async.Future<$1.Empty> deleteStorageObjects_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.DeleteStorageObjectsRequest> $request) async {
+    return deleteStorageObjects($call, await $request);
+  }
+
   $async.Future<$1.Empty> deleteStorageObjects(
       $grpc.ServiceCall call, $0.DeleteStorageObjectsRequest request);
+
+  $async.Future<$1.Empty> event_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.Event> $request) async {
+    return event($call, await $request);
+  }
+
   $async.Future<$1.Empty> event($grpc.ServiceCall call, $0.Event request);
+
+  $async.Future<$0.Account> getAccount_Pre(
+      $grpc.ServiceCall $call, $async.Future<$1.Empty> $request) async {
+    return getAccount($call, await $request);
+  }
+
   $async.Future<$0.Account> getAccount(
       $grpc.ServiceCall call, $1.Empty request);
+
+  $async.Future<$0.Users> getUsers_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.GetUsersRequest> $request) async {
+    return getUsers($call, await $request);
+  }
+
   $async.Future<$0.Users> getUsers(
       $grpc.ServiceCall call, $0.GetUsersRequest request);
+
+  $async.Future<$0.ValidatedSubscription> getSubscription_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.GetSubscriptionRequest> $request) async {
+    return getSubscription($call, await $request);
+  }
+
   $async.Future<$0.ValidatedSubscription> getSubscription(
       $grpc.ServiceCall call, $0.GetSubscriptionRequest request);
+
+  $async.Future<$0.MatchmakerStats> getMatchmakerStats_Pre(
+      $grpc.ServiceCall $call, $async.Future<$1.Empty> $request) async {
+    return getMatchmakerStats($call, await $request);
+  }
+
+  $async.Future<$0.MatchmakerStats> getMatchmakerStats(
+      $grpc.ServiceCall call, $1.Empty request);
+
+  $async.Future<$1.Empty> healthcheck_Pre(
+      $grpc.ServiceCall $call, $async.Future<$1.Empty> $request) async {
+    return healthcheck($call, await $request);
+  }
+
   $async.Future<$1.Empty> healthcheck($grpc.ServiceCall call, $1.Empty request);
+
+  $async.Future<$1.Empty> importFacebookFriends_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ImportFacebookFriendsRequest> $request) async {
+    return importFacebookFriends($call, await $request);
+  }
+
   $async.Future<$1.Empty> importFacebookFriends(
       $grpc.ServiceCall call, $0.ImportFacebookFriendsRequest request);
+
+  $async.Future<$1.Empty> importSteamFriends_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ImportSteamFriendsRequest> $request) async {
+    return importSteamFriends($call, await $request);
+  }
+
   $async.Future<$1.Empty> importSteamFriends(
       $grpc.ServiceCall call, $0.ImportSteamFriendsRequest request);
+
+  $async.Future<$1.Empty> joinGroup_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.JoinGroupRequest> $request) async {
+    return joinGroup($call, await $request);
+  }
+
   $async.Future<$1.Empty> joinGroup(
       $grpc.ServiceCall call, $0.JoinGroupRequest request);
+
+  $async.Future<$1.Empty> joinTournament_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.JoinTournamentRequest> $request) async {
+    return joinTournament($call, await $request);
+  }
+
   $async.Future<$1.Empty> joinTournament(
       $grpc.ServiceCall call, $0.JoinTournamentRequest request);
+
+  $async.Future<$1.Empty> kickGroupUsers_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.KickGroupUsersRequest> $request) async {
+    return kickGroupUsers($call, await $request);
+  }
+
   $async.Future<$1.Empty> kickGroupUsers(
       $grpc.ServiceCall call, $0.KickGroupUsersRequest request);
+
+  $async.Future<$1.Empty> leaveGroup_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.LeaveGroupRequest> $request) async {
+    return leaveGroup($call, await $request);
+  }
+
   $async.Future<$1.Empty> leaveGroup(
       $grpc.ServiceCall call, $0.LeaveGroupRequest request);
+
+  $async.Future<$1.Empty> linkApple_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountApple> $request) async {
+    return linkApple($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkApple(
       $grpc.ServiceCall call, $0.AccountApple request);
+
+  $async.Future<$1.Empty> linkCustom_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountCustom> $request) async {
+    return linkCustom($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkCustom(
       $grpc.ServiceCall call, $0.AccountCustom request);
+
+  $async.Future<$1.Empty> linkDevice_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountDevice> $request) async {
+    return linkDevice($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkDevice(
       $grpc.ServiceCall call, $0.AccountDevice request);
+
+  $async.Future<$1.Empty> linkEmail_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountEmail> $request) async {
+    return linkEmail($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkEmail(
       $grpc.ServiceCall call, $0.AccountEmail request);
+
+  $async.Future<$1.Empty> linkFacebook_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.LinkFacebookRequest> $request) async {
+    return linkFacebook($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkFacebook(
       $grpc.ServiceCall call, $0.LinkFacebookRequest request);
+
+  $async.Future<$1.Empty> linkFacebookInstantGame_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AccountFacebookInstantGame> $request) async {
+    return linkFacebookInstantGame($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkFacebookInstantGame(
       $grpc.ServiceCall call, $0.AccountFacebookInstantGame request);
+
+  $async.Future<$1.Empty> linkGameCenter_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AccountGameCenter> $request) async {
+    return linkGameCenter($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkGameCenter(
       $grpc.ServiceCall call, $0.AccountGameCenter request);
+
+  $async.Future<$1.Empty> linkGoogle_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountGoogle> $request) async {
+    return linkGoogle($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkGoogle(
       $grpc.ServiceCall call, $0.AccountGoogle request);
+
+  $async.Future<$1.Empty> linkSteam_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.LinkSteamRequest> $request) async {
+    return linkSteam($call, await $request);
+  }
+
   $async.Future<$1.Empty> linkSteam(
       $grpc.ServiceCall call, $0.LinkSteamRequest request);
+
+  $async.Future<$0.ChannelMessageList> listChannelMessages_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListChannelMessagesRequest> $request) async {
+    return listChannelMessages($call, await $request);
+  }
+
   $async.Future<$0.ChannelMessageList> listChannelMessages(
       $grpc.ServiceCall call, $0.ListChannelMessagesRequest request);
+
+  $async.Future<$0.FriendList> listFriends_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ListFriendsRequest> $request) async {
+    return listFriends($call, await $request);
+  }
+
   $async.Future<$0.FriendList> listFriends(
       $grpc.ServiceCall call, $0.ListFriendsRequest request);
+
+  $async.Future<$0.FriendsOfFriendsList> listFriendsOfFriends_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListFriendsOfFriendsRequest> $request) async {
+    return listFriendsOfFriends($call, await $request);
+  }
+
+  $async.Future<$0.FriendsOfFriendsList> listFriendsOfFriends(
+      $grpc.ServiceCall call, $0.ListFriendsOfFriendsRequest request);
+
+  $async.Future<$0.GroupList> listGroups_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ListGroupsRequest> $request) async {
+    return listGroups($call, await $request);
+  }
+
   $async.Future<$0.GroupList> listGroups(
       $grpc.ServiceCall call, $0.ListGroupsRequest request);
+
+  $async.Future<$0.GroupUserList> listGroupUsers_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ListGroupUsersRequest> $request) async {
+    return listGroupUsers($call, await $request);
+  }
+
   $async.Future<$0.GroupUserList> listGroupUsers(
       $grpc.ServiceCall call, $0.ListGroupUsersRequest request);
+
+  $async.Future<$0.LeaderboardRecordList> listLeaderboardRecords_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListLeaderboardRecordsRequest> $request) async {
+    return listLeaderboardRecords($call, await $request);
+  }
+
   $async.Future<$0.LeaderboardRecordList> listLeaderboardRecords(
       $grpc.ServiceCall call, $0.ListLeaderboardRecordsRequest request);
+
+  $async.Future<$0.LeaderboardRecordList> listLeaderboardRecordsAroundOwner_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListLeaderboardRecordsAroundOwnerRequest>
+          $request) async {
+    return listLeaderboardRecordsAroundOwner($call, await $request);
+  }
+
   $async.Future<$0.LeaderboardRecordList> listLeaderboardRecordsAroundOwner(
       $grpc.ServiceCall call,
       $0.ListLeaderboardRecordsAroundOwnerRequest request);
+
+  $async.Future<$0.MatchList> listMatches_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ListMatchesRequest> $request) async {
+    return listMatches($call, await $request);
+  }
+
   $async.Future<$0.MatchList> listMatches(
       $grpc.ServiceCall call, $0.ListMatchesRequest request);
+
+  $async.Future<$0.PartyList> listParties_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ListPartiesRequest> $request) async {
+    return listParties($call, await $request);
+  }
+
+  $async.Future<$0.PartyList> listParties(
+      $grpc.ServiceCall call, $0.ListPartiesRequest request);
+
+  $async.Future<$0.NotificationList> listNotifications_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListNotificationsRequest> $request) async {
+    return listNotifications($call, await $request);
+  }
+
   $async.Future<$0.NotificationList> listNotifications(
       $grpc.ServiceCall call, $0.ListNotificationsRequest request);
+
+  $async.Future<$0.StorageObjectList> listStorageObjects_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListStorageObjectsRequest> $request) async {
+    return listStorageObjects($call, await $request);
+  }
+
   $async.Future<$0.StorageObjectList> listStorageObjects(
       $grpc.ServiceCall call, $0.ListStorageObjectsRequest request);
+
+  $async.Future<$0.SubscriptionList> listSubscriptions_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListSubscriptionsRequest> $request) async {
+    return listSubscriptions($call, await $request);
+  }
+
   $async.Future<$0.SubscriptionList> listSubscriptions(
       $grpc.ServiceCall call, $0.ListSubscriptionsRequest request);
+
+  $async.Future<$0.TournamentList> listTournaments_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ListTournamentsRequest> $request) async {
+    return listTournaments($call, await $request);
+  }
+
   $async.Future<$0.TournamentList> listTournaments(
       $grpc.ServiceCall call, $0.ListTournamentsRequest request);
+
+  $async.Future<$0.TournamentRecordList> listTournamentRecords_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListTournamentRecordsRequest> $request) async {
+    return listTournamentRecords($call, await $request);
+  }
+
   $async.Future<$0.TournamentRecordList> listTournamentRecords(
       $grpc.ServiceCall call, $0.ListTournamentRecordsRequest request);
+
+  $async.Future<$0.TournamentRecordList> listTournamentRecordsAroundOwner_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ListTournamentRecordsAroundOwnerRequest>
+          $request) async {
+    return listTournamentRecordsAroundOwner($call, await $request);
+  }
+
   $async.Future<$0.TournamentRecordList> listTournamentRecordsAroundOwner(
       $grpc.ServiceCall call,
       $0.ListTournamentRecordsAroundOwnerRequest request);
+
+  $async.Future<$0.UserGroupList> listUserGroups_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.ListUserGroupsRequest> $request) async {
+    return listUserGroups($call, await $request);
+  }
+
   $async.Future<$0.UserGroupList> listUserGroups(
       $grpc.ServiceCall call, $0.ListUserGroupsRequest request);
+
+  $async.Future<$1.Empty> promoteGroupUsers_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.PromoteGroupUsersRequest> $request) async {
+    return promoteGroupUsers($call, await $request);
+  }
+
   $async.Future<$1.Empty> promoteGroupUsers(
       $grpc.ServiceCall call, $0.PromoteGroupUsersRequest request);
+
+  $async.Future<$1.Empty> demoteGroupUsers_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.DemoteGroupUsersRequest> $request) async {
+    return demoteGroupUsers($call, await $request);
+  }
+
   $async.Future<$1.Empty> demoteGroupUsers(
       $grpc.ServiceCall call, $0.DemoteGroupUsersRequest request);
+
+  $async.Future<$0.StorageObjects> readStorageObjects_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ReadStorageObjectsRequest> $request) async {
+    return readStorageObjects($call, await $request);
+  }
+
   $async.Future<$0.StorageObjects> readStorageObjects(
       $grpc.ServiceCall call, $0.ReadStorageObjectsRequest request);
+
+  $async.Future<$0.Rpc> rpcFunc_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.Rpc> $request) async {
+    return rpcFunc($call, await $request);
+  }
+
   $async.Future<$0.Rpc> rpcFunc($grpc.ServiceCall call, $0.Rpc request);
+
+  $async.Future<$1.Empty> unlinkApple_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountApple> $request) async {
+    return unlinkApple($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkApple(
       $grpc.ServiceCall call, $0.AccountApple request);
+
+  $async.Future<$1.Empty> unlinkCustom_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountCustom> $request) async {
+    return unlinkCustom($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkCustom(
       $grpc.ServiceCall call, $0.AccountCustom request);
+
+  $async.Future<$1.Empty> unlinkDevice_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountDevice> $request) async {
+    return unlinkDevice($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkDevice(
       $grpc.ServiceCall call, $0.AccountDevice request);
+
+  $async.Future<$1.Empty> unlinkEmail_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountEmail> $request) async {
+    return unlinkEmail($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkEmail(
       $grpc.ServiceCall call, $0.AccountEmail request);
+
+  $async.Future<$1.Empty> unlinkFacebook_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AccountFacebook> $request) async {
+    return unlinkFacebook($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkFacebook(
       $grpc.ServiceCall call, $0.AccountFacebook request);
+
+  $async.Future<$1.Empty> unlinkFacebookInstantGame_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AccountFacebookInstantGame> $request) async {
+    return unlinkFacebookInstantGame($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkFacebookInstantGame(
       $grpc.ServiceCall call, $0.AccountFacebookInstantGame request);
+
+  $async.Future<$1.Empty> unlinkGameCenter_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.AccountGameCenter> $request) async {
+    return unlinkGameCenter($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkGameCenter(
       $grpc.ServiceCall call, $0.AccountGameCenter request);
+
+  $async.Future<$1.Empty> unlinkGoogle_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountGoogle> $request) async {
+    return unlinkGoogle($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkGoogle(
       $grpc.ServiceCall call, $0.AccountGoogle request);
+
+  $async.Future<$1.Empty> unlinkSteam_Pre(
+      $grpc.ServiceCall $call, $async.Future<$0.AccountSteam> $request) async {
+    return unlinkSteam($call, await $request);
+  }
+
   $async.Future<$1.Empty> unlinkSteam(
       $grpc.ServiceCall call, $0.AccountSteam request);
+
+  $async.Future<$1.Empty> updateAccount_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.UpdateAccountRequest> $request) async {
+    return updateAccount($call, await $request);
+  }
+
   $async.Future<$1.Empty> updateAccount(
       $grpc.ServiceCall call, $0.UpdateAccountRequest request);
+
+  $async.Future<$1.Empty> updateGroup_Pre($grpc.ServiceCall $call,
+      $async.Future<$0.UpdateGroupRequest> $request) async {
+    return updateGroup($call, await $request);
+  }
+
   $async.Future<$1.Empty> updateGroup(
       $grpc.ServiceCall call, $0.UpdateGroupRequest request);
+
+  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseApple_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ValidatePurchaseAppleRequest> $request) async {
+    return validatePurchaseApple($call, await $request);
+  }
+
   $async.Future<$0.ValidatePurchaseResponse> validatePurchaseApple(
       $grpc.ServiceCall call, $0.ValidatePurchaseAppleRequest request);
+
+  $async.Future<$0.ValidateSubscriptionResponse> validateSubscriptionApple_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ValidateSubscriptionAppleRequest> $request) async {
+    return validateSubscriptionApple($call, await $request);
+  }
+
   $async.Future<$0.ValidateSubscriptionResponse> validateSubscriptionApple(
       $grpc.ServiceCall call, $0.ValidateSubscriptionAppleRequest request);
+
+  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseGoogle_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ValidatePurchaseGoogleRequest> $request) async {
+    return validatePurchaseGoogle($call, await $request);
+  }
+
   $async.Future<$0.ValidatePurchaseResponse> validatePurchaseGoogle(
       $grpc.ServiceCall call, $0.ValidatePurchaseGoogleRequest request);
+
+  $async.Future<$0.ValidateSubscriptionResponse> validateSubscriptionGoogle_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ValidateSubscriptionGoogleRequest> $request) async {
+    return validateSubscriptionGoogle($call, await $request);
+  }
+
   $async.Future<$0.ValidateSubscriptionResponse> validateSubscriptionGoogle(
       $grpc.ServiceCall call, $0.ValidateSubscriptionGoogleRequest request);
+
+  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseHuawei_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ValidatePurchaseHuaweiRequest> $request) async {
+    return validatePurchaseHuawei($call, await $request);
+  }
+
   $async.Future<$0.ValidatePurchaseResponse> validatePurchaseHuawei(
       $grpc.ServiceCall call, $0.ValidatePurchaseHuaweiRequest request);
+
+  $async.Future<$0.ValidatePurchaseResponse>
+      validatePurchaseFacebookInstant_Pre(
+          $grpc.ServiceCall $call,
+          $async.Future<$0.ValidatePurchaseFacebookInstantRequest>
+              $request) async {
+    return validatePurchaseFacebookInstant($call, await $request);
+  }
+
+  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseFacebookInstant(
+      $grpc.ServiceCall call,
+      $0.ValidatePurchaseFacebookInstantRequest request);
+
+  $async.Future<$0.LeaderboardRecord> writeLeaderboardRecord_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.WriteLeaderboardRecordRequest> $request) async {
+    return writeLeaderboardRecord($call, await $request);
+  }
+
   $async.Future<$0.LeaderboardRecord> writeLeaderboardRecord(
       $grpc.ServiceCall call, $0.WriteLeaderboardRecordRequest request);
+
+  $async.Future<$0.StorageObjectAcks> writeStorageObjects_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.WriteStorageObjectsRequest> $request) async {
+    return writeStorageObjects($call, await $request);
+  }
+
   $async.Future<$0.StorageObjectAcks> writeStorageObjects(
       $grpc.ServiceCall call, $0.WriteStorageObjectsRequest request);
+
+  $async.Future<$0.LeaderboardRecord> writeTournamentRecord_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.WriteTournamentRecordRequest> $request) async {
+    return writeTournamentRecord($call, await $request);
+  }
+
   $async.Future<$0.LeaderboardRecord> writeTournamentRecord(
       $grpc.ServiceCall call, $0.WriteTournamentRecordRequest request);
 }

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pbjson.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pbjson.dart
@@ -1,10 +1,15 @@
-///
-//  Generated code. Do not modify.
-//  source: apigrpc/apigrpc.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from apigrpc/apigrpc.proto.
 
-import 'dart:core' as $core;
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;

--- a/nakama/lib/src/api/proto/google/protobuf/empty.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/empty.pb.dart
@@ -1,47 +1,59 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/empty.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/empty.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+///
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
 class Empty extends $pb.GeneratedMessage {
+  factory Empty() => create();
+
+  Empty._();
+
+  factory Empty.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Empty.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Empty',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
+      _omitMessageNames ? '' : 'Empty',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
       createEmptyInstance: create)
     ..hasRequiredFields = false;
 
-  Empty._() : super();
-  factory Empty() => create();
-  factory Empty.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Empty.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Empty clone() => Empty()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Empty clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Empty copyWith(void Function(Empty) updates) =>
-      super.copyWith((message) => updates(message as Empty))
-          as Empty; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Empty)) as Empty;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
+  @$core.override
   Empty createEmptyInstance() => create();
   static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
@@ -49,3 +61,6 @@ class Empty extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
   static Empty? _defaultInstance;
 }
+
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/nakama/lib/src/api/proto/google/protobuf/empty.pbenum.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/empty.pbenum.dart
@@ -1,6 +1,11 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/empty.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/empty.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names

--- a/nakama/lib/src/api/proto/google/protobuf/empty.pbjson.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/empty.pbjson.dart
@@ -1,16 +1,21 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/empty.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/empty.proto.
 
-import 'dart:core' as $core;
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 
 @$core.Deprecated('Use emptyDescriptor instead')
-const Empty$json = const {
+const Empty$json = {
   '1': 'Empty',
 };
 

--- a/nakama/lib/src/api/proto/google/protobuf/timestamp.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/timestamp.pb.dart
@@ -1,75 +1,155 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/timestamp.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/timestamp.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: implementation_imports, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
 import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
-
 import 'package:protobuf/src/protobuf/mixins/well_known.dart' as $mixin;
 
-class Timestamp extends $pb.GeneratedMessage with $mixin.TimestampMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Timestamp',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.TimestampMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.TimestampMixin.fromProto3JsonHelper)
-    ..aInt64(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'seconds')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'nanos',
-        $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
-  Timestamp._() : super();
+/// A Timestamp represents a point in time independent of any time zone or local
+/// calendar, encoded as a count of seconds and fractions of seconds at
+/// nanosecond resolution. The count is relative to an epoch at UTC midnight on
+/// January 1, 1970, in the proleptic Gregorian calendar which extends the
+/// Gregorian calendar backwards to year one.
+///
+/// All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+/// second table is needed for interpretation, using a [24-hour linear
+/// smear](https://developers.google.com/time/smear).
+///
+/// The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+/// restricting to that range, we ensure that we can convert to and from [RFC
+/// 3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+///
+/// # Examples
+///
+/// Example 1: Compute Timestamp from POSIX `time()`.
+///
+///     Timestamp timestamp;
+///     timestamp.set_seconds(time(NULL));
+///     timestamp.set_nanos(0);
+///
+/// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+///
+///     struct timeval tv;
+///     gettimeofday(&tv, NULL);
+///
+///     Timestamp timestamp;
+///     timestamp.set_seconds(tv.tv_sec);
+///     timestamp.set_nanos(tv.tv_usec * 1000);
+///
+/// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+///
+///     FILETIME ft;
+///     GetSystemTimeAsFileTime(&ft);
+///     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+///
+///     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+///     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+///     Timestamp timestamp;
+///     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+///     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+///
+/// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+///
+///     long millis = System.currentTimeMillis();
+///
+///     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+///         .setNanos((int) ((millis % 1000) * 1000000)).build();
+///
+/// Example 5: Compute Timestamp from Java `Instant.now()`.
+///
+///     Instant now = Instant.now();
+///
+///     Timestamp timestamp =
+///         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+///             .setNanos(now.getNano()).build();
+///
+/// Example 6: Compute Timestamp from current time in Python.
+///
+///     timestamp = Timestamp()
+///     timestamp.GetCurrentTime()
+///
+/// # JSON Mapping
+///
+/// In JSON format, the Timestamp type is encoded as a string in the
+/// [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+/// format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+/// where {year} is always expressed using four digits while {month}, {day},
+/// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+/// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+/// are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+/// is required. A ProtoJSON serializer should always use UTC (as indicated by
+/// "Z") when printing the Timestamp type and a ProtoJSON parser should be
+/// able to accept both UTC and other timezones (as indicated by an offset).
+///
+/// For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+/// 01:30 UTC on January 15, 2017.
+///
+/// In JavaScript, one can convert a Date object to this format using the
+/// standard
+/// [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+/// method. In Python, a standard `datetime.datetime` object can be converted
+/// to this format using
+/// [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+/// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+/// the Joda Time's [`ISODateTimeFormat.dateTime()`](
+/// http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
+/// ) to obtain a formatter capable of generating timestamps in this format.
+class Timestamp extends $pb.GeneratedMessage with $mixin.TimestampMixin {
   factory Timestamp({
     $fixnum.Int64? seconds,
     $core.int? nanos,
   }) {
-    final _result = create();
-    if (seconds != null) {
-      _result.seconds = seconds;
-    }
-    if (nanos != null) {
-      _result.nanos = nanos;
-    }
-    return _result;
+    final result = create();
+    if (seconds != null) result.seconds = seconds;
+    if (nanos != null) result.nanos = nanos;
+    return result;
   }
-  factory Timestamp.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Timestamp.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Timestamp clone() => Timestamp()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Timestamp._();
+
+  factory Timestamp.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Timestamp.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Timestamp',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.timestamp)
+    ..aInt64(1, _omitFieldNames ? '' : 'seconds')
+    ..aI(2, _omitFieldNames ? '' : 'nanos')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Timestamp clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Timestamp copyWith(void Function(Timestamp) updates) =>
-      super.copyWith((message) => updates(message as Timestamp))
-          as Timestamp; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Timestamp)) as Timestamp;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Timestamp create() => Timestamp._();
+  @$core.override
   Timestamp createEmptyInstance() => create();
   static $pb.PbList<Timestamp> createRepeated() => $pb.PbList<Timestamp>();
   @$core.pragma('dart2js:noInline')
@@ -77,29 +157,31 @@ class Timestamp extends $pb.GeneratedMessage with $mixin.TimestampMixin {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Timestamp>(create);
   static Timestamp? _defaultInstance;
 
+  /// Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
+  /// be between -62135596800 and 253402300799 inclusive (which corresponds to
+  /// 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
   @$pb.TagNumber(1)
   $fixnum.Int64 get seconds => $_getI64(0);
   @$pb.TagNumber(1)
-  set seconds($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set seconds($fixnum.Int64 value) => $_setInt64(0, value);
   @$pb.TagNumber(1)
   $core.bool hasSeconds() => $_has(0);
   @$pb.TagNumber(1)
-  void clearSeconds() => clearField(1);
+  void clearSeconds() => $_clearField(1);
 
+  /// Non-negative fractions of a second at nanosecond resolution. This field is
+  /// the nanosecond portion of the duration, not an alternative to seconds.
+  /// Negative second values with fractions must still have non-negative nanos
+  /// values that count forward in time. Must be between 0 and 999,999,999
+  /// inclusive.
   @$pb.TagNumber(2)
   $core.int get nanos => $_getIZ(1);
   @$pb.TagNumber(2)
-  set nanos($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set nanos($core.int value) => $_setSignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasNanos() => $_has(1);
   @$pb.TagNumber(2)
-  void clearNanos() => clearField(2);
+  void clearNanos() => $_clearField(2);
 
   /// Creates a new instance from [dateTime].
   ///
@@ -110,3 +192,8 @@ class Timestamp extends $pb.GeneratedMessage with $mixin.TimestampMixin {
     return result;
   }
 }
+
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/nakama/lib/src/api/proto/google/protobuf/timestamp.pbenum.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/timestamp.pbenum.dart
@@ -1,6 +1,11 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/timestamp.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/timestamp.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names

--- a/nakama/lib/src/api/proto/google/protobuf/timestamp.pbjson.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/timestamp.pbjson.dart
@@ -1,23 +1,29 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/timestamp.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/timestamp.proto.
 
-import 'dart:core' as $core;
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 
 @$core.Deprecated('Use timestampDescriptor instead')
-const Timestamp$json = const {
+const Timestamp$json = {
   '1': 'Timestamp',
-  '2': const [
-    const {'1': 'seconds', '3': 1, '4': 1, '5': 3, '10': 'seconds'},
-    const {'1': 'nanos', '3': 2, '4': 1, '5': 5, '10': 'nanos'},
+  '2': [
+    {'1': 'seconds', '3': 1, '4': 1, '5': 3, '10': 'seconds'},
+    {'1': 'nanos', '3': 2, '4': 1, '5': 5, '10': 'nanos'},
   ],
 };
 
 /// Descriptor for `Timestamp`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List timestampDescriptor = $convert.base64Decode(
-    'CglUaW1lc3RhbXASGAoHc2Vjb25kcxgBIAEoA1IHc2Vjb25kcxIUCgVuYW5vcxgCIAEoBVIFbmFub3M=');
+    'CglUaW1lc3RhbXASGAoHc2Vjb25kcxgBIAEoA1IHc2Vjb25kcxIUCgVuYW5vcxgCIAEoBVIFbm'
+    'Fub3M=');

--- a/nakama/lib/src/api/proto/google/protobuf/wrappers.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/wrappers.pb.dart
@@ -1,66 +1,70 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/wrappers.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/wrappers.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: implementation_imports, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
 import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
-
 import 'package:protobuf/src/protobuf/mixins/well_known.dart' as $mixin;
 
-class DoubleValue extends $pb.GeneratedMessage with $mixin.DoubleValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DoubleValue',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.DoubleValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.DoubleValueMixin.fromProto3JsonHelper)
-    ..a<$core.double>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.OD)
-    ..hasRequiredFields = false;
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
-  DoubleValue._() : super();
+/// Wrapper message for `double`.
+///
+/// The JSON representation for `DoubleValue` is JSON number.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
+class DoubleValue extends $pb.GeneratedMessage with $mixin.DoubleValueMixin {
   factory DoubleValue({
     $core.double? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory DoubleValue.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DoubleValue.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DoubleValue clone() => DoubleValue()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  DoubleValue._();
+
+  factory DoubleValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DoubleValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'DoubleValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.doubleValue)
+    ..aD(1, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DoubleValue clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   DoubleValue copyWith(void Function(DoubleValue) updates) =>
       super.copyWith((message) => updates(message as DoubleValue))
-          as DoubleValue; // ignore: deprecated_member_use
+          as DoubleValue;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static DoubleValue create() => DoubleValue._();
+  @$core.override
   DoubleValue createEmptyInstance() => create();
   static $pb.PbList<DoubleValue> createRepeated() => $pb.PbList<DoubleValue>();
   @$core.pragma('dart2js:noInline')
@@ -68,68 +72,62 @@ class DoubleValue extends $pb.GeneratedMessage with $mixin.DoubleValueMixin {
       $pb.GeneratedMessage.$_defaultFor<DoubleValue>(create);
   static DoubleValue? _defaultInstance;
 
+  /// The double value.
   @$pb.TagNumber(1)
   $core.double get value => $_getN(0);
   @$pb.TagNumber(1)
-  set value($core.double v) {
-    $_setDouble(0, v);
-  }
-
+  set value($core.double value) => $_setDouble(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
+/// Wrapper message for `float`.
+///
+/// The JSON representation for `FloatValue` is JSON number.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
 class FloatValue extends $pb.GeneratedMessage with $mixin.FloatValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'FloatValue',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.FloatValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.FloatValueMixin.fromProto3JsonHelper)
-    ..a<$core.double>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.OF)
-    ..hasRequiredFields = false;
-
-  FloatValue._() : super();
   factory FloatValue({
     $core.double? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory FloatValue.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory FloatValue.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  FloatValue clone() => FloatValue()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  FloatValue._();
+
+  factory FloatValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory FloatValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'FloatValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.floatValue)
+    ..aD(1, _omitFieldNames ? '' : 'value', fieldType: $pb.PbFieldType.OF)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  FloatValue clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   FloatValue copyWith(void Function(FloatValue) updates) =>
-      super.copyWith((message) => updates(message as FloatValue))
-          as FloatValue; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FloatValue)) as FloatValue;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static FloatValue create() => FloatValue._();
+  @$core.override
   FloatValue createEmptyInstance() => create();
   static $pb.PbList<FloatValue> createRepeated() => $pb.PbList<FloatValue>();
   @$core.pragma('dart2js:noInline')
@@ -137,67 +135,62 @@ class FloatValue extends $pb.GeneratedMessage with $mixin.FloatValueMixin {
       $pb.GeneratedMessage.$_defaultFor<FloatValue>(create);
   static FloatValue? _defaultInstance;
 
+  /// The float value.
   @$pb.TagNumber(1)
   $core.double get value => $_getN(0);
   @$pb.TagNumber(1)
-  set value($core.double v) {
-    $_setFloat(0, v);
-  }
-
+  set value($core.double value) => $_setFloat(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
+/// Wrapper message for `int64`.
+///
+/// The JSON representation for `Int64Value` is JSON string.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
 class Int64Value extends $pb.GeneratedMessage with $mixin.Int64ValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Int64Value',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.Int64ValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.Int64ValueMixin.fromProto3JsonHelper)
-    ..aInt64(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value')
-    ..hasRequiredFields = false;
-
-  Int64Value._() : super();
   factory Int64Value({
     $fixnum.Int64? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory Int64Value.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Int64Value.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Int64Value clone() => Int64Value()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Int64Value._();
+
+  factory Int64Value.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Int64Value.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Int64Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.int64Value)
+    ..aInt64(1, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Int64Value clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Int64Value copyWith(void Function(Int64Value) updates) =>
-      super.copyWith((message) => updates(message as Int64Value))
-          as Int64Value; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Int64Value)) as Int64Value;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Int64Value create() => Int64Value._();
+  @$core.override
   Int64Value createEmptyInstance() => create();
   static $pb.PbList<Int64Value> createRepeated() => $pb.PbList<Int64Value>();
   @$core.pragma('dart2js:noInline')
@@ -205,69 +198,64 @@ class Int64Value extends $pb.GeneratedMessage with $mixin.Int64ValueMixin {
       $pb.GeneratedMessage.$_defaultFor<Int64Value>(create);
   static Int64Value? _defaultInstance;
 
+  /// The int64 value.
   @$pb.TagNumber(1)
   $fixnum.Int64 get value => $_getI64(0);
   @$pb.TagNumber(1)
-  set value($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set value($fixnum.Int64 value) => $_setInt64(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
+/// Wrapper message for `uint64`.
+///
+/// The JSON representation for `UInt64Value` is JSON string.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
 class UInt64Value extends $pb.GeneratedMessage with $mixin.UInt64ValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UInt64Value',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.UInt64ValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.UInt64ValueMixin.fromProto3JsonHelper)
-    ..a<$fixnum.Int64>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.OU6,
-        defaultOrMaker: $fixnum.Int64.ZERO)
-    ..hasRequiredFields = false;
-
-  UInt64Value._() : super();
   factory UInt64Value({
     $fixnum.Int64? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory UInt64Value.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UInt64Value.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  UInt64Value clone() => UInt64Value()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  UInt64Value._();
+
+  factory UInt64Value.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UInt64Value.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UInt64Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.uint64Value)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UInt64Value clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UInt64Value copyWith(void Function(UInt64Value) updates) =>
       super.copyWith((message) => updates(message as UInt64Value))
-          as UInt64Value; // ignore: deprecated_member_use
+          as UInt64Value;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UInt64Value create() => UInt64Value._();
+  @$core.override
   UInt64Value createEmptyInstance() => create();
   static $pb.PbList<UInt64Value> createRepeated() => $pb.PbList<UInt64Value>();
   @$core.pragma('dart2js:noInline')
@@ -275,68 +263,62 @@ class UInt64Value extends $pb.GeneratedMessage with $mixin.UInt64ValueMixin {
       $pb.GeneratedMessage.$_defaultFor<UInt64Value>(create);
   static UInt64Value? _defaultInstance;
 
+  /// The uint64 value.
   @$pb.TagNumber(1)
   $fixnum.Int64 get value => $_getI64(0);
   @$pb.TagNumber(1)
-  set value($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set value($fixnum.Int64 value) => $_setInt64(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
+/// Wrapper message for `int32`.
+///
+/// The JSON representation for `Int32Value` is JSON number.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
 class Int32Value extends $pb.GeneratedMessage with $mixin.Int32ValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Int32Value',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.Int32ValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.Int32ValueMixin.fromProto3JsonHelper)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
-
-  Int32Value._() : super();
   factory Int32Value({
     $core.int? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory Int32Value.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Int32Value.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Int32Value clone() => Int32Value()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Int32Value._();
+
+  factory Int32Value.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Int32Value.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Int32Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.int32Value)
+    ..aI(1, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Int32Value clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Int32Value copyWith(void Function(Int32Value) updates) =>
-      super.copyWith((message) => updates(message as Int32Value))
-          as Int32Value; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Int32Value)) as Int32Value;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Int32Value create() => Int32Value._();
+  @$core.override
   Int32Value createEmptyInstance() => create();
   static $pb.PbList<Int32Value> createRepeated() => $pb.PbList<Int32Value>();
   @$core.pragma('dart2js:noInline')
@@ -344,68 +326,63 @@ class Int32Value extends $pb.GeneratedMessage with $mixin.Int32ValueMixin {
       $pb.GeneratedMessage.$_defaultFor<Int32Value>(create);
   static Int32Value? _defaultInstance;
 
+  /// The int32 value.
   @$pb.TagNumber(1)
   $core.int get value => $_getIZ(0);
   @$pb.TagNumber(1)
-  set value($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set value($core.int value) => $_setSignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
+/// Wrapper message for `uint32`.
+///
+/// The JSON representation for `UInt32Value` is JSON number.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
 class UInt32Value extends $pb.GeneratedMessage with $mixin.UInt32ValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UInt32Value',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.UInt32ValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.UInt32ValueMixin.fromProto3JsonHelper)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false;
-
-  UInt32Value._() : super();
   factory UInt32Value({
     $core.int? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory UInt32Value.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UInt32Value.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  UInt32Value clone() => UInt32Value()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  UInt32Value._();
+
+  factory UInt32Value.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UInt32Value.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UInt32Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.uint32Value)
+    ..aI(1, _omitFieldNames ? '' : 'value', fieldType: $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UInt32Value clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UInt32Value copyWith(void Function(UInt32Value) updates) =>
       super.copyWith((message) => updates(message as UInt32Value))
-          as UInt32Value; // ignore: deprecated_member_use
+          as UInt32Value;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UInt32Value create() => UInt32Value._();
+  @$core.override
   UInt32Value createEmptyInstance() => create();
   static $pb.PbList<UInt32Value> createRepeated() => $pb.PbList<UInt32Value>();
   @$core.pragma('dart2js:noInline')
@@ -413,67 +390,62 @@ class UInt32Value extends $pb.GeneratedMessage with $mixin.UInt32ValueMixin {
       $pb.GeneratedMessage.$_defaultFor<UInt32Value>(create);
   static UInt32Value? _defaultInstance;
 
+  /// The uint32 value.
   @$pb.TagNumber(1)
   $core.int get value => $_getIZ(0);
   @$pb.TagNumber(1)
-  set value($core.int v) {
-    $_setUnsignedInt32(0, v);
-  }
-
+  set value($core.int value) => $_setUnsignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
+/// Wrapper message for `bool`.
+///
+/// The JSON representation for `BoolValue` is JSON `true` and `false`.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
 class BoolValue extends $pb.GeneratedMessage with $mixin.BoolValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'BoolValue',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.BoolValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.BoolValueMixin.fromProto3JsonHelper)
-    ..aOB(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value')
-    ..hasRequiredFields = false;
-
-  BoolValue._() : super();
   factory BoolValue({
     $core.bool? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory BoolValue.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BoolValue.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  BoolValue clone() => BoolValue()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  BoolValue._();
+
+  factory BoolValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory BoolValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'BoolValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.boolValue)
+    ..aOB(1, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  BoolValue clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   BoolValue copyWith(void Function(BoolValue) updates) =>
-      super.copyWith((message) => updates(message as BoolValue))
-          as BoolValue; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as BoolValue)) as BoolValue;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static BoolValue create() => BoolValue._();
+  @$core.override
   BoolValue createEmptyInstance() => create();
   static $pb.PbList<BoolValue> createRepeated() => $pb.PbList<BoolValue>();
   @$core.pragma('dart2js:noInline')
@@ -481,67 +453,63 @@ class BoolValue extends $pb.GeneratedMessage with $mixin.BoolValueMixin {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BoolValue>(create);
   static BoolValue? _defaultInstance;
 
+  /// The bool value.
   @$pb.TagNumber(1)
   $core.bool get value => $_getBF(0);
   @$pb.TagNumber(1)
-  set value($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set value($core.bool value) => $_setBool(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
+/// Wrapper message for `string`.
+///
+/// The JSON representation for `StringValue` is JSON string.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
 class StringValue extends $pb.GeneratedMessage with $mixin.StringValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StringValue',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.StringValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.StringValueMixin.fromProto3JsonHelper)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value')
-    ..hasRequiredFields = false;
-
-  StringValue._() : super();
   factory StringValue({
     $core.String? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory StringValue.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StringValue.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StringValue clone() => StringValue()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StringValue._();
+
+  factory StringValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StringValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StringValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.stringValue)
+    ..aOS(1, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StringValue clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StringValue copyWith(void Function(StringValue) updates) =>
       super.copyWith((message) => updates(message as StringValue))
-          as StringValue; // ignore: deprecated_member_use
+          as StringValue;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StringValue create() => StringValue._();
+  @$core.override
   StringValue createEmptyInstance() => create();
   static $pb.PbList<StringValue> createRepeated() => $pb.PbList<StringValue>();
   @$core.pragma('dart2js:noInline')
@@ -549,68 +517,63 @@ class StringValue extends $pb.GeneratedMessage with $mixin.StringValueMixin {
       $pb.GeneratedMessage.$_defaultFor<StringValue>(create);
   static StringValue? _defaultInstance;
 
+  /// The string value.
   @$pb.TagNumber(1)
   $core.String get value => $_getSZ(0);
   @$pb.TagNumber(1)
-  set value($core.String v) {
-    $_setString(0, v);
-  }
-
+  set value($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
 
+/// Wrapper message for `bytes`.
+///
+/// The JSON representation for `BytesValue` is JSON string.
+///
+/// Not recommended for use in new APIs, but still useful for legacy APIs and
+/// has no plan to be removed.
 class BytesValue extends $pb.GeneratedMessage with $mixin.BytesValueMixin {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'BytesValue',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.BytesValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.BytesValueMixin.fromProto3JsonHelper)
-    ..a<$core.List<$core.int>>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.OY)
-    ..hasRequiredFields = false;
-
-  BytesValue._() : super();
   factory BytesValue({
     $core.List<$core.int>? value,
   }) {
-    final _result = create();
-    if (value != null) {
-      _result.value = value;
-    }
-    return _result;
+    final result = create();
+    if (value != null) result.value = value;
+    return result;
   }
-  factory BytesValue.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BytesValue.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  BytesValue clone() => BytesValue()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  BytesValue._();
+
+  factory BytesValue.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory BytesValue.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'BytesValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      wellKnownType: $mixin.WellKnownType.bytesValue)
+    ..a<$core.List<$core.int>>(
+        1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  BytesValue clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   BytesValue copyWith(void Function(BytesValue) updates) =>
-      super.copyWith((message) => updates(message as BytesValue))
-          as BytesValue; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as BytesValue)) as BytesValue;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static BytesValue create() => BytesValue._();
+  @$core.override
   BytesValue createEmptyInstance() => create();
   static $pb.PbList<BytesValue> createRepeated() => $pb.PbList<BytesValue>();
   @$core.pragma('dart2js:noInline')
@@ -618,15 +581,18 @@ class BytesValue extends $pb.GeneratedMessage with $mixin.BytesValueMixin {
       $pb.GeneratedMessage.$_defaultFor<BytesValue>(create);
   static BytesValue? _defaultInstance;
 
+  /// The bytes value.
   @$pb.TagNumber(1)
   $core.List<$core.int> get value => $_getN(0);
   @$pb.TagNumber(1)
-  set value($core.List<$core.int> v) {
-    $_setBytes(0, v);
-  }
-
+  set value($core.List<$core.int> value) => $_setBytes(0, value);
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
+  void clearValue() => $_clearField(1);
 }
+
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/nakama/lib/src/api/proto/google/protobuf/wrappers.pbenum.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/wrappers.pbenum.dart
@@ -1,6 +1,11 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/wrappers.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/wrappers.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names

--- a/nakama/lib/src/api/proto/google/protobuf/wrappers.pbjson.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/wrappers.pbjson.dart
@@ -1,107 +1,120 @@
-///
-//  Generated code. Do not modify.
-//  source: google/protobuf/wrappers.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from google/protobuf/wrappers.proto.
 
-import 'dart:core' as $core;
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 
 @$core.Deprecated('Use doubleValueDescriptor instead')
-const DoubleValue$json = const {
+const DoubleValue$json = {
   '1': 'DoubleValue',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 1, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 1, '10': 'value'},
   ],
 };
 
 /// Descriptor for `DoubleValue`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List doubleValueDescriptor =
     $convert.base64Decode('CgtEb3VibGVWYWx1ZRIUCgV2YWx1ZRgBIAEoAVIFdmFsdWU=');
+
 @$core.Deprecated('Use floatValueDescriptor instead')
-const FloatValue$json = const {
+const FloatValue$json = {
   '1': 'FloatValue',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 2, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 2, '10': 'value'},
   ],
 };
 
 /// Descriptor for `FloatValue`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List floatValueDescriptor =
     $convert.base64Decode('CgpGbG9hdFZhbHVlEhQKBXZhbHVlGAEgASgCUgV2YWx1ZQ==');
+
 @$core.Deprecated('Use int64ValueDescriptor instead')
-const Int64Value$json = const {
+const Int64Value$json = {
   '1': 'Int64Value',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 3, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 3, '10': 'value'},
   ],
 };
 
 /// Descriptor for `Int64Value`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List int64ValueDescriptor =
     $convert.base64Decode('CgpJbnQ2NFZhbHVlEhQKBXZhbHVlGAEgASgDUgV2YWx1ZQ==');
+
 @$core.Deprecated('Use uInt64ValueDescriptor instead')
-const UInt64Value$json = const {
+const UInt64Value$json = {
   '1': 'UInt64Value',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 4, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 4, '10': 'value'},
   ],
 };
 
 /// Descriptor for `UInt64Value`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List uInt64ValueDescriptor =
     $convert.base64Decode('CgtVSW50NjRWYWx1ZRIUCgV2YWx1ZRgBIAEoBFIFdmFsdWU=');
+
 @$core.Deprecated('Use int32ValueDescriptor instead')
-const Int32Value$json = const {
+const Int32Value$json = {
   '1': 'Int32Value',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 5, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 5, '10': 'value'},
   ],
 };
 
 /// Descriptor for `Int32Value`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List int32ValueDescriptor =
     $convert.base64Decode('CgpJbnQzMlZhbHVlEhQKBXZhbHVlGAEgASgFUgV2YWx1ZQ==');
+
 @$core.Deprecated('Use uInt32ValueDescriptor instead')
-const UInt32Value$json = const {
+const UInt32Value$json = {
   '1': 'UInt32Value',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 13, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 13, '10': 'value'},
   ],
 };
 
 /// Descriptor for `UInt32Value`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List uInt32ValueDescriptor =
     $convert.base64Decode('CgtVSW50MzJWYWx1ZRIUCgV2YWx1ZRgBIAEoDVIFdmFsdWU=');
+
 @$core.Deprecated('Use boolValueDescriptor instead')
-const BoolValue$json = const {
+const BoolValue$json = {
   '1': 'BoolValue',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 8, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 8, '10': 'value'},
   ],
 };
 
 /// Descriptor for `BoolValue`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List boolValueDescriptor =
     $convert.base64Decode('CglCb29sVmFsdWUSFAoFdmFsdWUYASABKAhSBXZhbHVl');
+
 @$core.Deprecated('Use stringValueDescriptor instead')
-const StringValue$json = const {
+const StringValue$json = {
   '1': 'StringValue',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
   ],
 };
 
 /// Descriptor for `StringValue`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List stringValueDescriptor =
     $convert.base64Decode('CgtTdHJpbmdWYWx1ZRIUCgV2YWx1ZRgBIAEoCVIFdmFsdWU=');
+
 @$core.Deprecated('Use bytesValueDescriptor instead')
-const BytesValue$json = const {
+const BytesValue$json = {
   '1': 'BytesValue',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 12, '10': 'value'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 12, '10': 'value'},
   ],
 };
 

--- a/nakama/lib/src/api/proto/rtapi/realtime.pb.dart
+++ b/nakama/lib/src/api/proto/rtapi/realtime.pb.dart
@@ -1,18 +1,25 @@
-///
-//  Generated code. Do not modify.
-//  source: rtapi/realtime.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from rtapi/realtime.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:core' as $core;
 
 import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import '../api/api.pb.dart' as $2;
+import '../api/api.pb.dart' as $0;
+import '../google/protobuf/timestamp.pb.dart' as $2;
 import '../google/protobuf/wrappers.pb.dart' as $1;
-import '../google/protobuf/timestamp.pb.dart' as $0;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 export 'realtime.pbenum.dart';
 
@@ -66,10 +73,141 @@ enum Envelope_Message {
   partyData,
   partyDataSend,
   partyPresenceEvent,
+  partyUpdate,
   notSet
 }
 
+/// An envelope for a realtime message.
 class Envelope extends $pb.GeneratedMessage {
+  factory Envelope({
+    $core.String? cid,
+    Channel? channel,
+    ChannelJoin? channelJoin,
+    ChannelLeave? channelLeave,
+    $0.ChannelMessage? channelMessage,
+    ChannelMessageAck? channelMessageAck,
+    ChannelMessageSend? channelMessageSend,
+    ChannelMessageUpdate? channelMessageUpdate,
+    ChannelMessageRemove? channelMessageRemove,
+    ChannelPresenceEvent? channelPresenceEvent,
+    Error? error,
+    Match? match,
+    MatchCreate? matchCreate,
+    MatchData? matchData,
+    MatchDataSend? matchDataSend,
+    MatchJoin? matchJoin,
+    MatchLeave? matchLeave,
+    MatchPresenceEvent? matchPresenceEvent,
+    MatchmakerAdd? matchmakerAdd,
+    MatchmakerMatched? matchmakerMatched,
+    MatchmakerRemove? matchmakerRemove,
+    MatchmakerTicket? matchmakerTicket,
+    Notifications? notifications,
+    $0.Rpc? rpc,
+    Status? status,
+    StatusFollow? statusFollow,
+    StatusPresenceEvent? statusPresenceEvent,
+    StatusUnfollow? statusUnfollow,
+    StatusUpdate? statusUpdate,
+    StreamData? streamData,
+    StreamPresenceEvent? streamPresenceEvent,
+    Ping? ping,
+    Pong? pong,
+    Party? party,
+    PartyCreate? partyCreate,
+    PartyJoin? partyJoin,
+    PartyLeave? partyLeave,
+    PartyPromote? partyPromote,
+    PartyLeader? partyLeader,
+    PartyAccept? partyAccept,
+    PartyRemove? partyRemove,
+    PartyClose? partyClose,
+    PartyJoinRequestList? partyJoinRequestList,
+    PartyJoinRequest? partyJoinRequest,
+    PartyMatchmakerAdd? partyMatchmakerAdd,
+    PartyMatchmakerRemove? partyMatchmakerRemove,
+    PartyMatchmakerTicket? partyMatchmakerTicket,
+    PartyData? partyData,
+    PartyDataSend? partyDataSend,
+    PartyPresenceEvent? partyPresenceEvent,
+    PartyUpdate? partyUpdate,
+  }) {
+    final result = create();
+    if (cid != null) result.cid = cid;
+    if (channel != null) result.channel = channel;
+    if (channelJoin != null) result.channelJoin = channelJoin;
+    if (channelLeave != null) result.channelLeave = channelLeave;
+    if (channelMessage != null) result.channelMessage = channelMessage;
+    if (channelMessageAck != null) result.channelMessageAck = channelMessageAck;
+    if (channelMessageSend != null)
+      result.channelMessageSend = channelMessageSend;
+    if (channelMessageUpdate != null)
+      result.channelMessageUpdate = channelMessageUpdate;
+    if (channelMessageRemove != null)
+      result.channelMessageRemove = channelMessageRemove;
+    if (channelPresenceEvent != null)
+      result.channelPresenceEvent = channelPresenceEvent;
+    if (error != null) result.error = error;
+    if (match != null) result.match = match;
+    if (matchCreate != null) result.matchCreate = matchCreate;
+    if (matchData != null) result.matchData = matchData;
+    if (matchDataSend != null) result.matchDataSend = matchDataSend;
+    if (matchJoin != null) result.matchJoin = matchJoin;
+    if (matchLeave != null) result.matchLeave = matchLeave;
+    if (matchPresenceEvent != null)
+      result.matchPresenceEvent = matchPresenceEvent;
+    if (matchmakerAdd != null) result.matchmakerAdd = matchmakerAdd;
+    if (matchmakerMatched != null) result.matchmakerMatched = matchmakerMatched;
+    if (matchmakerRemove != null) result.matchmakerRemove = matchmakerRemove;
+    if (matchmakerTicket != null) result.matchmakerTicket = matchmakerTicket;
+    if (notifications != null) result.notifications = notifications;
+    if (rpc != null) result.rpc = rpc;
+    if (status != null) result.status = status;
+    if (statusFollow != null) result.statusFollow = statusFollow;
+    if (statusPresenceEvent != null)
+      result.statusPresenceEvent = statusPresenceEvent;
+    if (statusUnfollow != null) result.statusUnfollow = statusUnfollow;
+    if (statusUpdate != null) result.statusUpdate = statusUpdate;
+    if (streamData != null) result.streamData = streamData;
+    if (streamPresenceEvent != null)
+      result.streamPresenceEvent = streamPresenceEvent;
+    if (ping != null) result.ping = ping;
+    if (pong != null) result.pong = pong;
+    if (party != null) result.party = party;
+    if (partyCreate != null) result.partyCreate = partyCreate;
+    if (partyJoin != null) result.partyJoin = partyJoin;
+    if (partyLeave != null) result.partyLeave = partyLeave;
+    if (partyPromote != null) result.partyPromote = partyPromote;
+    if (partyLeader != null) result.partyLeader = partyLeader;
+    if (partyAccept != null) result.partyAccept = partyAccept;
+    if (partyRemove != null) result.partyRemove = partyRemove;
+    if (partyClose != null) result.partyClose = partyClose;
+    if (partyJoinRequestList != null)
+      result.partyJoinRequestList = partyJoinRequestList;
+    if (partyJoinRequest != null) result.partyJoinRequest = partyJoinRequest;
+    if (partyMatchmakerAdd != null)
+      result.partyMatchmakerAdd = partyMatchmakerAdd;
+    if (partyMatchmakerRemove != null)
+      result.partyMatchmakerRemove = partyMatchmakerRemove;
+    if (partyMatchmakerTicket != null)
+      result.partyMatchmakerTicket = partyMatchmakerTicket;
+    if (partyData != null) result.partyData = partyData;
+    if (partyDataSend != null) result.partyDataSend = partyDataSend;
+    if (partyPresenceEvent != null)
+      result.partyPresenceEvent = partyPresenceEvent;
+    if (partyUpdate != null) result.partyUpdate = partyUpdate;
+    return result;
+  }
+
+  Envelope._();
+
+  factory Envelope.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Envelope.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static const $core.Map<$core.int, Envelope_Message> _Envelope_MessageByTag = {
     2: Envelope_Message.channel,
     3: Envelope_Message.channelJoin,
@@ -120,16 +258,13 @@ class Envelope extends $pb.GeneratedMessage {
     48: Envelope_Message.partyData,
     49: Envelope_Message.partyDataSend,
     50: Envelope_Message.partyPresenceEvent,
+    51: Envelope_Message.partyUpdate,
     0: Envelope_Message.notSet
   };
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Envelope',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'Envelope',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
     ..oo(0, [
       2,
@@ -180,534 +315,124 @@ class Envelope extends $pb.GeneratedMessage {
       47,
       48,
       49,
-      50
+      50,
+      51
     ])
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'cid')
-    ..aOM<Channel>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channel',
+    ..aOS(1, _omitFieldNames ? '' : 'cid')
+    ..aOM<Channel>(2, _omitFieldNames ? '' : 'channel',
         subBuilder: Channel.create)
-    ..aOM<ChannelJoin>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelJoin',
+    ..aOM<ChannelJoin>(3, _omitFieldNames ? '' : 'channelJoin',
         subBuilder: ChannelJoin.create)
-    ..aOM<ChannelLeave>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelLeave',
+    ..aOM<ChannelLeave>(4, _omitFieldNames ? '' : 'channelLeave',
         subBuilder: ChannelLeave.create)
-    ..aOM<$2.ChannelMessage>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelMessage',
-        subBuilder: $2.ChannelMessage.create)
-    ..aOM<ChannelMessageAck>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelMessageAck',
+    ..aOM<$0.ChannelMessage>(5, _omitFieldNames ? '' : 'channelMessage',
+        subBuilder: $0.ChannelMessage.create)
+    ..aOM<ChannelMessageAck>(6, _omitFieldNames ? '' : 'channelMessageAck',
         subBuilder: ChannelMessageAck.create)
-    ..aOM<ChannelMessageSend>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelMessageSend',
+    ..aOM<ChannelMessageSend>(7, _omitFieldNames ? '' : 'channelMessageSend',
         subBuilder: ChannelMessageSend.create)
     ..aOM<ChannelMessageUpdate>(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelMessageUpdate',
+        8, _omitFieldNames ? '' : 'channelMessageUpdate',
         subBuilder: ChannelMessageUpdate.create)
     ..aOM<ChannelMessageRemove>(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelMessageRemove',
+        9, _omitFieldNames ? '' : 'channelMessageRemove',
         subBuilder: ChannelMessageRemove.create)
     ..aOM<ChannelPresenceEvent>(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelPresenceEvent',
+        10, _omitFieldNames ? '' : 'channelPresenceEvent',
         subBuilder: ChannelPresenceEvent.create)
-    ..aOM<Error>(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'error',
-        subBuilder: Error.create)
-    ..aOM<Match>(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'match',
-        subBuilder: Match.create)
-    ..aOM<MatchCreate>(
-        13,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchCreate',
+    ..aOM<Error>(11, _omitFieldNames ? '' : 'error', subBuilder: Error.create)
+    ..aOM<Match>(12, _omitFieldNames ? '' : 'match', subBuilder: Match.create)
+    ..aOM<MatchCreate>(13, _omitFieldNames ? '' : 'matchCreate',
         subBuilder: MatchCreate.create)
-    ..aOM<MatchData>(
-        14,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchData',
+    ..aOM<MatchData>(14, _omitFieldNames ? '' : 'matchData',
         subBuilder: MatchData.create)
-    ..aOM<MatchDataSend>(
-        15,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchDataSend',
+    ..aOM<MatchDataSend>(15, _omitFieldNames ? '' : 'matchDataSend',
         subBuilder: MatchDataSend.create)
-    ..aOM<MatchJoin>(
-        16,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchJoin',
+    ..aOM<MatchJoin>(16, _omitFieldNames ? '' : 'matchJoin',
         subBuilder: MatchJoin.create)
-    ..aOM<MatchLeave>(
-        17,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchLeave',
+    ..aOM<MatchLeave>(17, _omitFieldNames ? '' : 'matchLeave',
         subBuilder: MatchLeave.create)
-    ..aOM<MatchPresenceEvent>(
-        18,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchPresenceEvent',
+    ..aOM<MatchPresenceEvent>(18, _omitFieldNames ? '' : 'matchPresenceEvent',
         subBuilder: MatchPresenceEvent.create)
-    ..aOM<MatchmakerAdd>(
-        19,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchmakerAdd',
+    ..aOM<MatchmakerAdd>(19, _omitFieldNames ? '' : 'matchmakerAdd',
         subBuilder: MatchmakerAdd.create)
-    ..aOM<MatchmakerMatched>(
-        20,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchmakerMatched',
+    ..aOM<MatchmakerMatched>(20, _omitFieldNames ? '' : 'matchmakerMatched',
         subBuilder: MatchmakerMatched.create)
-    ..aOM<MatchmakerRemove>(
-        21,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchmakerRemove',
+    ..aOM<MatchmakerRemove>(21, _omitFieldNames ? '' : 'matchmakerRemove',
         subBuilder: MatchmakerRemove.create)
-    ..aOM<MatchmakerTicket>(
-        22,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchmakerTicket',
+    ..aOM<MatchmakerTicket>(22, _omitFieldNames ? '' : 'matchmakerTicket',
         subBuilder: MatchmakerTicket.create)
-    ..aOM<Notifications>(
-        23,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'notifications',
+    ..aOM<Notifications>(23, _omitFieldNames ? '' : 'notifications',
         subBuilder: Notifications.create)
-    ..aOM<$2.Rpc>(
-        24,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'rpc',
-        subBuilder: $2.Rpc.create)
-    ..aOM<Status>(
-        25,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'status',
+    ..aOM<$0.Rpc>(24, _omitFieldNames ? '' : 'rpc', subBuilder: $0.Rpc.create)
+    ..aOM<Status>(25, _omitFieldNames ? '' : 'status',
         subBuilder: Status.create)
-    ..aOM<StatusFollow>(
-        26,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'statusFollow',
+    ..aOM<StatusFollow>(26, _omitFieldNames ? '' : 'statusFollow',
         subBuilder: StatusFollow.create)
-    ..aOM<StatusPresenceEvent>(
-        27,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'statusPresenceEvent',
+    ..aOM<StatusPresenceEvent>(27, _omitFieldNames ? '' : 'statusPresenceEvent',
         subBuilder: StatusPresenceEvent.create)
-    ..aOM<StatusUnfollow>(
-        28,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'statusUnfollow',
+    ..aOM<StatusUnfollow>(28, _omitFieldNames ? '' : 'statusUnfollow',
         subBuilder: StatusUnfollow.create)
-    ..aOM<StatusUpdate>(
-        29,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'statusUpdate',
+    ..aOM<StatusUpdate>(29, _omitFieldNames ? '' : 'statusUpdate',
         subBuilder: StatusUpdate.create)
-    ..aOM<StreamData>(
-        30,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'streamData',
+    ..aOM<StreamData>(30, _omitFieldNames ? '' : 'streamData',
         subBuilder: StreamData.create)
-    ..aOM<StreamPresenceEvent>(
-        31,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'streamPresenceEvent',
+    ..aOM<StreamPresenceEvent>(31, _omitFieldNames ? '' : 'streamPresenceEvent',
         subBuilder: StreamPresenceEvent.create)
-    ..aOM<Ping>(
-        32,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ping',
-        subBuilder: Ping.create)
-    ..aOM<Pong>(
-        33,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'pong',
-        subBuilder: Pong.create)
-    ..aOM<Party>(
-        34,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'party',
-        subBuilder: Party.create)
-    ..aOM<PartyCreate>(
-        35,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyCreate',
+    ..aOM<Ping>(32, _omitFieldNames ? '' : 'ping', subBuilder: Ping.create)
+    ..aOM<Pong>(33, _omitFieldNames ? '' : 'pong', subBuilder: Pong.create)
+    ..aOM<Party>(34, _omitFieldNames ? '' : 'party', subBuilder: Party.create)
+    ..aOM<PartyCreate>(35, _omitFieldNames ? '' : 'partyCreate',
         subBuilder: PartyCreate.create)
-    ..aOM<PartyJoin>(
-        36,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyJoin',
+    ..aOM<PartyJoin>(36, _omitFieldNames ? '' : 'partyJoin',
         subBuilder: PartyJoin.create)
-    ..aOM<PartyLeave>(
-        37,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyLeave',
+    ..aOM<PartyLeave>(37, _omitFieldNames ? '' : 'partyLeave',
         subBuilder: PartyLeave.create)
-    ..aOM<PartyPromote>(
-        38,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyPromote',
+    ..aOM<PartyPromote>(38, _omitFieldNames ? '' : 'partyPromote',
         subBuilder: PartyPromote.create)
-    ..aOM<PartyLeader>(
-        39,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyLeader',
+    ..aOM<PartyLeader>(39, _omitFieldNames ? '' : 'partyLeader',
         subBuilder: PartyLeader.create)
-    ..aOM<PartyAccept>(
-        40,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyAccept',
+    ..aOM<PartyAccept>(40, _omitFieldNames ? '' : 'partyAccept',
         subBuilder: PartyAccept.create)
-    ..aOM<PartyRemove>(
-        41,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyRemove',
+    ..aOM<PartyRemove>(41, _omitFieldNames ? '' : 'partyRemove',
         subBuilder: PartyRemove.create)
-    ..aOM<PartyClose>(
-        42,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyClose',
+    ..aOM<PartyClose>(42, _omitFieldNames ? '' : 'partyClose',
         subBuilder: PartyClose.create)
     ..aOM<PartyJoinRequestList>(
-        43,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyJoinRequestList',
+        43, _omitFieldNames ? '' : 'partyJoinRequestList',
         subBuilder: PartyJoinRequestList.create)
-    ..aOM<PartyJoinRequest>(
-        44,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyJoinRequest',
+    ..aOM<PartyJoinRequest>(44, _omitFieldNames ? '' : 'partyJoinRequest',
         subBuilder: PartyJoinRequest.create)
-    ..aOM<PartyMatchmakerAdd>(
-        45,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyMatchmakerAdd',
+    ..aOM<PartyMatchmakerAdd>(45, _omitFieldNames ? '' : 'partyMatchmakerAdd',
         subBuilder: PartyMatchmakerAdd.create)
     ..aOM<PartyMatchmakerRemove>(
-        46,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyMatchmakerRemove',
+        46, _omitFieldNames ? '' : 'partyMatchmakerRemove',
         subBuilder: PartyMatchmakerRemove.create)
     ..aOM<PartyMatchmakerTicket>(
-        47,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyMatchmakerTicket',
+        47, _omitFieldNames ? '' : 'partyMatchmakerTicket',
         subBuilder: PartyMatchmakerTicket.create)
-    ..aOM<PartyData>(
-        48,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyData',
+    ..aOM<PartyData>(48, _omitFieldNames ? '' : 'partyData',
         subBuilder: PartyData.create)
-    ..aOM<PartyDataSend>(
-        49,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyDataSend',
+    ..aOM<PartyDataSend>(49, _omitFieldNames ? '' : 'partyDataSend',
         subBuilder: PartyDataSend.create)
-    ..aOM<PartyPresenceEvent>(
-        50,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyPresenceEvent',
+    ..aOM<PartyPresenceEvent>(50, _omitFieldNames ? '' : 'partyPresenceEvent',
         subBuilder: PartyPresenceEvent.create)
+    ..aOM<PartyUpdate>(51, _omitFieldNames ? '' : 'partyUpdate',
+        subBuilder: PartyUpdate.create)
     ..hasRequiredFields = false;
 
-  Envelope._() : super();
-  factory Envelope({
-    $core.String? cid,
-    Channel? channel,
-    ChannelJoin? channelJoin,
-    ChannelLeave? channelLeave,
-    $2.ChannelMessage? channelMessage,
-    ChannelMessageAck? channelMessageAck,
-    ChannelMessageSend? channelMessageSend,
-    ChannelMessageUpdate? channelMessageUpdate,
-    ChannelMessageRemove? channelMessageRemove,
-    ChannelPresenceEvent? channelPresenceEvent,
-    Error? error,
-    Match? match,
-    MatchCreate? matchCreate,
-    MatchData? matchData,
-    MatchDataSend? matchDataSend,
-    MatchJoin? matchJoin,
-    MatchLeave? matchLeave,
-    MatchPresenceEvent? matchPresenceEvent,
-    MatchmakerAdd? matchmakerAdd,
-    MatchmakerMatched? matchmakerMatched,
-    MatchmakerRemove? matchmakerRemove,
-    MatchmakerTicket? matchmakerTicket,
-    Notifications? notifications,
-    $2.Rpc? rpc,
-    Status? status,
-    StatusFollow? statusFollow,
-    StatusPresenceEvent? statusPresenceEvent,
-    StatusUnfollow? statusUnfollow,
-    StatusUpdate? statusUpdate,
-    StreamData? streamData,
-    StreamPresenceEvent? streamPresenceEvent,
-    Ping? ping,
-    Pong? pong,
-    Party? party,
-    PartyCreate? partyCreate,
-    PartyJoin? partyJoin,
-    PartyLeave? partyLeave,
-    PartyPromote? partyPromote,
-    PartyLeader? partyLeader,
-    PartyAccept? partyAccept,
-    PartyRemove? partyRemove,
-    PartyClose? partyClose,
-    PartyJoinRequestList? partyJoinRequestList,
-    PartyJoinRequest? partyJoinRequest,
-    PartyMatchmakerAdd? partyMatchmakerAdd,
-    PartyMatchmakerRemove? partyMatchmakerRemove,
-    PartyMatchmakerTicket? partyMatchmakerTicket,
-    PartyData? partyData,
-    PartyDataSend? partyDataSend,
-    PartyPresenceEvent? partyPresenceEvent,
-  }) {
-    final _result = create();
-    if (cid != null) {
-      _result.cid = cid;
-    }
-    if (channel != null) {
-      _result.channel = channel;
-    }
-    if (channelJoin != null) {
-      _result.channelJoin = channelJoin;
-    }
-    if (channelLeave != null) {
-      _result.channelLeave = channelLeave;
-    }
-    if (channelMessage != null) {
-      _result.channelMessage = channelMessage;
-    }
-    if (channelMessageAck != null) {
-      _result.channelMessageAck = channelMessageAck;
-    }
-    if (channelMessageSend != null) {
-      _result.channelMessageSend = channelMessageSend;
-    }
-    if (channelMessageUpdate != null) {
-      _result.channelMessageUpdate = channelMessageUpdate;
-    }
-    if (channelMessageRemove != null) {
-      _result.channelMessageRemove = channelMessageRemove;
-    }
-    if (channelPresenceEvent != null) {
-      _result.channelPresenceEvent = channelPresenceEvent;
-    }
-    if (error != null) {
-      _result.error = error;
-    }
-    if (match != null) {
-      _result.match = match;
-    }
-    if (matchCreate != null) {
-      _result.matchCreate = matchCreate;
-    }
-    if (matchData != null) {
-      _result.matchData = matchData;
-    }
-    if (matchDataSend != null) {
-      _result.matchDataSend = matchDataSend;
-    }
-    if (matchJoin != null) {
-      _result.matchJoin = matchJoin;
-    }
-    if (matchLeave != null) {
-      _result.matchLeave = matchLeave;
-    }
-    if (matchPresenceEvent != null) {
-      _result.matchPresenceEvent = matchPresenceEvent;
-    }
-    if (matchmakerAdd != null) {
-      _result.matchmakerAdd = matchmakerAdd;
-    }
-    if (matchmakerMatched != null) {
-      _result.matchmakerMatched = matchmakerMatched;
-    }
-    if (matchmakerRemove != null) {
-      _result.matchmakerRemove = matchmakerRemove;
-    }
-    if (matchmakerTicket != null) {
-      _result.matchmakerTicket = matchmakerTicket;
-    }
-    if (notifications != null) {
-      _result.notifications = notifications;
-    }
-    if (rpc != null) {
-      _result.rpc = rpc;
-    }
-    if (status != null) {
-      _result.status = status;
-    }
-    if (statusFollow != null) {
-      _result.statusFollow = statusFollow;
-    }
-    if (statusPresenceEvent != null) {
-      _result.statusPresenceEvent = statusPresenceEvent;
-    }
-    if (statusUnfollow != null) {
-      _result.statusUnfollow = statusUnfollow;
-    }
-    if (statusUpdate != null) {
-      _result.statusUpdate = statusUpdate;
-    }
-    if (streamData != null) {
-      _result.streamData = streamData;
-    }
-    if (streamPresenceEvent != null) {
-      _result.streamPresenceEvent = streamPresenceEvent;
-    }
-    if (ping != null) {
-      _result.ping = ping;
-    }
-    if (pong != null) {
-      _result.pong = pong;
-    }
-    if (party != null) {
-      _result.party = party;
-    }
-    if (partyCreate != null) {
-      _result.partyCreate = partyCreate;
-    }
-    if (partyJoin != null) {
-      _result.partyJoin = partyJoin;
-    }
-    if (partyLeave != null) {
-      _result.partyLeave = partyLeave;
-    }
-    if (partyPromote != null) {
-      _result.partyPromote = partyPromote;
-    }
-    if (partyLeader != null) {
-      _result.partyLeader = partyLeader;
-    }
-    if (partyAccept != null) {
-      _result.partyAccept = partyAccept;
-    }
-    if (partyRemove != null) {
-      _result.partyRemove = partyRemove;
-    }
-    if (partyClose != null) {
-      _result.partyClose = partyClose;
-    }
-    if (partyJoinRequestList != null) {
-      _result.partyJoinRequestList = partyJoinRequestList;
-    }
-    if (partyJoinRequest != null) {
-      _result.partyJoinRequest = partyJoinRequest;
-    }
-    if (partyMatchmakerAdd != null) {
-      _result.partyMatchmakerAdd = partyMatchmakerAdd;
-    }
-    if (partyMatchmakerRemove != null) {
-      _result.partyMatchmakerRemove = partyMatchmakerRemove;
-    }
-    if (partyMatchmakerTicket != null) {
-      _result.partyMatchmakerTicket = partyMatchmakerTicket;
-    }
-    if (partyData != null) {
-      _result.partyData = partyData;
-    }
-    if (partyDataSend != null) {
-      _result.partyDataSend = partyDataSend;
-    }
-    if (partyPresenceEvent != null) {
-      _result.partyPresenceEvent = partyPresenceEvent;
-    }
-    return _result;
-  }
-  factory Envelope.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Envelope.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Envelope clone() => Envelope()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Envelope clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Envelope copyWith(void Function(Envelope) updates) =>
-      super.copyWith((message) => updates(message as Envelope))
-          as Envelope; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Envelope)) as Envelope;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Envelope create() => Envelope._();
+  @$core.override
   Envelope createEmptyInstance() => create();
   static $pb.PbList<Envelope> createRepeated() => $pb.PbList<Envelope>();
   @$core.pragma('dart2js:noInline')
@@ -715,759 +440,723 @@ class Envelope extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Envelope>(create);
   static Envelope? _defaultInstance;
 
+  @$pb.TagNumber(2)
+  @$pb.TagNumber(3)
+  @$pb.TagNumber(4)
+  @$pb.TagNumber(5)
+  @$pb.TagNumber(6)
+  @$pb.TagNumber(7)
+  @$pb.TagNumber(8)
+  @$pb.TagNumber(9)
+  @$pb.TagNumber(10)
+  @$pb.TagNumber(11)
+  @$pb.TagNumber(12)
+  @$pb.TagNumber(13)
+  @$pb.TagNumber(14)
+  @$pb.TagNumber(15)
+  @$pb.TagNumber(16)
+  @$pb.TagNumber(17)
+  @$pb.TagNumber(18)
+  @$pb.TagNumber(19)
+  @$pb.TagNumber(20)
+  @$pb.TagNumber(21)
+  @$pb.TagNumber(22)
+  @$pb.TagNumber(23)
+  @$pb.TagNumber(24)
+  @$pb.TagNumber(25)
+  @$pb.TagNumber(26)
+  @$pb.TagNumber(27)
+  @$pb.TagNumber(28)
+  @$pb.TagNumber(29)
+  @$pb.TagNumber(30)
+  @$pb.TagNumber(31)
+  @$pb.TagNumber(32)
+  @$pb.TagNumber(33)
+  @$pb.TagNumber(34)
+  @$pb.TagNumber(35)
+  @$pb.TagNumber(36)
+  @$pb.TagNumber(37)
+  @$pb.TagNumber(38)
+  @$pb.TagNumber(39)
+  @$pb.TagNumber(40)
+  @$pb.TagNumber(41)
+  @$pb.TagNumber(42)
+  @$pb.TagNumber(43)
+  @$pb.TagNumber(44)
+  @$pb.TagNumber(45)
+  @$pb.TagNumber(46)
+  @$pb.TagNumber(47)
+  @$pb.TagNumber(48)
+  @$pb.TagNumber(49)
+  @$pb.TagNumber(50)
+  @$pb.TagNumber(51)
   Envelope_Message whichMessage() => _Envelope_MessageByTag[$_whichOneof(0)]!;
-  void clearMessage() => clearField($_whichOneof(0));
+  @$pb.TagNumber(2)
+  @$pb.TagNumber(3)
+  @$pb.TagNumber(4)
+  @$pb.TagNumber(5)
+  @$pb.TagNumber(6)
+  @$pb.TagNumber(7)
+  @$pb.TagNumber(8)
+  @$pb.TagNumber(9)
+  @$pb.TagNumber(10)
+  @$pb.TagNumber(11)
+  @$pb.TagNumber(12)
+  @$pb.TagNumber(13)
+  @$pb.TagNumber(14)
+  @$pb.TagNumber(15)
+  @$pb.TagNumber(16)
+  @$pb.TagNumber(17)
+  @$pb.TagNumber(18)
+  @$pb.TagNumber(19)
+  @$pb.TagNumber(20)
+  @$pb.TagNumber(21)
+  @$pb.TagNumber(22)
+  @$pb.TagNumber(23)
+  @$pb.TagNumber(24)
+  @$pb.TagNumber(25)
+  @$pb.TagNumber(26)
+  @$pb.TagNumber(27)
+  @$pb.TagNumber(28)
+  @$pb.TagNumber(29)
+  @$pb.TagNumber(30)
+  @$pb.TagNumber(31)
+  @$pb.TagNumber(32)
+  @$pb.TagNumber(33)
+  @$pb.TagNumber(34)
+  @$pb.TagNumber(35)
+  @$pb.TagNumber(36)
+  @$pb.TagNumber(37)
+  @$pb.TagNumber(38)
+  @$pb.TagNumber(39)
+  @$pb.TagNumber(40)
+  @$pb.TagNumber(41)
+  @$pb.TagNumber(42)
+  @$pb.TagNumber(43)
+  @$pb.TagNumber(44)
+  @$pb.TagNumber(45)
+  @$pb.TagNumber(46)
+  @$pb.TagNumber(47)
+  @$pb.TagNumber(48)
+  @$pb.TagNumber(49)
+  @$pb.TagNumber(50)
+  @$pb.TagNumber(51)
+  void clearMessage() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
   $core.String get cid => $_getSZ(0);
   @$pb.TagNumber(1)
-  set cid($core.String v) {
-    $_setString(0, v);
-  }
-
+  set cid($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCid() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCid() => clearField(1);
+  void clearCid() => $_clearField(1);
 
+  /// A response from a channel join operation.
   @$pb.TagNumber(2)
   Channel get channel => $_getN(1);
   @$pb.TagNumber(2)
-  set channel(Channel v) {
-    setField(2, v);
-  }
-
+  set channel(Channel value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasChannel() => $_has(1);
   @$pb.TagNumber(2)
-  void clearChannel() => clearField(2);
+  void clearChannel() => $_clearField(2);
   @$pb.TagNumber(2)
   Channel ensureChannel() => $_ensure(1);
 
+  /// Join a realtime chat channel.
   @$pb.TagNumber(3)
   ChannelJoin get channelJoin => $_getN(2);
   @$pb.TagNumber(3)
-  set channelJoin(ChannelJoin v) {
-    setField(3, v);
-  }
-
+  set channelJoin(ChannelJoin value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasChannelJoin() => $_has(2);
   @$pb.TagNumber(3)
-  void clearChannelJoin() => clearField(3);
+  void clearChannelJoin() => $_clearField(3);
   @$pb.TagNumber(3)
   ChannelJoin ensureChannelJoin() => $_ensure(2);
 
+  /// Leave a realtime chat channel.
   @$pb.TagNumber(4)
   ChannelLeave get channelLeave => $_getN(3);
   @$pb.TagNumber(4)
-  set channelLeave(ChannelLeave v) {
-    setField(4, v);
-  }
-
+  set channelLeave(ChannelLeave value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasChannelLeave() => $_has(3);
   @$pb.TagNumber(4)
-  void clearChannelLeave() => clearField(4);
+  void clearChannelLeave() => $_clearField(4);
   @$pb.TagNumber(4)
   ChannelLeave ensureChannelLeave() => $_ensure(3);
 
+  /// An incoming message on a realtime chat channel.
   @$pb.TagNumber(5)
-  $2.ChannelMessage get channelMessage => $_getN(4);
+  $0.ChannelMessage get channelMessage => $_getN(4);
   @$pb.TagNumber(5)
-  set channelMessage($2.ChannelMessage v) {
-    setField(5, v);
-  }
-
+  set channelMessage($0.ChannelMessage value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasChannelMessage() => $_has(4);
   @$pb.TagNumber(5)
-  void clearChannelMessage() => clearField(5);
+  void clearChannelMessage() => $_clearField(5);
   @$pb.TagNumber(5)
-  $2.ChannelMessage ensureChannelMessage() => $_ensure(4);
+  $0.ChannelMessage ensureChannelMessage() => $_ensure(4);
 
+  /// An acknowledgement received in response to sending a message on a chat channel.
   @$pb.TagNumber(6)
   ChannelMessageAck get channelMessageAck => $_getN(5);
   @$pb.TagNumber(6)
-  set channelMessageAck(ChannelMessageAck v) {
-    setField(6, v);
-  }
-
+  set channelMessageAck(ChannelMessageAck value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasChannelMessageAck() => $_has(5);
   @$pb.TagNumber(6)
-  void clearChannelMessageAck() => clearField(6);
+  void clearChannelMessageAck() => $_clearField(6);
   @$pb.TagNumber(6)
   ChannelMessageAck ensureChannelMessageAck() => $_ensure(5);
 
+  /// Send a message to a realtime chat channel.
   @$pb.TagNumber(7)
   ChannelMessageSend get channelMessageSend => $_getN(6);
   @$pb.TagNumber(7)
-  set channelMessageSend(ChannelMessageSend v) {
-    setField(7, v);
-  }
-
+  set channelMessageSend(ChannelMessageSend value) => $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasChannelMessageSend() => $_has(6);
   @$pb.TagNumber(7)
-  void clearChannelMessageSend() => clearField(7);
+  void clearChannelMessageSend() => $_clearField(7);
   @$pb.TagNumber(7)
   ChannelMessageSend ensureChannelMessageSend() => $_ensure(6);
 
+  /// Update a message previously sent to a realtime chat channel.
   @$pb.TagNumber(8)
   ChannelMessageUpdate get channelMessageUpdate => $_getN(7);
   @$pb.TagNumber(8)
-  set channelMessageUpdate(ChannelMessageUpdate v) {
-    setField(8, v);
-  }
-
+  set channelMessageUpdate(ChannelMessageUpdate value) => $_setField(8, value);
   @$pb.TagNumber(8)
   $core.bool hasChannelMessageUpdate() => $_has(7);
   @$pb.TagNumber(8)
-  void clearChannelMessageUpdate() => clearField(8);
+  void clearChannelMessageUpdate() => $_clearField(8);
   @$pb.TagNumber(8)
   ChannelMessageUpdate ensureChannelMessageUpdate() => $_ensure(7);
 
+  /// Remove a message previously sent to a realtime chat channel.
   @$pb.TagNumber(9)
   ChannelMessageRemove get channelMessageRemove => $_getN(8);
   @$pb.TagNumber(9)
-  set channelMessageRemove(ChannelMessageRemove v) {
-    setField(9, v);
-  }
-
+  set channelMessageRemove(ChannelMessageRemove value) => $_setField(9, value);
   @$pb.TagNumber(9)
   $core.bool hasChannelMessageRemove() => $_has(8);
   @$pb.TagNumber(9)
-  void clearChannelMessageRemove() => clearField(9);
+  void clearChannelMessageRemove() => $_clearField(9);
   @$pb.TagNumber(9)
   ChannelMessageRemove ensureChannelMessageRemove() => $_ensure(8);
 
+  /// Presence update for a particular realtime chat channel.
   @$pb.TagNumber(10)
   ChannelPresenceEvent get channelPresenceEvent => $_getN(9);
   @$pb.TagNumber(10)
-  set channelPresenceEvent(ChannelPresenceEvent v) {
-    setField(10, v);
-  }
-
+  set channelPresenceEvent(ChannelPresenceEvent value) => $_setField(10, value);
   @$pb.TagNumber(10)
   $core.bool hasChannelPresenceEvent() => $_has(9);
   @$pb.TagNumber(10)
-  void clearChannelPresenceEvent() => clearField(10);
+  void clearChannelPresenceEvent() => $_clearField(10);
   @$pb.TagNumber(10)
   ChannelPresenceEvent ensureChannelPresenceEvent() => $_ensure(9);
 
+  /// Describes an error which occurred on the server.
   @$pb.TagNumber(11)
   Error get error => $_getN(10);
   @$pb.TagNumber(11)
-  set error(Error v) {
-    setField(11, v);
-  }
-
+  set error(Error value) => $_setField(11, value);
   @$pb.TagNumber(11)
   $core.bool hasError() => $_has(10);
   @$pb.TagNumber(11)
-  void clearError() => clearField(11);
+  void clearError() => $_clearField(11);
   @$pb.TagNumber(11)
   Error ensureError() => $_ensure(10);
 
+  /// Incoming information about a realtime match.
   @$pb.TagNumber(12)
   Match get match => $_getN(11);
   @$pb.TagNumber(12)
-  set match(Match v) {
-    setField(12, v);
-  }
-
+  set match(Match value) => $_setField(12, value);
   @$pb.TagNumber(12)
   $core.bool hasMatch() => $_has(11);
   @$pb.TagNumber(12)
-  void clearMatch() => clearField(12);
+  void clearMatch() => $_clearField(12);
   @$pb.TagNumber(12)
   Match ensureMatch() => $_ensure(11);
 
+  /// A client to server request to create a realtime match.
   @$pb.TagNumber(13)
   MatchCreate get matchCreate => $_getN(12);
   @$pb.TagNumber(13)
-  set matchCreate(MatchCreate v) {
-    setField(13, v);
-  }
-
+  set matchCreate(MatchCreate value) => $_setField(13, value);
   @$pb.TagNumber(13)
   $core.bool hasMatchCreate() => $_has(12);
   @$pb.TagNumber(13)
-  void clearMatchCreate() => clearField(13);
+  void clearMatchCreate() => $_clearField(13);
   @$pb.TagNumber(13)
   MatchCreate ensureMatchCreate() => $_ensure(12);
 
+  /// Incoming realtime match data delivered from the server.
   @$pb.TagNumber(14)
   MatchData get matchData => $_getN(13);
   @$pb.TagNumber(14)
-  set matchData(MatchData v) {
-    setField(14, v);
-  }
-
+  set matchData(MatchData value) => $_setField(14, value);
   @$pb.TagNumber(14)
   $core.bool hasMatchData() => $_has(13);
   @$pb.TagNumber(14)
-  void clearMatchData() => clearField(14);
+  void clearMatchData() => $_clearField(14);
   @$pb.TagNumber(14)
   MatchData ensureMatchData() => $_ensure(13);
 
+  /// A client to server request to send data to a realtime match.
   @$pb.TagNumber(15)
   MatchDataSend get matchDataSend => $_getN(14);
   @$pb.TagNumber(15)
-  set matchDataSend(MatchDataSend v) {
-    setField(15, v);
-  }
-
+  set matchDataSend(MatchDataSend value) => $_setField(15, value);
   @$pb.TagNumber(15)
   $core.bool hasMatchDataSend() => $_has(14);
   @$pb.TagNumber(15)
-  void clearMatchDataSend() => clearField(15);
+  void clearMatchDataSend() => $_clearField(15);
   @$pb.TagNumber(15)
   MatchDataSend ensureMatchDataSend() => $_ensure(14);
 
+  /// A client to server request to join a realtime match.
   @$pb.TagNumber(16)
   MatchJoin get matchJoin => $_getN(15);
   @$pb.TagNumber(16)
-  set matchJoin(MatchJoin v) {
-    setField(16, v);
-  }
-
+  set matchJoin(MatchJoin value) => $_setField(16, value);
   @$pb.TagNumber(16)
   $core.bool hasMatchJoin() => $_has(15);
   @$pb.TagNumber(16)
-  void clearMatchJoin() => clearField(16);
+  void clearMatchJoin() => $_clearField(16);
   @$pb.TagNumber(16)
   MatchJoin ensureMatchJoin() => $_ensure(15);
 
+  /// A client to server request to leave a realtime match.
   @$pb.TagNumber(17)
   MatchLeave get matchLeave => $_getN(16);
   @$pb.TagNumber(17)
-  set matchLeave(MatchLeave v) {
-    setField(17, v);
-  }
-
+  set matchLeave(MatchLeave value) => $_setField(17, value);
   @$pb.TagNumber(17)
   $core.bool hasMatchLeave() => $_has(16);
   @$pb.TagNumber(17)
-  void clearMatchLeave() => clearField(17);
+  void clearMatchLeave() => $_clearField(17);
   @$pb.TagNumber(17)
   MatchLeave ensureMatchLeave() => $_ensure(16);
 
+  /// Presence update for a particular realtime match.
   @$pb.TagNumber(18)
   MatchPresenceEvent get matchPresenceEvent => $_getN(17);
   @$pb.TagNumber(18)
-  set matchPresenceEvent(MatchPresenceEvent v) {
-    setField(18, v);
-  }
-
+  set matchPresenceEvent(MatchPresenceEvent value) => $_setField(18, value);
   @$pb.TagNumber(18)
   $core.bool hasMatchPresenceEvent() => $_has(17);
   @$pb.TagNumber(18)
-  void clearMatchPresenceEvent() => clearField(18);
+  void clearMatchPresenceEvent() => $_clearField(18);
   @$pb.TagNumber(18)
   MatchPresenceEvent ensureMatchPresenceEvent() => $_ensure(17);
 
+  /// Submit a new matchmaking process request.
   @$pb.TagNumber(19)
   MatchmakerAdd get matchmakerAdd => $_getN(18);
   @$pb.TagNumber(19)
-  set matchmakerAdd(MatchmakerAdd v) {
-    setField(19, v);
-  }
-
+  set matchmakerAdd(MatchmakerAdd value) => $_setField(19, value);
   @$pb.TagNumber(19)
   $core.bool hasMatchmakerAdd() => $_has(18);
   @$pb.TagNumber(19)
-  void clearMatchmakerAdd() => clearField(19);
+  void clearMatchmakerAdd() => $_clearField(19);
   @$pb.TagNumber(19)
   MatchmakerAdd ensureMatchmakerAdd() => $_ensure(18);
 
+  /// A successful matchmaking result.
   @$pb.TagNumber(20)
   MatchmakerMatched get matchmakerMatched => $_getN(19);
   @$pb.TagNumber(20)
-  set matchmakerMatched(MatchmakerMatched v) {
-    setField(20, v);
-  }
-
+  set matchmakerMatched(MatchmakerMatched value) => $_setField(20, value);
   @$pb.TagNumber(20)
   $core.bool hasMatchmakerMatched() => $_has(19);
   @$pb.TagNumber(20)
-  void clearMatchmakerMatched() => clearField(20);
+  void clearMatchmakerMatched() => $_clearField(20);
   @$pb.TagNumber(20)
   MatchmakerMatched ensureMatchmakerMatched() => $_ensure(19);
 
+  /// Cancel a matchmaking process using a ticket.
   @$pb.TagNumber(21)
   MatchmakerRemove get matchmakerRemove => $_getN(20);
   @$pb.TagNumber(21)
-  set matchmakerRemove(MatchmakerRemove v) {
-    setField(21, v);
-  }
-
+  set matchmakerRemove(MatchmakerRemove value) => $_setField(21, value);
   @$pb.TagNumber(21)
   $core.bool hasMatchmakerRemove() => $_has(20);
   @$pb.TagNumber(21)
-  void clearMatchmakerRemove() => clearField(21);
+  void clearMatchmakerRemove() => $_clearField(21);
   @$pb.TagNumber(21)
   MatchmakerRemove ensureMatchmakerRemove() => $_ensure(20);
 
+  /// A response from starting a new matchmaking process.
   @$pb.TagNumber(22)
   MatchmakerTicket get matchmakerTicket => $_getN(21);
   @$pb.TagNumber(22)
-  set matchmakerTicket(MatchmakerTicket v) {
-    setField(22, v);
-  }
-
+  set matchmakerTicket(MatchmakerTicket value) => $_setField(22, value);
   @$pb.TagNumber(22)
   $core.bool hasMatchmakerTicket() => $_has(21);
   @$pb.TagNumber(22)
-  void clearMatchmakerTicket() => clearField(22);
+  void clearMatchmakerTicket() => $_clearField(22);
   @$pb.TagNumber(22)
   MatchmakerTicket ensureMatchmakerTicket() => $_ensure(21);
 
+  /// Notifications send by the server.
   @$pb.TagNumber(23)
   Notifications get notifications => $_getN(22);
   @$pb.TagNumber(23)
-  set notifications(Notifications v) {
-    setField(23, v);
-  }
-
+  set notifications(Notifications value) => $_setField(23, value);
   @$pb.TagNumber(23)
   $core.bool hasNotifications() => $_has(22);
   @$pb.TagNumber(23)
-  void clearNotifications() => clearField(23);
+  void clearNotifications() => $_clearField(23);
   @$pb.TagNumber(23)
   Notifications ensureNotifications() => $_ensure(22);
 
+  /// RPC call or response.
   @$pb.TagNumber(24)
-  $2.Rpc get rpc => $_getN(23);
+  $0.Rpc get rpc => $_getN(23);
   @$pb.TagNumber(24)
-  set rpc($2.Rpc v) {
-    setField(24, v);
-  }
-
+  set rpc($0.Rpc value) => $_setField(24, value);
   @$pb.TagNumber(24)
   $core.bool hasRpc() => $_has(23);
   @$pb.TagNumber(24)
-  void clearRpc() => clearField(24);
+  void clearRpc() => $_clearField(24);
   @$pb.TagNumber(24)
-  $2.Rpc ensureRpc() => $_ensure(23);
+  $0.Rpc ensureRpc() => $_ensure(23);
 
+  /// An incoming status snapshot for some set of users.
   @$pb.TagNumber(25)
   Status get status => $_getN(24);
   @$pb.TagNumber(25)
-  set status(Status v) {
-    setField(25, v);
-  }
-
+  set status(Status value) => $_setField(25, value);
   @$pb.TagNumber(25)
   $core.bool hasStatus() => $_has(24);
   @$pb.TagNumber(25)
-  void clearStatus() => clearField(25);
+  void clearStatus() => $_clearField(25);
   @$pb.TagNumber(25)
   Status ensureStatus() => $_ensure(24);
 
+  /// Start following some set of users to receive their status updates.
   @$pb.TagNumber(26)
   StatusFollow get statusFollow => $_getN(25);
   @$pb.TagNumber(26)
-  set statusFollow(StatusFollow v) {
-    setField(26, v);
-  }
-
+  set statusFollow(StatusFollow value) => $_setField(26, value);
   @$pb.TagNumber(26)
   $core.bool hasStatusFollow() => $_has(25);
   @$pb.TagNumber(26)
-  void clearStatusFollow() => clearField(26);
+  void clearStatusFollow() => $_clearField(26);
   @$pb.TagNumber(26)
   StatusFollow ensureStatusFollow() => $_ensure(25);
 
+  /// An incoming status update.
   @$pb.TagNumber(27)
   StatusPresenceEvent get statusPresenceEvent => $_getN(26);
   @$pb.TagNumber(27)
-  set statusPresenceEvent(StatusPresenceEvent v) {
-    setField(27, v);
-  }
-
+  set statusPresenceEvent(StatusPresenceEvent value) => $_setField(27, value);
   @$pb.TagNumber(27)
   $core.bool hasStatusPresenceEvent() => $_has(26);
   @$pb.TagNumber(27)
-  void clearStatusPresenceEvent() => clearField(27);
+  void clearStatusPresenceEvent() => $_clearField(27);
   @$pb.TagNumber(27)
   StatusPresenceEvent ensureStatusPresenceEvent() => $_ensure(26);
 
+  /// Stop following some set of users to no longer receive their status updates.
   @$pb.TagNumber(28)
   StatusUnfollow get statusUnfollow => $_getN(27);
   @$pb.TagNumber(28)
-  set statusUnfollow(StatusUnfollow v) {
-    setField(28, v);
-  }
-
+  set statusUnfollow(StatusUnfollow value) => $_setField(28, value);
   @$pb.TagNumber(28)
   $core.bool hasStatusUnfollow() => $_has(27);
   @$pb.TagNumber(28)
-  void clearStatusUnfollow() => clearField(28);
+  void clearStatusUnfollow() => $_clearField(28);
   @$pb.TagNumber(28)
   StatusUnfollow ensureStatusUnfollow() => $_ensure(27);
 
+  /// Set the user's own status.
   @$pb.TagNumber(29)
   StatusUpdate get statusUpdate => $_getN(28);
   @$pb.TagNumber(29)
-  set statusUpdate(StatusUpdate v) {
-    setField(29, v);
-  }
-
+  set statusUpdate(StatusUpdate value) => $_setField(29, value);
   @$pb.TagNumber(29)
   $core.bool hasStatusUpdate() => $_has(28);
   @$pb.TagNumber(29)
-  void clearStatusUpdate() => clearField(29);
+  void clearStatusUpdate() => $_clearField(29);
   @$pb.TagNumber(29)
   StatusUpdate ensureStatusUpdate() => $_ensure(28);
 
+  /// A data message delivered over a stream.
   @$pb.TagNumber(30)
   StreamData get streamData => $_getN(29);
   @$pb.TagNumber(30)
-  set streamData(StreamData v) {
-    setField(30, v);
-  }
-
+  set streamData(StreamData value) => $_setField(30, value);
   @$pb.TagNumber(30)
   $core.bool hasStreamData() => $_has(29);
   @$pb.TagNumber(30)
-  void clearStreamData() => clearField(30);
+  void clearStreamData() => $_clearField(30);
   @$pb.TagNumber(30)
   StreamData ensureStreamData() => $_ensure(29);
 
+  /// Presence update for a particular stream.
   @$pb.TagNumber(31)
   StreamPresenceEvent get streamPresenceEvent => $_getN(30);
   @$pb.TagNumber(31)
-  set streamPresenceEvent(StreamPresenceEvent v) {
-    setField(31, v);
-  }
-
+  set streamPresenceEvent(StreamPresenceEvent value) => $_setField(31, value);
   @$pb.TagNumber(31)
   $core.bool hasStreamPresenceEvent() => $_has(30);
   @$pb.TagNumber(31)
-  void clearStreamPresenceEvent() => clearField(31);
+  void clearStreamPresenceEvent() => $_clearField(31);
   @$pb.TagNumber(31)
   StreamPresenceEvent ensureStreamPresenceEvent() => $_ensure(30);
 
+  /// Application-level heartbeat and connection check.
   @$pb.TagNumber(32)
   Ping get ping => $_getN(31);
   @$pb.TagNumber(32)
-  set ping(Ping v) {
-    setField(32, v);
-  }
-
+  set ping(Ping value) => $_setField(32, value);
   @$pb.TagNumber(32)
   $core.bool hasPing() => $_has(31);
   @$pb.TagNumber(32)
-  void clearPing() => clearField(32);
+  void clearPing() => $_clearField(32);
   @$pb.TagNumber(32)
   Ping ensurePing() => $_ensure(31);
 
+  /// Application-level heartbeat and connection check response.
   @$pb.TagNumber(33)
   Pong get pong => $_getN(32);
   @$pb.TagNumber(33)
-  set pong(Pong v) {
-    setField(33, v);
-  }
-
+  set pong(Pong value) => $_setField(33, value);
   @$pb.TagNumber(33)
   $core.bool hasPong() => $_has(32);
   @$pb.TagNumber(33)
-  void clearPong() => clearField(33);
+  void clearPong() => $_clearField(33);
   @$pb.TagNumber(33)
   Pong ensurePong() => $_ensure(32);
 
+  /// Incoming information about a party.
   @$pb.TagNumber(34)
   Party get party => $_getN(33);
   @$pb.TagNumber(34)
-  set party(Party v) {
-    setField(34, v);
-  }
-
+  set party(Party value) => $_setField(34, value);
   @$pb.TagNumber(34)
   $core.bool hasParty() => $_has(33);
   @$pb.TagNumber(34)
-  void clearParty() => clearField(34);
+  void clearParty() => $_clearField(34);
   @$pb.TagNumber(34)
   Party ensureParty() => $_ensure(33);
 
+  /// Create a party.
   @$pb.TagNumber(35)
   PartyCreate get partyCreate => $_getN(34);
   @$pb.TagNumber(35)
-  set partyCreate(PartyCreate v) {
-    setField(35, v);
-  }
-
+  set partyCreate(PartyCreate value) => $_setField(35, value);
   @$pb.TagNumber(35)
   $core.bool hasPartyCreate() => $_has(34);
   @$pb.TagNumber(35)
-  void clearPartyCreate() => clearField(35);
+  void clearPartyCreate() => $_clearField(35);
   @$pb.TagNumber(35)
   PartyCreate ensurePartyCreate() => $_ensure(34);
 
+  /// Join a party, or request to join if the party is not open.
   @$pb.TagNumber(36)
   PartyJoin get partyJoin => $_getN(35);
   @$pb.TagNumber(36)
-  set partyJoin(PartyJoin v) {
-    setField(36, v);
-  }
-
+  set partyJoin(PartyJoin value) => $_setField(36, value);
   @$pb.TagNumber(36)
   $core.bool hasPartyJoin() => $_has(35);
   @$pb.TagNumber(36)
-  void clearPartyJoin() => clearField(36);
+  void clearPartyJoin() => $_clearField(36);
   @$pb.TagNumber(36)
   PartyJoin ensurePartyJoin() => $_ensure(35);
 
+  /// Leave a party.
   @$pb.TagNumber(37)
   PartyLeave get partyLeave => $_getN(36);
   @$pb.TagNumber(37)
-  set partyLeave(PartyLeave v) {
-    setField(37, v);
-  }
-
+  set partyLeave(PartyLeave value) => $_setField(37, value);
   @$pb.TagNumber(37)
   $core.bool hasPartyLeave() => $_has(36);
   @$pb.TagNumber(37)
-  void clearPartyLeave() => clearField(37);
+  void clearPartyLeave() => $_clearField(37);
   @$pb.TagNumber(37)
   PartyLeave ensurePartyLeave() => $_ensure(36);
 
+  /// Promote a new party leader.
   @$pb.TagNumber(38)
   PartyPromote get partyPromote => $_getN(37);
   @$pb.TagNumber(38)
-  set partyPromote(PartyPromote v) {
-    setField(38, v);
-  }
-
+  set partyPromote(PartyPromote value) => $_setField(38, value);
   @$pb.TagNumber(38)
   $core.bool hasPartyPromote() => $_has(37);
   @$pb.TagNumber(38)
-  void clearPartyPromote() => clearField(38);
+  void clearPartyPromote() => $_clearField(38);
   @$pb.TagNumber(38)
   PartyPromote ensurePartyPromote() => $_ensure(37);
 
+  /// Announcement of a new party leader.
   @$pb.TagNumber(39)
   PartyLeader get partyLeader => $_getN(38);
   @$pb.TagNumber(39)
-  set partyLeader(PartyLeader v) {
-    setField(39, v);
-  }
-
+  set partyLeader(PartyLeader value) => $_setField(39, value);
   @$pb.TagNumber(39)
   $core.bool hasPartyLeader() => $_has(38);
   @$pb.TagNumber(39)
-  void clearPartyLeader() => clearField(39);
+  void clearPartyLeader() => $_clearField(39);
   @$pb.TagNumber(39)
   PartyLeader ensurePartyLeader() => $_ensure(38);
 
+  /// Accept a request to join.
   @$pb.TagNumber(40)
   PartyAccept get partyAccept => $_getN(39);
   @$pb.TagNumber(40)
-  set partyAccept(PartyAccept v) {
-    setField(40, v);
-  }
-
+  set partyAccept(PartyAccept value) => $_setField(40, value);
   @$pb.TagNumber(40)
   $core.bool hasPartyAccept() => $_has(39);
   @$pb.TagNumber(40)
-  void clearPartyAccept() => clearField(40);
+  void clearPartyAccept() => $_clearField(40);
   @$pb.TagNumber(40)
   PartyAccept ensurePartyAccept() => $_ensure(39);
 
+  /// Kick a party member, or decline a request to join.
   @$pb.TagNumber(41)
   PartyRemove get partyRemove => $_getN(40);
   @$pb.TagNumber(41)
-  set partyRemove(PartyRemove v) {
-    setField(41, v);
-  }
-
+  set partyRemove(PartyRemove value) => $_setField(41, value);
   @$pb.TagNumber(41)
   $core.bool hasPartyRemove() => $_has(40);
   @$pb.TagNumber(41)
-  void clearPartyRemove() => clearField(41);
+  void clearPartyRemove() => $_clearField(41);
   @$pb.TagNumber(41)
   PartyRemove ensurePartyRemove() => $_ensure(40);
 
+  /// End a party, kicking all party members and closing it.
   @$pb.TagNumber(42)
   PartyClose get partyClose => $_getN(41);
   @$pb.TagNumber(42)
-  set partyClose(PartyClose v) {
-    setField(42, v);
-  }
-
+  set partyClose(PartyClose value) => $_setField(42, value);
   @$pb.TagNumber(42)
   $core.bool hasPartyClose() => $_has(41);
   @$pb.TagNumber(42)
-  void clearPartyClose() => clearField(42);
+  void clearPartyClose() => $_clearField(42);
   @$pb.TagNumber(42)
   PartyClose ensurePartyClose() => $_ensure(41);
 
+  /// Request a list of pending join requests for a party.
   @$pb.TagNumber(43)
   PartyJoinRequestList get partyJoinRequestList => $_getN(42);
   @$pb.TagNumber(43)
-  set partyJoinRequestList(PartyJoinRequestList v) {
-    setField(43, v);
-  }
-
+  set partyJoinRequestList(PartyJoinRequestList value) => $_setField(43, value);
   @$pb.TagNumber(43)
   $core.bool hasPartyJoinRequestList() => $_has(42);
   @$pb.TagNumber(43)
-  void clearPartyJoinRequestList() => clearField(43);
+  void clearPartyJoinRequestList() => $_clearField(43);
   @$pb.TagNumber(43)
   PartyJoinRequestList ensurePartyJoinRequestList() => $_ensure(42);
 
+  /// Incoming notification for one or more new presences attempting to join the party.
   @$pb.TagNumber(44)
   PartyJoinRequest get partyJoinRequest => $_getN(43);
   @$pb.TagNumber(44)
-  set partyJoinRequest(PartyJoinRequest v) {
-    setField(44, v);
-  }
-
+  set partyJoinRequest(PartyJoinRequest value) => $_setField(44, value);
   @$pb.TagNumber(44)
   $core.bool hasPartyJoinRequest() => $_has(43);
   @$pb.TagNumber(44)
-  void clearPartyJoinRequest() => clearField(44);
+  void clearPartyJoinRequest() => $_clearField(44);
   @$pb.TagNumber(44)
   PartyJoinRequest ensurePartyJoinRequest() => $_ensure(43);
 
+  /// Begin matchmaking as a party.
   @$pb.TagNumber(45)
   PartyMatchmakerAdd get partyMatchmakerAdd => $_getN(44);
   @$pb.TagNumber(45)
-  set partyMatchmakerAdd(PartyMatchmakerAdd v) {
-    setField(45, v);
-  }
-
+  set partyMatchmakerAdd(PartyMatchmakerAdd value) => $_setField(45, value);
   @$pb.TagNumber(45)
   $core.bool hasPartyMatchmakerAdd() => $_has(44);
   @$pb.TagNumber(45)
-  void clearPartyMatchmakerAdd() => clearField(45);
+  void clearPartyMatchmakerAdd() => $_clearField(45);
   @$pb.TagNumber(45)
   PartyMatchmakerAdd ensurePartyMatchmakerAdd() => $_ensure(44);
 
+  /// Cancel a party matchmaking process using a ticket.
   @$pb.TagNumber(46)
   PartyMatchmakerRemove get partyMatchmakerRemove => $_getN(45);
   @$pb.TagNumber(46)
-  set partyMatchmakerRemove(PartyMatchmakerRemove v) {
-    setField(46, v);
-  }
-
+  set partyMatchmakerRemove(PartyMatchmakerRemove value) =>
+      $_setField(46, value);
   @$pb.TagNumber(46)
   $core.bool hasPartyMatchmakerRemove() => $_has(45);
   @$pb.TagNumber(46)
-  void clearPartyMatchmakerRemove() => clearField(46);
+  void clearPartyMatchmakerRemove() => $_clearField(46);
   @$pb.TagNumber(46)
   PartyMatchmakerRemove ensurePartyMatchmakerRemove() => $_ensure(45);
 
+  /// A response from starting a new party matchmaking process.
   @$pb.TagNumber(47)
   PartyMatchmakerTicket get partyMatchmakerTicket => $_getN(46);
   @$pb.TagNumber(47)
-  set partyMatchmakerTicket(PartyMatchmakerTicket v) {
-    setField(47, v);
-  }
-
+  set partyMatchmakerTicket(PartyMatchmakerTicket value) =>
+      $_setField(47, value);
   @$pb.TagNumber(47)
   $core.bool hasPartyMatchmakerTicket() => $_has(46);
   @$pb.TagNumber(47)
-  void clearPartyMatchmakerTicket() => clearField(47);
+  void clearPartyMatchmakerTicket() => $_clearField(47);
   @$pb.TagNumber(47)
   PartyMatchmakerTicket ensurePartyMatchmakerTicket() => $_ensure(46);
 
+  /// Incoming party data delivered from the server.
   @$pb.TagNumber(48)
   PartyData get partyData => $_getN(47);
   @$pb.TagNumber(48)
-  set partyData(PartyData v) {
-    setField(48, v);
-  }
-
+  set partyData(PartyData value) => $_setField(48, value);
   @$pb.TagNumber(48)
   $core.bool hasPartyData() => $_has(47);
   @$pb.TagNumber(48)
-  void clearPartyData() => clearField(48);
+  void clearPartyData() => $_clearField(48);
   @$pb.TagNumber(48)
   PartyData ensurePartyData() => $_ensure(47);
 
+  /// A client to server request to send data to a party.
   @$pb.TagNumber(49)
   PartyDataSend get partyDataSend => $_getN(48);
   @$pb.TagNumber(49)
-  set partyDataSend(PartyDataSend v) {
-    setField(49, v);
-  }
-
+  set partyDataSend(PartyDataSend value) => $_setField(49, value);
   @$pb.TagNumber(49)
   $core.bool hasPartyDataSend() => $_has(48);
   @$pb.TagNumber(49)
-  void clearPartyDataSend() => clearField(49);
+  void clearPartyDataSend() => $_clearField(49);
   @$pb.TagNumber(49)
   PartyDataSend ensurePartyDataSend() => $_ensure(48);
 
+  /// Presence update for a particular party.
   @$pb.TagNumber(50)
   PartyPresenceEvent get partyPresenceEvent => $_getN(49);
   @$pb.TagNumber(50)
-  set partyPresenceEvent(PartyPresenceEvent v) {
-    setField(50, v);
-  }
-
+  set partyPresenceEvent(PartyPresenceEvent value) => $_setField(50, value);
   @$pb.TagNumber(50)
   $core.bool hasPartyPresenceEvent() => $_has(49);
   @$pb.TagNumber(50)
-  void clearPartyPresenceEvent() => clearField(50);
+  void clearPartyPresenceEvent() => $_clearField(50);
   @$pb.TagNumber(50)
   PartyPresenceEvent ensurePartyPresenceEvent() => $_ensure(49);
+
+  /// Update Party label and whether it's open or closed.
+  @$pb.TagNumber(51)
+  PartyUpdate get partyUpdate => $_getN(50);
+  @$pb.TagNumber(51)
+  set partyUpdate(PartyUpdate value) => $_setField(51, value);
+  @$pb.TagNumber(51)
+  $core.bool hasPartyUpdate() => $_has(50);
+  @$pb.TagNumber(51)
+  void clearPartyUpdate() => $_clearField(51);
+  @$pb.TagNumber(51)
+  PartyUpdate ensurePartyUpdate() => $_ensure(50);
 }
 
+/// A realtime chat channel.
 class Channel extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Channel',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..pc<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presences',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..aOM<UserPresence>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'self',
-        subBuilder: UserPresence.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'roomName')
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIdOne')
-    ..aOS(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIdTwo')
-    ..hasRequiredFields = false;
-
-  Channel._() : super();
   factory Channel({
     $core.String? id,
     $core.Iterable<UserPresence>? presences,
@@ -1477,49 +1166,54 @@ class Channel extends $pb.GeneratedMessage {
     $core.String? userIdOne,
     $core.String? userIdTwo,
   }) {
-    final _result = create();
-    if (id != null) {
-      _result.id = id;
-    }
-    if (presences != null) {
-      _result.presences.addAll(presences);
-    }
-    if (self != null) {
-      _result.self = self;
-    }
-    if (roomName != null) {
-      _result.roomName = roomName;
-    }
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIdOne != null) {
-      _result.userIdOne = userIdOne;
-    }
-    if (userIdTwo != null) {
-      _result.userIdTwo = userIdTwo;
-    }
-    return _result;
+    final result = create();
+    if (id != null) result.id = id;
+    if (presences != null) result.presences.addAll(presences);
+    if (self != null) result.self = self;
+    if (roomName != null) result.roomName = roomName;
+    if (groupId != null) result.groupId = groupId;
+    if (userIdOne != null) result.userIdOne = userIdOne;
+    if (userIdTwo != null) result.userIdTwo = userIdTwo;
+    return result;
   }
-  factory Channel.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Channel.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Channel clone() => Channel()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Channel._();
+
+  factory Channel.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Channel.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Channel',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'id')
+    ..pPM<UserPresence>(2, _omitFieldNames ? '' : 'presences',
+        subBuilder: UserPresence.create)
+    ..aOM<UserPresence>(3, _omitFieldNames ? '' : 'self',
+        subBuilder: UserPresence.create)
+    ..aOS(4, _omitFieldNames ? '' : 'roomName')
+    ..aOS(5, _omitFieldNames ? '' : 'groupId')
+    ..aOS(6, _omitFieldNames ? '' : 'userIdOne')
+    ..aOS(7, _omitFieldNames ? '' : 'userIdTwo')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Channel clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Channel copyWith(void Function(Channel) updates) =>
-      super.copyWith((message) => updates(message as Channel))
-          as Channel; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Channel)) as Channel;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Channel create() => Channel._();
+  @$core.override
   Channel createEmptyInstance() => create();
   static $pb.PbList<Channel> createRepeated() => $pb.PbList<Channel>();
   @$core.pragma('dart2js:noInline')
@@ -1527,160 +1221,124 @@ class Channel extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Channel>(create);
   static Channel? _defaultInstance;
 
+  /// The ID of the channel.
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearId() => clearField(1);
+  void clearId() => $_clearField(1);
 
+  /// The users currently in the channel.
   @$pb.TagNumber(2)
-  $core.List<UserPresence> get presences => $_getList(1);
+  $pb.PbList<UserPresence> get presences => $_getList(1);
 
+  /// A reference to the current user's presence in the channel.
   @$pb.TagNumber(3)
   UserPresence get self => $_getN(2);
   @$pb.TagNumber(3)
-  set self(UserPresence v) {
-    setField(3, v);
-  }
-
+  set self(UserPresence value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasSelf() => $_has(2);
   @$pb.TagNumber(3)
-  void clearSelf() => clearField(3);
+  void clearSelf() => $_clearField(3);
   @$pb.TagNumber(3)
   UserPresence ensureSelf() => $_ensure(2);
 
+  /// The name of the chat room, or an empty string if this message was not sent through a chat room.
   @$pb.TagNumber(4)
   $core.String get roomName => $_getSZ(3);
   @$pb.TagNumber(4)
-  set roomName($core.String v) {
-    $_setString(3, v);
-  }
-
+  set roomName($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasRoomName() => $_has(3);
   @$pb.TagNumber(4)
-  void clearRoomName() => clearField(4);
+  void clearRoomName() => $_clearField(4);
 
+  /// The ID of the group, or an empty string if this message was not sent through a group channel.
   @$pb.TagNumber(5)
   $core.String get groupId => $_getSZ(4);
   @$pb.TagNumber(5)
-  set groupId($core.String v) {
-    $_setString(4, v);
-  }
-
+  set groupId($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasGroupId() => $_has(4);
   @$pb.TagNumber(5)
-  void clearGroupId() => clearField(5);
+  void clearGroupId() => $_clearField(5);
 
+  /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
   @$pb.TagNumber(6)
   $core.String get userIdOne => $_getSZ(5);
   @$pb.TagNumber(6)
-  set userIdOne($core.String v) {
-    $_setString(5, v);
-  }
-
+  set userIdOne($core.String value) => $_setString(5, value);
   @$pb.TagNumber(6)
   $core.bool hasUserIdOne() => $_has(5);
   @$pb.TagNumber(6)
-  void clearUserIdOne() => clearField(6);
+  void clearUserIdOne() => $_clearField(6);
 
+  /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
   @$pb.TagNumber(7)
   $core.String get userIdTwo => $_getSZ(6);
   @$pb.TagNumber(7)
-  set userIdTwo($core.String v) {
-    $_setString(6, v);
-  }
-
+  set userIdTwo($core.String value) => $_setString(6, value);
   @$pb.TagNumber(7)
   $core.bool hasUserIdTwo() => $_has(6);
   @$pb.TagNumber(7)
-  void clearUserIdTwo() => clearField(7);
+  void clearUserIdTwo() => $_clearField(7);
 }
 
+/// Join operation for a realtime chat channel.
 class ChannelJoin extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelJoin',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'target')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'type',
-        $pb.PbFieldType.O3)
-    ..aOM<$1.BoolValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persistence',
-        subBuilder: $1.BoolValue.create)
-    ..aOM<$1.BoolValue>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'hidden',
-        subBuilder: $1.BoolValue.create)
-    ..hasRequiredFields = false;
-
-  ChannelJoin._() : super();
   factory ChannelJoin({
     $core.String? target,
     $core.int? type,
     $1.BoolValue? persistence,
     $1.BoolValue? hidden,
   }) {
-    final _result = create();
-    if (target != null) {
-      _result.target = target;
-    }
-    if (type != null) {
-      _result.type = type;
-    }
-    if (persistence != null) {
-      _result.persistence = persistence;
-    }
-    if (hidden != null) {
-      _result.hidden = hidden;
-    }
-    return _result;
+    final result = create();
+    if (target != null) result.target = target;
+    if (type != null) result.type = type;
+    if (persistence != null) result.persistence = persistence;
+    if (hidden != null) result.hidden = hidden;
+    return result;
   }
-  factory ChannelJoin.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelJoin.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelJoin clone() => ChannelJoin()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelJoin._();
+
+  factory ChannelJoin.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelJoin.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelJoin',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'target')
+    ..aI(2, _omitFieldNames ? '' : 'type')
+    ..aOM<$1.BoolValue>(3, _omitFieldNames ? '' : 'persistence',
+        subBuilder: $1.BoolValue.create)
+    ..aOM<$1.BoolValue>(4, _omitFieldNames ? '' : 'hidden',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelJoin clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelJoin copyWith(void Function(ChannelJoin) updates) =>
       super.copyWith((message) => updates(message as ChannelJoin))
-          as ChannelJoin; // ignore: deprecated_member_use
+          as ChannelJoin;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelJoin create() => ChannelJoin._();
+  @$core.override
   ChannelJoin createEmptyInstance() => create();
   static $pb.PbList<ChannelJoin> createRepeated() => $pb.PbList<ChannelJoin>();
   @$core.pragma('dart2js:noInline')
@@ -1688,105 +1346,91 @@ class ChannelJoin extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelJoin>(create);
   static ChannelJoin? _defaultInstance;
 
+  /// The user ID to DM with, group ID to chat with, or room channel name to join.
   @$pb.TagNumber(1)
   $core.String get target => $_getSZ(0);
   @$pb.TagNumber(1)
-  set target($core.String v) {
-    $_setString(0, v);
-  }
-
+  set target($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTarget() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTarget() => clearField(1);
+  void clearTarget() => $_clearField(1);
 
+  /// The type of the chat channel.
   @$pb.TagNumber(2)
   $core.int get type => $_getIZ(1);
   @$pb.TagNumber(2)
-  set type($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set type($core.int value) => $_setSignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasType() => $_has(1);
   @$pb.TagNumber(2)
-  void clearType() => clearField(2);
+  void clearType() => $_clearField(2);
 
+  /// Whether messages sent on this channel should be persistent.
   @$pb.TagNumber(3)
   $1.BoolValue get persistence => $_getN(2);
   @$pb.TagNumber(3)
-  set persistence($1.BoolValue v) {
-    setField(3, v);
-  }
-
+  set persistence($1.BoolValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasPersistence() => $_has(2);
   @$pb.TagNumber(3)
-  void clearPersistence() => clearField(3);
+  void clearPersistence() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.BoolValue ensurePersistence() => $_ensure(2);
 
+  /// Whether the user should appear in the channel's presence list and events.
   @$pb.TagNumber(4)
   $1.BoolValue get hidden => $_getN(3);
   @$pb.TagNumber(4)
-  set hidden($1.BoolValue v) {
-    setField(4, v);
-  }
-
+  set hidden($1.BoolValue value) => $_setField(4, value);
   @$pb.TagNumber(4)
   $core.bool hasHidden() => $_has(3);
   @$pb.TagNumber(4)
-  void clearHidden() => clearField(4);
+  void clearHidden() => $_clearField(4);
   @$pb.TagNumber(4)
   $1.BoolValue ensureHidden() => $_ensure(3);
 }
 
+/// Leave a realtime channel.
 class ChannelLeave extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelLeave',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelId')
-    ..hasRequiredFields = false;
-
-  ChannelLeave._() : super();
   factory ChannelLeave({
     $core.String? channelId,
   }) {
-    final _result = create();
-    if (channelId != null) {
-      _result.channelId = channelId;
-    }
-    return _result;
+    final result = create();
+    if (channelId != null) result.channelId = channelId;
+    return result;
   }
-  factory ChannelLeave.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelLeave.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelLeave clone() => ChannelLeave()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelLeave._();
+
+  factory ChannelLeave.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelLeave.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelLeave',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'channelId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelLeave clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelLeave copyWith(void Function(ChannelLeave) updates) =>
       super.copyWith((message) => updates(message as ChannelLeave))
-          as ChannelLeave; // ignore: deprecated_member_use
+          as ChannelLeave;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelLeave create() => ChannelLeave._();
+  @$core.override
   ChannelLeave createEmptyInstance() => create();
   static $pb.PbList<ChannelLeave> createRepeated() =>
       $pb.PbList<ChannelLeave>();
@@ -1795,159 +1439,91 @@ class ChannelLeave extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelLeave>(create);
   static ChannelLeave? _defaultInstance;
 
+  /// The ID of the channel to leave.
   @$pb.TagNumber(1)
   $core.String get channelId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set channelId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set channelId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasChannelId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearChannelId() => clearField(1);
+  void clearChannelId() => $_clearField(1);
 }
 
+/// A receipt reply from a channel message send operation.
 class ChannelMessageAck extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelMessageAck',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'messageId')
-    ..aOM<$1.Int32Value>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'code',
-        subBuilder: $1.Int32Value.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..aOM<$0.Timestamp>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'createTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$0.Timestamp>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'updateTime',
-        subBuilder: $0.Timestamp.create)
-    ..aOM<$1.BoolValue>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persistent',
-        subBuilder: $1.BoolValue.create)
-    ..aOS(
-        8,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'roomName')
-    ..aOS(
-        9,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..aOS(
-        10,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIdOne')
-    ..aOS(
-        11,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIdTwo')
-    ..hasRequiredFields = false;
-
-  ChannelMessageAck._() : super();
   factory ChannelMessageAck({
     $core.String? channelId,
     $core.String? messageId,
     $1.Int32Value? code,
     $core.String? username,
-    $0.Timestamp? createTime,
-    $0.Timestamp? updateTime,
+    $2.Timestamp? createTime,
+    $2.Timestamp? updateTime,
     $1.BoolValue? persistent,
     $core.String? roomName,
     $core.String? groupId,
     $core.String? userIdOne,
     $core.String? userIdTwo,
   }) {
-    final _result = create();
-    if (channelId != null) {
-      _result.channelId = channelId;
-    }
-    if (messageId != null) {
-      _result.messageId = messageId;
-    }
-    if (code != null) {
-      _result.code = code;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    if (createTime != null) {
-      _result.createTime = createTime;
-    }
-    if (updateTime != null) {
-      _result.updateTime = updateTime;
-    }
-    if (persistent != null) {
-      _result.persistent = persistent;
-    }
-    if (roomName != null) {
-      _result.roomName = roomName;
-    }
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIdOne != null) {
-      _result.userIdOne = userIdOne;
-    }
-    if (userIdTwo != null) {
-      _result.userIdTwo = userIdTwo;
-    }
-    return _result;
+    final result = create();
+    if (channelId != null) result.channelId = channelId;
+    if (messageId != null) result.messageId = messageId;
+    if (code != null) result.code = code;
+    if (username != null) result.username = username;
+    if (createTime != null) result.createTime = createTime;
+    if (updateTime != null) result.updateTime = updateTime;
+    if (persistent != null) result.persistent = persistent;
+    if (roomName != null) result.roomName = roomName;
+    if (groupId != null) result.groupId = groupId;
+    if (userIdOne != null) result.userIdOne = userIdOne;
+    if (userIdTwo != null) result.userIdTwo = userIdTwo;
+    return result;
   }
-  factory ChannelMessageAck.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelMessageAck.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelMessageAck clone() => ChannelMessageAck()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelMessageAck._();
+
+  factory ChannelMessageAck.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelMessageAck.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelMessageAck',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'channelId')
+    ..aOS(2, _omitFieldNames ? '' : 'messageId')
+    ..aOM<$1.Int32Value>(3, _omitFieldNames ? '' : 'code',
+        subBuilder: $1.Int32Value.create)
+    ..aOS(4, _omitFieldNames ? '' : 'username')
+    ..aOM<$2.Timestamp>(5, _omitFieldNames ? '' : 'createTime',
+        subBuilder: $2.Timestamp.create)
+    ..aOM<$2.Timestamp>(6, _omitFieldNames ? '' : 'updateTime',
+        subBuilder: $2.Timestamp.create)
+    ..aOM<$1.BoolValue>(7, _omitFieldNames ? '' : 'persistent',
+        subBuilder: $1.BoolValue.create)
+    ..aOS(8, _omitFieldNames ? '' : 'roomName')
+    ..aOS(9, _omitFieldNames ? '' : 'groupId')
+    ..aOS(10, _omitFieldNames ? '' : 'userIdOne')
+    ..aOS(11, _omitFieldNames ? '' : 'userIdTwo')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelMessageAck clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelMessageAck copyWith(void Function(ChannelMessageAck) updates) =>
       super.copyWith((message) => updates(message as ChannelMessageAck))
-          as ChannelMessageAck; // ignore: deprecated_member_use
+          as ChannelMessageAck;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelMessageAck create() => ChannelMessageAck._();
+  @$core.override
   ChannelMessageAck createEmptyInstance() => create();
   static $pb.PbList<ChannelMessageAck> createRepeated() =>
       $pb.PbList<ChannelMessageAck>();
@@ -1956,202 +1532,168 @@ class ChannelMessageAck extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageAck>(create);
   static ChannelMessageAck? _defaultInstance;
 
+  /// The channel the message was sent to.
   @$pb.TagNumber(1)
   $core.String get channelId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set channelId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set channelId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasChannelId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearChannelId() => clearField(1);
+  void clearChannelId() => $_clearField(1);
 
+  /// The unique ID assigned to the message.
   @$pb.TagNumber(2)
   $core.String get messageId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set messageId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set messageId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMessageId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMessageId() => clearField(2);
+  void clearMessageId() => $_clearField(2);
 
+  /// The code representing a message type or category.
   @$pb.TagNumber(3)
   $1.Int32Value get code => $_getN(2);
   @$pb.TagNumber(3)
-  set code($1.Int32Value v) {
-    setField(3, v);
-  }
-
+  set code($1.Int32Value value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasCode() => $_has(2);
   @$pb.TagNumber(3)
-  void clearCode() => clearField(3);
+  void clearCode() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.Int32Value ensureCode() => $_ensure(2);
 
+  /// Username of the message sender.
   @$pb.TagNumber(4)
   $core.String get username => $_getSZ(3);
   @$pb.TagNumber(4)
-  set username($core.String v) {
-    $_setString(3, v);
-  }
-
+  set username($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasUsername() => $_has(3);
   @$pb.TagNumber(4)
-  void clearUsername() => clearField(4);
+  void clearUsername() => $_clearField(4);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the message was created.
   @$pb.TagNumber(5)
-  $0.Timestamp get createTime => $_getN(4);
+  $2.Timestamp get createTime => $_getN(4);
   @$pb.TagNumber(5)
-  set createTime($0.Timestamp v) {
-    setField(5, v);
-  }
-
+  set createTime($2.Timestamp value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasCreateTime() => $_has(4);
   @$pb.TagNumber(5)
-  void clearCreateTime() => clearField(5);
+  void clearCreateTime() => $_clearField(5);
   @$pb.TagNumber(5)
-  $0.Timestamp ensureCreateTime() => $_ensure(4);
+  $2.Timestamp ensureCreateTime() => $_ensure(4);
 
+  /// The UNIX time (for gRPC clients) or ISO string (for REST clients) when the message was last updated.
   @$pb.TagNumber(6)
-  $0.Timestamp get updateTime => $_getN(5);
+  $2.Timestamp get updateTime => $_getN(5);
   @$pb.TagNumber(6)
-  set updateTime($0.Timestamp v) {
-    setField(6, v);
-  }
-
+  set updateTime($2.Timestamp value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasUpdateTime() => $_has(5);
   @$pb.TagNumber(6)
-  void clearUpdateTime() => clearField(6);
+  void clearUpdateTime() => $_clearField(6);
   @$pb.TagNumber(6)
-  $0.Timestamp ensureUpdateTime() => $_ensure(5);
+  $2.Timestamp ensureUpdateTime() => $_ensure(5);
 
+  /// True if the message was persisted to the channel's history, false otherwise.
   @$pb.TagNumber(7)
   $1.BoolValue get persistent => $_getN(6);
   @$pb.TagNumber(7)
-  set persistent($1.BoolValue v) {
-    setField(7, v);
-  }
-
+  set persistent($1.BoolValue value) => $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasPersistent() => $_has(6);
   @$pb.TagNumber(7)
-  void clearPersistent() => clearField(7);
+  void clearPersistent() => $_clearField(7);
   @$pb.TagNumber(7)
   $1.BoolValue ensurePersistent() => $_ensure(6);
 
+  /// The name of the chat room, or an empty string if this message was not sent through a chat room.
   @$pb.TagNumber(8)
   $core.String get roomName => $_getSZ(7);
   @$pb.TagNumber(8)
-  set roomName($core.String v) {
-    $_setString(7, v);
-  }
-
+  set roomName($core.String value) => $_setString(7, value);
   @$pb.TagNumber(8)
   $core.bool hasRoomName() => $_has(7);
   @$pb.TagNumber(8)
-  void clearRoomName() => clearField(8);
+  void clearRoomName() => $_clearField(8);
 
+  /// The ID of the group, or an empty string if this message was not sent through a group channel.
   @$pb.TagNumber(9)
   $core.String get groupId => $_getSZ(8);
   @$pb.TagNumber(9)
-  set groupId($core.String v) {
-    $_setString(8, v);
-  }
-
+  set groupId($core.String value) => $_setString(8, value);
   @$pb.TagNumber(9)
   $core.bool hasGroupId() => $_has(8);
   @$pb.TagNumber(9)
-  void clearGroupId() => clearField(9);
+  void clearGroupId() => $_clearField(9);
 
+  /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
   @$pb.TagNumber(10)
   $core.String get userIdOne => $_getSZ(9);
   @$pb.TagNumber(10)
-  set userIdOne($core.String v) {
-    $_setString(9, v);
-  }
-
+  set userIdOne($core.String value) => $_setString(9, value);
   @$pb.TagNumber(10)
   $core.bool hasUserIdOne() => $_has(9);
   @$pb.TagNumber(10)
-  void clearUserIdOne() => clearField(10);
+  void clearUserIdOne() => $_clearField(10);
 
+  /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
   @$pb.TagNumber(11)
   $core.String get userIdTwo => $_getSZ(10);
   @$pb.TagNumber(11)
-  set userIdTwo($core.String v) {
-    $_setString(10, v);
-  }
-
+  set userIdTwo($core.String value) => $_setString(10, value);
   @$pb.TagNumber(11)
   $core.bool hasUserIdTwo() => $_has(10);
   @$pb.TagNumber(11)
-  void clearUserIdTwo() => clearField(11);
+  void clearUserIdTwo() => $_clearField(11);
 }
 
+/// Send a message to a realtime channel.
 class ChannelMessageSend extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelMessageSend',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'content')
-    ..hasRequiredFields = false;
-
-  ChannelMessageSend._() : super();
   factory ChannelMessageSend({
     $core.String? channelId,
     $core.String? content,
   }) {
-    final _result = create();
-    if (channelId != null) {
-      _result.channelId = channelId;
-    }
-    if (content != null) {
-      _result.content = content;
-    }
-    return _result;
+    final result = create();
+    if (channelId != null) result.channelId = channelId;
+    if (content != null) result.content = content;
+    return result;
   }
-  factory ChannelMessageSend.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelMessageSend.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelMessageSend clone() => ChannelMessageSend()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelMessageSend._();
+
+  factory ChannelMessageSend.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelMessageSend.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelMessageSend',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'channelId')
+    ..aOS(2, _omitFieldNames ? '' : 'content')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelMessageSend clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelMessageSend copyWith(void Function(ChannelMessageSend) updates) =>
       super.copyWith((message) => updates(message as ChannelMessageSend))
-          as ChannelMessageSend; // ignore: deprecated_member_use
+          as ChannelMessageSend;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelMessageSend create() => ChannelMessageSend._();
+  @$core.override
   ChannelMessageSend createEmptyInstance() => create();
   static $pb.PbList<ChannelMessageSend> createRepeated() =>
       $pb.PbList<ChannelMessageSend>();
@@ -2160,96 +1702,73 @@ class ChannelMessageSend extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageSend>(create);
   static ChannelMessageSend? _defaultInstance;
 
+  /// The channel to sent to.
   @$pb.TagNumber(1)
   $core.String get channelId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set channelId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set channelId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasChannelId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearChannelId() => clearField(1);
+  void clearChannelId() => $_clearField(1);
 
+  /// Message content.
   @$pb.TagNumber(2)
   $core.String get content => $_getSZ(1);
   @$pb.TagNumber(2)
-  set content($core.String v) {
-    $_setString(1, v);
-  }
-
+  set content($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasContent() => $_has(1);
   @$pb.TagNumber(2)
-  void clearContent() => clearField(2);
+  void clearContent() => $_clearField(2);
 }
 
+/// Update a message previously sent to a realtime channel.
 class ChannelMessageUpdate extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelMessageUpdate',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'messageId')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'content')
-    ..hasRequiredFields = false;
-
-  ChannelMessageUpdate._() : super();
   factory ChannelMessageUpdate({
     $core.String? channelId,
     $core.String? messageId,
     $core.String? content,
   }) {
-    final _result = create();
-    if (channelId != null) {
-      _result.channelId = channelId;
-    }
-    if (messageId != null) {
-      _result.messageId = messageId;
-    }
-    if (content != null) {
-      _result.content = content;
-    }
-    return _result;
+    final result = create();
+    if (channelId != null) result.channelId = channelId;
+    if (messageId != null) result.messageId = messageId;
+    if (content != null) result.content = content;
+    return result;
   }
-  factory ChannelMessageUpdate.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelMessageUpdate.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelMessageUpdate clone() =>
-      ChannelMessageUpdate()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelMessageUpdate._();
+
+  factory ChannelMessageUpdate.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelMessageUpdate.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelMessageUpdate',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'channelId')
+    ..aOS(2, _omitFieldNames ? '' : 'messageId')
+    ..aOS(3, _omitFieldNames ? '' : 'content')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelMessageUpdate clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelMessageUpdate copyWith(void Function(ChannelMessageUpdate) updates) =>
       super.copyWith((message) => updates(message as ChannelMessageUpdate))
-          as ChannelMessageUpdate; // ignore: deprecated_member_use
+          as ChannelMessageUpdate;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelMessageUpdate create() => ChannelMessageUpdate._();
+  @$core.override
   ChannelMessageUpdate createEmptyInstance() => create();
   static $pb.PbList<ChannelMessageUpdate> createRepeated() =>
       $pb.PbList<ChannelMessageUpdate>();
@@ -2258,99 +1777,80 @@ class ChannelMessageUpdate extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageUpdate>(create);
   static ChannelMessageUpdate? _defaultInstance;
 
+  /// The channel the message was sent to.
   @$pb.TagNumber(1)
   $core.String get channelId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set channelId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set channelId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasChannelId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearChannelId() => clearField(1);
+  void clearChannelId() => $_clearField(1);
 
+  /// The ID assigned to the message to update.
   @$pb.TagNumber(2)
   $core.String get messageId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set messageId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set messageId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMessageId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMessageId() => clearField(2);
+  void clearMessageId() => $_clearField(2);
 
+  /// New message content.
   @$pb.TagNumber(3)
   $core.String get content => $_getSZ(2);
   @$pb.TagNumber(3)
-  set content($core.String v) {
-    $_setString(2, v);
-  }
-
+  set content($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasContent() => $_has(2);
   @$pb.TagNumber(3)
-  void clearContent() => clearField(3);
+  void clearContent() => $_clearField(3);
 }
 
+/// Remove a message previously sent to a realtime channel.
 class ChannelMessageRemove extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelMessageRemove',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'messageId')
-    ..hasRequiredFields = false;
-
-  ChannelMessageRemove._() : super();
   factory ChannelMessageRemove({
     $core.String? channelId,
     $core.String? messageId,
   }) {
-    final _result = create();
-    if (channelId != null) {
-      _result.channelId = channelId;
-    }
-    if (messageId != null) {
-      _result.messageId = messageId;
-    }
-    return _result;
+    final result = create();
+    if (channelId != null) result.channelId = channelId;
+    if (messageId != null) result.messageId = messageId;
+    return result;
   }
-  factory ChannelMessageRemove.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelMessageRemove.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelMessageRemove clone() =>
-      ChannelMessageRemove()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelMessageRemove._();
+
+  factory ChannelMessageRemove.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelMessageRemove.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelMessageRemove',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'channelId')
+    ..aOS(2, _omitFieldNames ? '' : 'messageId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelMessageRemove clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelMessageRemove copyWith(void Function(ChannelMessageRemove) updates) =>
       super.copyWith((message) => updates(message as ChannelMessageRemove))
-          as ChannelMessageRemove; // ignore: deprecated_member_use
+          as ChannelMessageRemove;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelMessageRemove create() => ChannelMessageRemove._();
+  @$core.override
   ChannelMessageRemove createEmptyInstance() => create();
   static $pb.PbList<ChannelMessageRemove> createRepeated() =>
       $pb.PbList<ChannelMessageRemove>();
@@ -2359,83 +1859,29 @@ class ChannelMessageRemove extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageRemove>(create);
   static ChannelMessageRemove? _defaultInstance;
 
+  /// The channel the message was sent to.
   @$pb.TagNumber(1)
   $core.String get channelId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set channelId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set channelId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasChannelId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearChannelId() => clearField(1);
+  void clearChannelId() => $_clearField(1);
 
+  /// The ID assigned to the message to update.
   @$pb.TagNumber(2)
   $core.String get messageId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set messageId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set messageId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMessageId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMessageId() => clearField(2);
+  void clearMessageId() => $_clearField(2);
 }
 
+/// A set of joins and leaves on a particular channel.
 class ChannelPresenceEvent extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChannelPresenceEvent',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'channelId')
-    ..pc<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'joins',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..pc<UserPresence>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaves',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'roomName')
-    ..aOS(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'groupId')
-    ..aOS(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIdOne')
-    ..aOS(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIdTwo')
-    ..hasRequiredFields = false;
-
-  ChannelPresenceEvent._() : super();
   factory ChannelPresenceEvent({
     $core.String? channelId,
     $core.Iterable<UserPresence>? joins,
@@ -2445,50 +1891,55 @@ class ChannelPresenceEvent extends $pb.GeneratedMessage {
     $core.String? userIdOne,
     $core.String? userIdTwo,
   }) {
-    final _result = create();
-    if (channelId != null) {
-      _result.channelId = channelId;
-    }
-    if (joins != null) {
-      _result.joins.addAll(joins);
-    }
-    if (leaves != null) {
-      _result.leaves.addAll(leaves);
-    }
-    if (roomName != null) {
-      _result.roomName = roomName;
-    }
-    if (groupId != null) {
-      _result.groupId = groupId;
-    }
-    if (userIdOne != null) {
-      _result.userIdOne = userIdOne;
-    }
-    if (userIdTwo != null) {
-      _result.userIdTwo = userIdTwo;
-    }
-    return _result;
+    final result = create();
+    if (channelId != null) result.channelId = channelId;
+    if (joins != null) result.joins.addAll(joins);
+    if (leaves != null) result.leaves.addAll(leaves);
+    if (roomName != null) result.roomName = roomName;
+    if (groupId != null) result.groupId = groupId;
+    if (userIdOne != null) result.userIdOne = userIdOne;
+    if (userIdTwo != null) result.userIdTwo = userIdTwo;
+    return result;
   }
-  factory ChannelPresenceEvent.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChannelPresenceEvent.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChannelPresenceEvent clone() =>
-      ChannelPresenceEvent()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  ChannelPresenceEvent._();
+
+  factory ChannelPresenceEvent.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ChannelPresenceEvent.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ChannelPresenceEvent',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'channelId')
+    ..pPM<UserPresence>(2, _omitFieldNames ? '' : 'joins',
+        subBuilder: UserPresence.create)
+    ..pPM<UserPresence>(3, _omitFieldNames ? '' : 'leaves',
+        subBuilder: UserPresence.create)
+    ..aOS(4, _omitFieldNames ? '' : 'roomName')
+    ..aOS(5, _omitFieldNames ? '' : 'groupId')
+    ..aOS(6, _omitFieldNames ? '' : 'userIdOne')
+    ..aOS(7, _omitFieldNames ? '' : 'userIdTwo')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ChannelPresenceEvent clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   ChannelPresenceEvent copyWith(void Function(ChannelPresenceEvent) updates) =>
       super.copyWith((message) => updates(message as ChannelPresenceEvent))
-          as ChannelPresenceEvent; // ignore: deprecated_member_use
+          as ChannelPresenceEvent;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ChannelPresenceEvent create() => ChannelPresenceEvent._();
+  @$core.override
   ChannelPresenceEvent createEmptyInstance() => create();
   static $pb.PbList<ChannelPresenceEvent> createRepeated() =>
       $pb.PbList<ChannelPresenceEvent>();
@@ -2497,142 +1948,114 @@ class ChannelPresenceEvent extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ChannelPresenceEvent>(create);
   static ChannelPresenceEvent? _defaultInstance;
 
+  /// The channel identifier this event is for.
   @$pb.TagNumber(1)
   $core.String get channelId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set channelId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set channelId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasChannelId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearChannelId() => clearField(1);
+  void clearChannelId() => $_clearField(1);
 
+  /// Presences joining the channel as part of this event, if any.
   @$pb.TagNumber(2)
-  $core.List<UserPresence> get joins => $_getList(1);
+  $pb.PbList<UserPresence> get joins => $_getList(1);
 
+  /// Presences leaving the channel as part of this event, if any.
   @$pb.TagNumber(3)
-  $core.List<UserPresence> get leaves => $_getList(2);
+  $pb.PbList<UserPresence> get leaves => $_getList(2);
 
+  /// The name of the chat room, or an empty string if this message was not sent through a chat room.
   @$pb.TagNumber(4)
   $core.String get roomName => $_getSZ(3);
   @$pb.TagNumber(4)
-  set roomName($core.String v) {
-    $_setString(3, v);
-  }
-
+  set roomName($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasRoomName() => $_has(3);
   @$pb.TagNumber(4)
-  void clearRoomName() => clearField(4);
+  void clearRoomName() => $_clearField(4);
 
+  /// The ID of the group, or an empty string if this message was not sent through a group channel.
   @$pb.TagNumber(5)
   $core.String get groupId => $_getSZ(4);
   @$pb.TagNumber(5)
-  set groupId($core.String v) {
-    $_setString(4, v);
-  }
-
+  set groupId($core.String value) => $_setString(4, value);
   @$pb.TagNumber(5)
   $core.bool hasGroupId() => $_has(4);
   @$pb.TagNumber(5)
-  void clearGroupId() => clearField(5);
+  void clearGroupId() => $_clearField(5);
 
+  /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
   @$pb.TagNumber(6)
   $core.String get userIdOne => $_getSZ(5);
   @$pb.TagNumber(6)
-  set userIdOne($core.String v) {
-    $_setString(5, v);
-  }
-
+  set userIdOne($core.String value) => $_setString(5, value);
   @$pb.TagNumber(6)
   $core.bool hasUserIdOne() => $_has(5);
   @$pb.TagNumber(6)
-  void clearUserIdOne() => clearField(6);
+  void clearUserIdOne() => $_clearField(6);
 
+  /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
   @$pb.TagNumber(7)
   $core.String get userIdTwo => $_getSZ(6);
   @$pb.TagNumber(7)
-  set userIdTwo($core.String v) {
-    $_setString(6, v);
-  }
-
+  set userIdTwo($core.String value) => $_setString(6, value);
   @$pb.TagNumber(7)
   $core.bool hasUserIdTwo() => $_has(6);
   @$pb.TagNumber(7)
-  void clearUserIdTwo() => clearField(7);
+  void clearUserIdTwo() => $_clearField(7);
 }
 
+/// A logical error which may occur on the server.
 class Error extends $pb.GeneratedMessage {
+  factory Error({
+    $core.int? code,
+    $core.String? message,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? context,
+  }) {
+    final result = create();
+    if (code != null) result.code = code;
+    if (message != null) result.message = message;
+    if (context != null) result.context.addEntries(context);
+    return result;
+  }
+
+  Error._();
+
+  factory Error.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Error.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Error',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'Error',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'code',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'message')
-    ..m<$core.String, $core.String>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'context',
+    ..aI(1, _omitFieldNames ? '' : 'code')
+    ..aOS(2, _omitFieldNames ? '' : 'message')
+    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'context',
         entryClassName: 'Error.ContextEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.realtime'))
     ..hasRequiredFields = false;
 
-  Error._() : super();
-  factory Error({
-    $core.int? code,
-    $core.String? message,
-    $core.Map<$core.String, $core.String>? context,
-  }) {
-    final _result = create();
-    if (code != null) {
-      _result.code = code;
-    }
-    if (message != null) {
-      _result.message = message;
-    }
-    if (context != null) {
-      _result.context.addAll(context);
-    }
-    return _result;
-  }
-  factory Error.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Error.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Error clone() => Error()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Error clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Error copyWith(void Function(Error) updates) =>
-      super.copyWith((message) => updates(message as Error))
-          as Error; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Error)) as Error;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Error create() => Error._();
+  @$core.override
   Error createEmptyInstance() => create();
   static $pb.PbList<Error> createRepeated() => $pb.PbList<Error>();
   @$core.pragma('dart2js:noInline')
@@ -2640,82 +2063,33 @@ class Error extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Error>(create);
   static Error? _defaultInstance;
 
+  /// The error code which should be one of "Error.Code" enums.
   @$pb.TagNumber(1)
   $core.int get code => $_getIZ(0);
   @$pb.TagNumber(1)
-  set code($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set code($core.int value) => $_setSignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasCode() => $_has(0);
   @$pb.TagNumber(1)
-  void clearCode() => clearField(1);
+  void clearCode() => $_clearField(1);
 
+  /// A message in English to help developers debug the response.
   @$pb.TagNumber(2)
   $core.String get message => $_getSZ(1);
   @$pb.TagNumber(2)
-  set message($core.String v) {
-    $_setString(1, v);
-  }
-
+  set message($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMessage() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMessage() => clearField(2);
+  void clearMessage() => $_clearField(2);
 
+  /// Additional error details which may be different for each response.
   @$pb.TagNumber(3)
-  $core.Map<$core.String, $core.String> get context => $_getMap(2);
+  $pb.PbMap<$core.String, $core.String> get context => $_getMap(2);
 }
 
+/// A realtime match.
 class Match extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Match',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchId')
-    ..aOB(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'authoritative')
-    ..aOM<$1.StringValue>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'label',
-        subBuilder: $1.StringValue.create)
-    ..a<$core.int>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'size',
-        $pb.PbFieldType.O3)
-    ..pc<UserPresence>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presences',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..aOM<UserPresence>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'self',
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  Match._() : super();
   factory Match({
     $core.String? matchId,
     $core.bool? authoritative,
@@ -2724,46 +2098,53 @@ class Match extends $pb.GeneratedMessage {
     $core.Iterable<UserPresence>? presences,
     UserPresence? self,
   }) {
-    final _result = create();
-    if (matchId != null) {
-      _result.matchId = matchId;
-    }
-    if (authoritative != null) {
-      _result.authoritative = authoritative;
-    }
-    if (label != null) {
-      _result.label = label;
-    }
-    if (size != null) {
-      _result.size = size;
-    }
-    if (presences != null) {
-      _result.presences.addAll(presences);
-    }
-    if (self != null) {
-      _result.self = self;
-    }
-    return _result;
+    final result = create();
+    if (matchId != null) result.matchId = matchId;
+    if (authoritative != null) result.authoritative = authoritative;
+    if (label != null) result.label = label;
+    if (size != null) result.size = size;
+    if (presences != null) result.presences.addAll(presences);
+    if (self != null) result.self = self;
+    return result;
   }
-  factory Match.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Match.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Match clone() => Match()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Match._();
+
+  factory Match.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Match.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Match',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'matchId')
+    ..aOB(2, _omitFieldNames ? '' : 'authoritative')
+    ..aOM<$1.StringValue>(3, _omitFieldNames ? '' : 'label',
+        subBuilder: $1.StringValue.create)
+    ..aI(4, _omitFieldNames ? '' : 'size')
+    ..pPM<UserPresence>(5, _omitFieldNames ? '' : 'presences',
+        subBuilder: UserPresence.create)
+    ..aOM<UserPresence>(6, _omitFieldNames ? '' : 'self',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Match clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Match copyWith(void Function(Match) updates) =>
-      super.copyWith((message) => updates(message as Match))
-          as Match; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Match)) as Match;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Match create() => Match._();
+  @$core.override
   Match createEmptyInstance() => create();
   static $pb.PbList<Match> createRepeated() => $pb.PbList<Match>();
   @$core.pragma('dart2js:noInline')
@@ -2771,120 +2152,105 @@ class Match extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Match>(create);
   static Match? _defaultInstance;
 
+  /// The match unique ID.
   @$pb.TagNumber(1)
   $core.String get matchId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set matchId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set matchId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMatchId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMatchId() => clearField(1);
+  void clearMatchId() => $_clearField(1);
 
+  /// True if it's an server-managed authoritative match, false otherwise.
   @$pb.TagNumber(2)
   $core.bool get authoritative => $_getBF(1);
   @$pb.TagNumber(2)
-  set authoritative($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set authoritative($core.bool value) => $_setBool(1, value);
   @$pb.TagNumber(2)
   $core.bool hasAuthoritative() => $_has(1);
   @$pb.TagNumber(2)
-  void clearAuthoritative() => clearField(2);
+  void clearAuthoritative() => $_clearField(2);
 
+  /// Match label, if any.
   @$pb.TagNumber(3)
   $1.StringValue get label => $_getN(2);
   @$pb.TagNumber(3)
-  set label($1.StringValue v) {
-    setField(3, v);
-  }
-
+  set label($1.StringValue value) => $_setField(3, value);
   @$pb.TagNumber(3)
   $core.bool hasLabel() => $_has(2);
   @$pb.TagNumber(3)
-  void clearLabel() => clearField(3);
+  void clearLabel() => $_clearField(3);
   @$pb.TagNumber(3)
   $1.StringValue ensureLabel() => $_ensure(2);
 
+  /// The number of users currently in the match.
   @$pb.TagNumber(4)
   $core.int get size => $_getIZ(3);
   @$pb.TagNumber(4)
-  set size($core.int v) {
-    $_setSignedInt32(3, v);
-  }
-
+  set size($core.int value) => $_setSignedInt32(3, value);
   @$pb.TagNumber(4)
   $core.bool hasSize() => $_has(3);
   @$pb.TagNumber(4)
-  void clearSize() => clearField(4);
+  void clearSize() => $_clearField(4);
 
+  /// The users currently in the match.
   @$pb.TagNumber(5)
-  $core.List<UserPresence> get presences => $_getList(4);
+  $pb.PbList<UserPresence> get presences => $_getList(4);
 
+  /// A reference to the current user's presence in the match.
   @$pb.TagNumber(6)
   UserPresence get self => $_getN(5);
   @$pb.TagNumber(6)
-  set self(UserPresence v) {
-    setField(6, v);
-  }
-
+  set self(UserPresence value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasSelf() => $_has(5);
   @$pb.TagNumber(6)
-  void clearSelf() => clearField(6);
+  void clearSelf() => $_clearField(6);
   @$pb.TagNumber(6)
   UserPresence ensureSelf() => $_ensure(5);
 }
 
+/// Create a new realtime match.
 class MatchCreate extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchCreate',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..hasRequiredFields = false;
-
-  MatchCreate._() : super();
   factory MatchCreate({
     $core.String? name,
   }) {
-    final _result = create();
-    if (name != null) {
-      _result.name = name;
-    }
-    return _result;
+    final result = create();
+    if (name != null) result.name = name;
+    return result;
   }
-  factory MatchCreate.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchCreate.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchCreate clone() => MatchCreate()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchCreate._();
+
+  factory MatchCreate.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchCreate.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchCreate',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchCreate clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchCreate copyWith(void Function(MatchCreate) updates) =>
       super.copyWith((message) => updates(message as MatchCreate))
-          as MatchCreate; // ignore: deprecated_member_use
+          as MatchCreate;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchCreate create() => MatchCreate._();
+  @$core.override
   MatchCreate createEmptyInstance() => create();
   static $pb.PbList<MatchCreate> createRepeated() => $pb.PbList<MatchCreate>();
   @$core.pragma('dart2js:noInline')
@@ -2892,59 +2258,19 @@ class MatchCreate extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<MatchCreate>(create);
   static MatchCreate? _defaultInstance;
 
+  /// Optional name to use when creating the match.
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
-  void clearName() => clearField(1);
+  void clearName() => $_clearField(1);
 }
 
+/// Realtime match data received from the server.
 class MatchData extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchData',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchId')
-    ..aOM<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presence',
-        subBuilder: UserPresence.create)
-    ..aInt64(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'opCode')
-    ..a<$core.List<$core.int>>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'data',
-        $pb.PbFieldType.OY)
-    ..aOB(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reliable')
-    ..hasRequiredFields = false;
-
-  MatchData._() : super();
   factory MatchData({
     $core.String? matchId,
     UserPresence? presence,
@@ -2952,43 +2278,50 @@ class MatchData extends $pb.GeneratedMessage {
     $core.List<$core.int>? data,
     $core.bool? reliable,
   }) {
-    final _result = create();
-    if (matchId != null) {
-      _result.matchId = matchId;
-    }
-    if (presence != null) {
-      _result.presence = presence;
-    }
-    if (opCode != null) {
-      _result.opCode = opCode;
-    }
-    if (data != null) {
-      _result.data = data;
-    }
-    if (reliable != null) {
-      _result.reliable = reliable;
-    }
-    return _result;
+    final result = create();
+    if (matchId != null) result.matchId = matchId;
+    if (presence != null) result.presence = presence;
+    if (opCode != null) result.opCode = opCode;
+    if (data != null) result.data = data;
+    if (reliable != null) result.reliable = reliable;
+    return result;
   }
-  factory MatchData.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchData.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchData clone() => MatchData()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchData._();
+
+  factory MatchData.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchData.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchData',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'matchId')
+    ..aOM<UserPresence>(2, _omitFieldNames ? '' : 'presence',
+        subBuilder: UserPresence.create)
+    ..aInt64(3, _omitFieldNames ? '' : 'opCode')
+    ..a<$core.List<$core.int>>(
+        4, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..aOB(5, _omitFieldNames ? '' : 'reliable')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchData clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchData copyWith(void Function(MatchData) updates) =>
-      super.copyWith((message) => updates(message as MatchData))
-          as MatchData; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MatchData)) as MatchData;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchData create() => MatchData._();
+  @$core.override
   MatchData createEmptyInstance() => create();
   static $pb.PbList<MatchData> createRepeated() => $pb.PbList<MatchData>();
   @$core.pragma('dart2js:noInline')
@@ -2996,110 +2329,61 @@ class MatchData extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MatchData>(create);
   static MatchData? _defaultInstance;
 
+  /// The match unique ID.
   @$pb.TagNumber(1)
   $core.String get matchId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set matchId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set matchId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMatchId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMatchId() => clearField(1);
+  void clearMatchId() => $_clearField(1);
 
+  /// A reference to the user presence that sent this data, if any.
   @$pb.TagNumber(2)
   UserPresence get presence => $_getN(1);
   @$pb.TagNumber(2)
-  set presence(UserPresence v) {
-    setField(2, v);
-  }
-
+  set presence(UserPresence value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPresence() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPresence() => clearField(2);
+  void clearPresence() => $_clearField(2);
   @$pb.TagNumber(2)
   UserPresence ensurePresence() => $_ensure(1);
 
+  /// Op code value.
   @$pb.TagNumber(3)
   $fixnum.Int64 get opCode => $_getI64(2);
   @$pb.TagNumber(3)
-  set opCode($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set opCode($fixnum.Int64 value) => $_setInt64(2, value);
   @$pb.TagNumber(3)
   $core.bool hasOpCode() => $_has(2);
   @$pb.TagNumber(3)
-  void clearOpCode() => clearField(3);
+  void clearOpCode() => $_clearField(3);
 
+  /// Data payload, if any.
   @$pb.TagNumber(4)
   $core.List<$core.int> get data => $_getN(3);
   @$pb.TagNumber(4)
-  set data($core.List<$core.int> v) {
-    $_setBytes(3, v);
-  }
-
+  set data($core.List<$core.int> value) => $_setBytes(3, value);
   @$pb.TagNumber(4)
   $core.bool hasData() => $_has(3);
   @$pb.TagNumber(4)
-  void clearData() => clearField(4);
+  void clearData() => $_clearField(4);
 
+  /// True if this data was delivered reliably, false otherwise.
   @$pb.TagNumber(5)
   $core.bool get reliable => $_getBF(4);
   @$pb.TagNumber(5)
-  set reliable($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set reliable($core.bool value) => $_setBool(4, value);
   @$pb.TagNumber(5)
   $core.bool hasReliable() => $_has(4);
   @$pb.TagNumber(5)
-  void clearReliable() => clearField(5);
+  void clearReliable() => $_clearField(5);
 }
 
+/// Send realtime match data to the server.
 class MatchDataSend extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchDataSend',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchId')
-    ..aInt64(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'opCode')
-    ..a<$core.List<$core.int>>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'data',
-        $pb.PbFieldType.OY)
-    ..pc<UserPresence>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presences',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..aOB(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reliable')
-    ..hasRequiredFields = false;
-
-  MatchDataSend._() : super();
   factory MatchDataSend({
     $core.String? matchId,
     $fixnum.Int64? opCode,
@@ -3107,43 +2391,51 @@ class MatchDataSend extends $pb.GeneratedMessage {
     $core.Iterable<UserPresence>? presences,
     $core.bool? reliable,
   }) {
-    final _result = create();
-    if (matchId != null) {
-      _result.matchId = matchId;
-    }
-    if (opCode != null) {
-      _result.opCode = opCode;
-    }
-    if (data != null) {
-      _result.data = data;
-    }
-    if (presences != null) {
-      _result.presences.addAll(presences);
-    }
-    if (reliable != null) {
-      _result.reliable = reliable;
-    }
-    return _result;
+    final result = create();
+    if (matchId != null) result.matchId = matchId;
+    if (opCode != null) result.opCode = opCode;
+    if (data != null) result.data = data;
+    if (presences != null) result.presences.addAll(presences);
+    if (reliable != null) result.reliable = reliable;
+    return result;
   }
-  factory MatchDataSend.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchDataSend.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchDataSend clone() => MatchDataSend()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchDataSend._();
+
+  factory MatchDataSend.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchDataSend.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchDataSend',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'matchId')
+    ..aInt64(2, _omitFieldNames ? '' : 'opCode')
+    ..a<$core.List<$core.int>>(
+        3, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..pPM<UserPresence>(4, _omitFieldNames ? '' : 'presences',
+        subBuilder: UserPresence.create)
+    ..aOB(5, _omitFieldNames ? '' : 'reliable')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchDataSend clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchDataSend copyWith(void Function(MatchDataSend) updates) =>
       super.copyWith((message) => updates(message as MatchDataSend))
-          as MatchDataSend; // ignore: deprecated_member_use
+          as MatchDataSend;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchDataSend create() => MatchDataSend._();
+  @$core.override
   MatchDataSend createEmptyInstance() => create();
   static $pb.PbList<MatchDataSend> createRepeated() =>
       $pb.PbList<MatchDataSend>();
@@ -3152,134 +2444,108 @@ class MatchDataSend extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<MatchDataSend>(create);
   static MatchDataSend? _defaultInstance;
 
+  /// The match unique ID.
   @$pb.TagNumber(1)
   $core.String get matchId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set matchId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set matchId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMatchId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMatchId() => clearField(1);
+  void clearMatchId() => $_clearField(1);
 
+  /// Op code value.
   @$pb.TagNumber(2)
   $fixnum.Int64 get opCode => $_getI64(1);
   @$pb.TagNumber(2)
-  set opCode($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set opCode($fixnum.Int64 value) => $_setInt64(1, value);
   @$pb.TagNumber(2)
   $core.bool hasOpCode() => $_has(1);
   @$pb.TagNumber(2)
-  void clearOpCode() => clearField(2);
+  void clearOpCode() => $_clearField(2);
 
+  /// Data payload, if any.
   @$pb.TagNumber(3)
   $core.List<$core.int> get data => $_getN(2);
   @$pb.TagNumber(3)
-  set data($core.List<$core.int> v) {
-    $_setBytes(2, v);
-  }
-
+  set data($core.List<$core.int> value) => $_setBytes(2, value);
   @$pb.TagNumber(3)
   $core.bool hasData() => $_has(2);
   @$pb.TagNumber(3)
-  void clearData() => clearField(3);
+  void clearData() => $_clearField(3);
 
+  /// List of presences in the match to deliver to, if filtering is required. Otherwise deliver to everyone in the match.
   @$pb.TagNumber(4)
-  $core.List<UserPresence> get presences => $_getList(3);
+  $pb.PbList<UserPresence> get presences => $_getList(3);
 
+  /// True if the data should be sent reliably, false otherwise.
   @$pb.TagNumber(5)
   $core.bool get reliable => $_getBF(4);
   @$pb.TagNumber(5)
-  set reliable($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set reliable($core.bool value) => $_setBool(4, value);
   @$pb.TagNumber(5)
   $core.bool hasReliable() => $_has(4);
   @$pb.TagNumber(5)
-  void clearReliable() => clearField(5);
+  void clearReliable() => $_clearField(5);
 }
 
 enum MatchJoin_Id { matchId, token, notSet }
 
+/// Join an existing realtime match.
 class MatchJoin extends $pb.GeneratedMessage {
+  factory MatchJoin({
+    $core.String? matchId,
+    $core.String? token,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>? metadata,
+  }) {
+    final result = create();
+    if (matchId != null) result.matchId = matchId;
+    if (token != null) result.token = token;
+    if (metadata != null) result.metadata.addEntries(metadata);
+    return result;
+  }
+
+  MatchJoin._();
+
+  factory MatchJoin.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchJoin.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static const $core.Map<$core.int, MatchJoin_Id> _MatchJoin_IdByTag = {
     1: MatchJoin_Id.matchId,
     2: MatchJoin_Id.token,
     0: MatchJoin_Id.notSet
   };
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchJoin',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'MatchJoin',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
     ..oo(0, [1, 2])
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..m<$core.String, $core.String>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'metadata',
+    ..aOS(1, _omitFieldNames ? '' : 'matchId')
+    ..aOS(2, _omitFieldNames ? '' : 'token')
+    ..m<$core.String, $core.String>(3, _omitFieldNames ? '' : 'metadata',
         entryClassName: 'MatchJoin.MetadataEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.realtime'))
     ..hasRequiredFields = false;
 
-  MatchJoin._() : super();
-  factory MatchJoin({
-    $core.String? matchId,
-    $core.String? token,
-    $core.Map<$core.String, $core.String>? metadata,
-  }) {
-    final _result = create();
-    if (matchId != null) {
-      _result.matchId = matchId;
-    }
-    if (token != null) {
-      _result.token = token;
-    }
-    if (metadata != null) {
-      _result.metadata.addAll(metadata);
-    }
-    return _result;
-  }
-  factory MatchJoin.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchJoin.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchJoin clone() => MatchJoin()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchJoin clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchJoin copyWith(void Function(MatchJoin) updates) =>
-      super.copyWith((message) => updates(message as MatchJoin))
-          as MatchJoin; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MatchJoin)) as MatchJoin;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchJoin create() => MatchJoin._();
+  @$core.override
   MatchJoin createEmptyInstance() => create();
   static $pb.PbList<MatchJoin> createRepeated() => $pb.PbList<MatchJoin>();
   @$core.pragma('dart2js:noInline')
@@ -3287,83 +2553,77 @@ class MatchJoin extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MatchJoin>(create);
   static MatchJoin? _defaultInstance;
 
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
   MatchJoin_Id whichId() => _MatchJoin_IdByTag[$_whichOneof(0)]!;
-  void clearId() => clearField($_whichOneof(0));
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  void clearId() => $_clearField($_whichOneof(0));
 
+  /// The match unique ID.
   @$pb.TagNumber(1)
   $core.String get matchId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set matchId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set matchId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMatchId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMatchId() => clearField(1);
+  void clearMatchId() => $_clearField(1);
 
+  /// A matchmaking result token.
   @$pb.TagNumber(2)
   $core.String get token => $_getSZ(1);
   @$pb.TagNumber(2)
-  set token($core.String v) {
-    $_setString(1, v);
-  }
-
+  set token($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasToken() => $_has(1);
   @$pb.TagNumber(2)
-  void clearToken() => clearField(2);
+  void clearToken() => $_clearField(2);
 
+  /// An optional set of key-value metadata pairs to be passed to the match handler, if any.
   @$pb.TagNumber(3)
-  $core.Map<$core.String, $core.String> get metadata => $_getMap(2);
+  $pb.PbMap<$core.String, $core.String> get metadata => $_getMap(2);
 }
 
+/// Leave a realtime match.
 class MatchLeave extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchLeave',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchId')
-    ..hasRequiredFields = false;
-
-  MatchLeave._() : super();
   factory MatchLeave({
     $core.String? matchId,
   }) {
-    final _result = create();
-    if (matchId != null) {
-      _result.matchId = matchId;
-    }
-    return _result;
+    final result = create();
+    if (matchId != null) result.matchId = matchId;
+    return result;
   }
-  factory MatchLeave.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchLeave.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchLeave clone() => MatchLeave()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchLeave._();
+
+  factory MatchLeave.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchLeave.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchLeave',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'matchId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchLeave clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchLeave copyWith(void Function(MatchLeave) updates) =>
-      super.copyWith((message) => updates(message as MatchLeave))
-          as MatchLeave; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MatchLeave)) as MatchLeave;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchLeave create() => MatchLeave._();
+  @$core.override
   MatchLeave createEmptyInstance() => create();
   static $pb.PbList<MatchLeave> createRepeated() => $pb.PbList<MatchLeave>();
   @$core.pragma('dart2js:noInline')
@@ -3371,87 +2631,65 @@ class MatchLeave extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<MatchLeave>(create);
   static MatchLeave? _defaultInstance;
 
+  /// The match unique ID.
   @$pb.TagNumber(1)
   $core.String get matchId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set matchId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set matchId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMatchId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMatchId() => clearField(1);
+  void clearMatchId() => $_clearField(1);
 }
 
+/// A set of joins and leaves on a particular realtime match.
 class MatchPresenceEvent extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchPresenceEvent',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchId')
-    ..pc<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'joins',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..pc<UserPresence>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaves',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  MatchPresenceEvent._() : super();
   factory MatchPresenceEvent({
     $core.String? matchId,
     $core.Iterable<UserPresence>? joins,
     $core.Iterable<UserPresence>? leaves,
   }) {
-    final _result = create();
-    if (matchId != null) {
-      _result.matchId = matchId;
-    }
-    if (joins != null) {
-      _result.joins.addAll(joins);
-    }
-    if (leaves != null) {
-      _result.leaves.addAll(leaves);
-    }
-    return _result;
+    final result = create();
+    if (matchId != null) result.matchId = matchId;
+    if (joins != null) result.joins.addAll(joins);
+    if (leaves != null) result.leaves.addAll(leaves);
+    return result;
   }
-  factory MatchPresenceEvent.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchPresenceEvent.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchPresenceEvent clone() => MatchPresenceEvent()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchPresenceEvent._();
+
+  factory MatchPresenceEvent.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchPresenceEvent.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchPresenceEvent',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'matchId')
+    ..pPM<UserPresence>(2, _omitFieldNames ? '' : 'joins',
+        subBuilder: UserPresence.create)
+    ..pPM<UserPresence>(3, _omitFieldNames ? '' : 'leaves',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchPresenceEvent clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchPresenceEvent copyWith(void Function(MatchPresenceEvent) updates) =>
       super.copyWith((message) => updates(message as MatchPresenceEvent))
-          as MatchPresenceEvent; // ignore: deprecated_member_use
+          as MatchPresenceEvent;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchPresenceEvent create() => MatchPresenceEvent._();
+  @$core.override
   MatchPresenceEvent createEmptyInstance() => create();
   static $pb.PbList<MatchPresenceEvent> createRepeated() =>
       $pb.PbList<MatchPresenceEvent>();
@@ -3460,127 +2698,95 @@ class MatchPresenceEvent extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<MatchPresenceEvent>(create);
   static MatchPresenceEvent? _defaultInstance;
 
+  /// The match unique ID.
   @$pb.TagNumber(1)
   $core.String get matchId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set matchId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set matchId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMatchId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMatchId() => clearField(1);
+  void clearMatchId() => $_clearField(1);
 
+  /// User presences that have just joined the match.
   @$pb.TagNumber(2)
-  $core.List<UserPresence> get joins => $_getList(1);
+  $pb.PbList<UserPresence> get joins => $_getList(1);
 
+  /// User presences that have just left the match.
   @$pb.TagNumber(3)
-  $core.List<UserPresence> get leaves => $_getList(2);
+  $pb.PbList<UserPresence> get leaves => $_getList(2);
 }
 
+/// Start a new matchmaking process.
 class MatchmakerAdd extends $pb.GeneratedMessage {
+  factory MatchmakerAdd({
+    $core.int? minCount,
+    $core.int? maxCount,
+    $core.String? query,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>?
+        stringProperties,
+    $core.Iterable<$core.MapEntry<$core.String, $core.double>>?
+        numericProperties,
+    $1.Int32Value? countMultiple,
+  }) {
+    final result = create();
+    if (minCount != null) result.minCount = minCount;
+    if (maxCount != null) result.maxCount = maxCount;
+    if (query != null) result.query = query;
+    if (stringProperties != null)
+      result.stringProperties.addEntries(stringProperties);
+    if (numericProperties != null)
+      result.numericProperties.addEntries(numericProperties);
+    if (countMultiple != null) result.countMultiple = countMultiple;
+    return result;
+  }
+
+  MatchmakerAdd._();
+
+  factory MatchmakerAdd.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchmakerAdd.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchmakerAdd',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'MatchmakerAdd',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'minCount',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxCount',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'query')
+    ..aI(1, _omitFieldNames ? '' : 'minCount')
+    ..aI(2, _omitFieldNames ? '' : 'maxCount')
+    ..aOS(3, _omitFieldNames ? '' : 'query')
     ..m<$core.String, $core.String>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'stringProperties',
+        4, _omitFieldNames ? '' : 'stringProperties',
         entryClassName: 'MatchmakerAdd.StringPropertiesEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.realtime'))
     ..m<$core.String, $core.double>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'numericProperties',
+        5, _omitFieldNames ? '' : 'numericProperties',
         entryClassName: 'MatchmakerAdd.NumericPropertiesEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OD,
         packageName: const $pb.PackageName('nakama.realtime'))
-    ..aOM<$1.Int32Value>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'countMultiple',
+    ..aOM<$1.Int32Value>(6, _omitFieldNames ? '' : 'countMultiple',
         subBuilder: $1.Int32Value.create)
     ..hasRequiredFields = false;
 
-  MatchmakerAdd._() : super();
-  factory MatchmakerAdd({
-    $core.int? minCount,
-    $core.int? maxCount,
-    $core.String? query,
-    $core.Map<$core.String, $core.String>? stringProperties,
-    $core.Map<$core.String, $core.double>? numericProperties,
-    $1.Int32Value? countMultiple,
-  }) {
-    final _result = create();
-    if (minCount != null) {
-      _result.minCount = minCount;
-    }
-    if (maxCount != null) {
-      _result.maxCount = maxCount;
-    }
-    if (query != null) {
-      _result.query = query;
-    }
-    if (stringProperties != null) {
-      _result.stringProperties.addAll(stringProperties);
-    }
-    if (numericProperties != null) {
-      _result.numericProperties.addAll(numericProperties);
-    }
-    if (countMultiple != null) {
-      _result.countMultiple = countMultiple;
-    }
-    return _result;
-  }
-  factory MatchmakerAdd.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchmakerAdd.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchmakerAdd clone() => MatchmakerAdd()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerAdd clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchmakerAdd copyWith(void Function(MatchmakerAdd) updates) =>
       super.copyWith((message) => updates(message as MatchmakerAdd))
-          as MatchmakerAdd; // ignore: deprecated_member_use
+          as MatchmakerAdd;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchmakerAdd create() => MatchmakerAdd._();
+  @$core.override
   MatchmakerAdd createEmptyInstance() => create();
   static $pb.PbList<MatchmakerAdd> createRepeated() =>
       $pb.PbList<MatchmakerAdd>();
@@ -3589,99 +2795,103 @@ class MatchmakerAdd extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<MatchmakerAdd>(create);
   static MatchmakerAdd? _defaultInstance;
 
+  /// Minimum total user count to match together.
   @$pb.TagNumber(1)
   $core.int get minCount => $_getIZ(0);
   @$pb.TagNumber(1)
-  set minCount($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set minCount($core.int value) => $_setSignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMinCount() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMinCount() => clearField(1);
+  void clearMinCount() => $_clearField(1);
 
+  /// Maximum total user count to match together.
   @$pb.TagNumber(2)
   $core.int get maxCount => $_getIZ(1);
   @$pb.TagNumber(2)
-  set maxCount($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set maxCount($core.int value) => $_setSignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMaxCount() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMaxCount() => clearField(2);
+  void clearMaxCount() => $_clearField(2);
 
+  /// Filter query used to identify suitable users.
   @$pb.TagNumber(3)
   $core.String get query => $_getSZ(2);
   @$pb.TagNumber(3)
-  set query($core.String v) {
-    $_setString(2, v);
-  }
-
+  set query($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasQuery() => $_has(2);
   @$pb.TagNumber(3)
-  void clearQuery() => clearField(3);
+  void clearQuery() => $_clearField(3);
 
+  /// String properties.
   @$pb.TagNumber(4)
-  $core.Map<$core.String, $core.String> get stringProperties => $_getMap(3);
+  $pb.PbMap<$core.String, $core.String> get stringProperties => $_getMap(3);
 
+  /// Numeric properties.
   @$pb.TagNumber(5)
-  $core.Map<$core.String, $core.double> get numericProperties => $_getMap(4);
+  $pb.PbMap<$core.String, $core.double> get numericProperties => $_getMap(4);
 
+  /// Optional multiple of the count that must be satisfied.
   @$pb.TagNumber(6)
   $1.Int32Value get countMultiple => $_getN(5);
   @$pb.TagNumber(6)
-  set countMultiple($1.Int32Value v) {
-    setField(6, v);
-  }
-
+  set countMultiple($1.Int32Value value) => $_setField(6, value);
   @$pb.TagNumber(6)
   $core.bool hasCountMultiple() => $_has(5);
   @$pb.TagNumber(6)
-  void clearCountMultiple() => clearField(6);
+  void clearCountMultiple() => $_clearField(6);
   @$pb.TagNumber(6)
   $1.Int32Value ensureCountMultiple() => $_ensure(5);
 }
 
 class MatchmakerMatched_MatchmakerUser extends $pb.GeneratedMessage {
+  factory MatchmakerMatched_MatchmakerUser({
+    UserPresence? presence,
+    $core.String? partyId,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>?
+        stringProperties,
+    $core.Iterable<$core.MapEntry<$core.String, $core.double>>?
+        numericProperties,
+  }) {
+    final result = create();
+    if (presence != null) result.presence = presence;
+    if (partyId != null) result.partyId = partyId;
+    if (stringProperties != null)
+      result.stringProperties.addEntries(stringProperties);
+    if (numericProperties != null)
+      result.numericProperties.addEntries(numericProperties);
+    return result;
+  }
+
+  MatchmakerMatched_MatchmakerUser._();
+
+  factory MatchmakerMatched_MatchmakerUser.fromBuffer(
+          $core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchmakerMatched_MatchmakerUser.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchmakerMatched.MatchmakerUser',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'MatchmakerMatched.MatchmakerUser',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
-    ..aOM<UserPresence>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presence',
+    ..aOM<UserPresence>(1, _omitFieldNames ? '' : 'presence',
         subBuilder: UserPresence.create)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
+    ..aOS(2, _omitFieldNames ? '' : 'partyId')
     ..m<$core.String, $core.String>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'stringProperties',
+        5, _omitFieldNames ? '' : 'stringProperties',
         entryClassName:
             'MatchmakerMatched.MatchmakerUser.StringPropertiesEntry',
         keyFieldType: $pb.PbFieldType.OS,
         valueFieldType: $pb.PbFieldType.OS,
         packageName: const $pb.PackageName('nakama.realtime'))
     ..m<$core.String, $core.double>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'numericProperties',
+        6, _omitFieldNames ? '' : 'numericProperties',
         entryClassName:
             'MatchmakerMatched.MatchmakerUser.NumericPropertiesEntry',
         keyFieldType: $pb.PbFieldType.OS,
@@ -3689,51 +2899,22 @@ class MatchmakerMatched_MatchmakerUser extends $pb.GeneratedMessage {
         packageName: const $pb.PackageName('nakama.realtime'))
     ..hasRequiredFields = false;
 
-  MatchmakerMatched_MatchmakerUser._() : super();
-  factory MatchmakerMatched_MatchmakerUser({
-    UserPresence? presence,
-    $core.String? partyId,
-    $core.Map<$core.String, $core.String>? stringProperties,
-    $core.Map<$core.String, $core.double>? numericProperties,
-  }) {
-    final _result = create();
-    if (presence != null) {
-      _result.presence = presence;
-    }
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (stringProperties != null) {
-      _result.stringProperties.addAll(stringProperties);
-    }
-    if (numericProperties != null) {
-      _result.numericProperties.addAll(numericProperties);
-    }
-    return _result;
-  }
-  factory MatchmakerMatched_MatchmakerUser.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchmakerMatched_MatchmakerUser.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchmakerMatched_MatchmakerUser clone() =>
-      MatchmakerMatched_MatchmakerUser()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerMatched_MatchmakerUser clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchmakerMatched_MatchmakerUser copyWith(
           void Function(MatchmakerMatched_MatchmakerUser) updates) =>
       super.copyWith(
               (message) => updates(message as MatchmakerMatched_MatchmakerUser))
-          as MatchmakerMatched_MatchmakerUser; // ignore: deprecated_member_use
+          as MatchmakerMatched_MatchmakerUser;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchmakerMatched_MatchmakerUser create() =>
       MatchmakerMatched_MatchmakerUser._();
+  @$core.override
   MatchmakerMatched_MatchmakerUser createEmptyInstance() => create();
   static $pb.PbList<MatchmakerMatched_MatchmakerUser> createRepeated() =>
       $pb.PbList<MatchmakerMatched_MatchmakerUser>();
@@ -3743,89 +2924,41 @@ class MatchmakerMatched_MatchmakerUser extends $pb.GeneratedMessage {
           create);
   static MatchmakerMatched_MatchmakerUser? _defaultInstance;
 
+  /// User info.
   @$pb.TagNumber(1)
   UserPresence get presence => $_getN(0);
   @$pb.TagNumber(1)
-  set presence(UserPresence v) {
-    setField(1, v);
-  }
-
+  set presence(UserPresence value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasPresence() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPresence() => clearField(1);
+  void clearPresence() => $_clearField(1);
   @$pb.TagNumber(1)
   UserPresence ensurePresence() => $_ensure(0);
 
+  /// Party identifier, if this user was matched as a party member.
   @$pb.TagNumber(2)
   $core.String get partyId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set partyId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set partyId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasPartyId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPartyId() => clearField(2);
+  void clearPartyId() => $_clearField(2);
 
+  /// String properties.
   @$pb.TagNumber(5)
-  $core.Map<$core.String, $core.String> get stringProperties => $_getMap(2);
+  $pb.PbMap<$core.String, $core.String> get stringProperties => $_getMap(2);
 
+  /// Numeric properties.
   @$pb.TagNumber(6)
-  $core.Map<$core.String, $core.double> get numericProperties => $_getMap(3);
+  $pb.PbMap<$core.String, $core.double> get numericProperties => $_getMap(3);
 }
 
 enum MatchmakerMatched_Id { matchId, token, notSet }
 
+/// A successful matchmaking result.
 class MatchmakerMatched extends $pb.GeneratedMessage {
-  static const $core.Map<$core.int, MatchmakerMatched_Id>
-      _MatchmakerMatched_IdByTag = {
-    2: MatchmakerMatched_Id.matchId,
-    3: MatchmakerMatched_Id.token,
-    0: MatchmakerMatched_Id.notSet
-  };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchmakerMatched',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..oo(0, [2, 3])
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ticket')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'matchId')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..pc<MatchmakerMatched_MatchmakerUser>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'users',
-        $pb.PbFieldType.PM,
-        subBuilder: MatchmakerMatched_MatchmakerUser.create)
-    ..aOM<MatchmakerMatched_MatchmakerUser>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'self',
-        subBuilder: MatchmakerMatched_MatchmakerUser.create)
-    ..hasRequiredFields = false;
-
-  MatchmakerMatched._() : super();
   factory MatchmakerMatched({
     $core.String? ticket,
     $core.String? matchId,
@@ -3833,43 +2966,58 @@ class MatchmakerMatched extends $pb.GeneratedMessage {
     $core.Iterable<MatchmakerMatched_MatchmakerUser>? users,
     MatchmakerMatched_MatchmakerUser? self,
   }) {
-    final _result = create();
-    if (ticket != null) {
-      _result.ticket = ticket;
-    }
-    if (matchId != null) {
-      _result.matchId = matchId;
-    }
-    if (token != null) {
-      _result.token = token;
-    }
-    if (users != null) {
-      _result.users.addAll(users);
-    }
-    if (self != null) {
-      _result.self = self;
-    }
-    return _result;
+    final result = create();
+    if (ticket != null) result.ticket = ticket;
+    if (matchId != null) result.matchId = matchId;
+    if (token != null) result.token = token;
+    if (users != null) result.users.addAll(users);
+    if (self != null) result.self = self;
+    return result;
   }
-  factory MatchmakerMatched.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchmakerMatched.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchmakerMatched clone() => MatchmakerMatched()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchmakerMatched._();
+
+  factory MatchmakerMatched.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchmakerMatched.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static const $core.Map<$core.int, MatchmakerMatched_Id>
+      _MatchmakerMatched_IdByTag = {
+    2: MatchmakerMatched_Id.matchId,
+    3: MatchmakerMatched_Id.token,
+    0: MatchmakerMatched_Id.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchmakerMatched',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..oo(0, [2, 3])
+    ..aOS(1, _omitFieldNames ? '' : 'ticket')
+    ..aOS(2, _omitFieldNames ? '' : 'matchId')
+    ..aOS(3, _omitFieldNames ? '' : 'token')
+    ..pPM<MatchmakerMatched_MatchmakerUser>(4, _omitFieldNames ? '' : 'users',
+        subBuilder: MatchmakerMatched_MatchmakerUser.create)
+    ..aOM<MatchmakerMatched_MatchmakerUser>(5, _omitFieldNames ? '' : 'self',
+        subBuilder: MatchmakerMatched_MatchmakerUser.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerMatched clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchmakerMatched copyWith(void Function(MatchmakerMatched) updates) =>
       super.copyWith((message) => updates(message as MatchmakerMatched))
-          as MatchmakerMatched; // ignore: deprecated_member_use
+          as MatchmakerMatched;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchmakerMatched create() => MatchmakerMatched._();
+  @$core.override
   MatchmakerMatched createEmptyInstance() => create();
   static $pb.PbList<MatchmakerMatched> createRepeated() =>
       $pb.PbList<MatchmakerMatched>();
@@ -3878,110 +3026,101 @@ class MatchmakerMatched extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<MatchmakerMatched>(create);
   static MatchmakerMatched? _defaultInstance;
 
+  @$pb.TagNumber(2)
+  @$pb.TagNumber(3)
   MatchmakerMatched_Id whichId() =>
       _MatchmakerMatched_IdByTag[$_whichOneof(0)]!;
-  void clearId() => clearField($_whichOneof(0));
+  @$pb.TagNumber(2)
+  @$pb.TagNumber(3)
+  void clearId() => $_clearField($_whichOneof(0));
 
+  /// The matchmaking ticket that has completed.
   @$pb.TagNumber(1)
   $core.String get ticket => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ticket($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ticket($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTicket() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTicket() => clearField(1);
+  void clearTicket() => $_clearField(1);
 
+  /// Match ID.
   @$pb.TagNumber(2)
   $core.String get matchId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set matchId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set matchId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMatchId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMatchId() => clearField(2);
+  void clearMatchId() => $_clearField(2);
 
+  /// Match join token.
   @$pb.TagNumber(3)
   $core.String get token => $_getSZ(2);
   @$pb.TagNumber(3)
-  set token($core.String v) {
-    $_setString(2, v);
-  }
-
+  set token($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasToken() => $_has(2);
   @$pb.TagNumber(3)
-  void clearToken() => clearField(3);
+  void clearToken() => $_clearField(3);
 
+  /// The users that have been matched together, and information about their matchmaking data.
   @$pb.TagNumber(4)
-  $core.List<MatchmakerMatched_MatchmakerUser> get users => $_getList(3);
+  $pb.PbList<MatchmakerMatched_MatchmakerUser> get users => $_getList(3);
 
+  /// A reference to the current user and their properties.
   @$pb.TagNumber(5)
   MatchmakerMatched_MatchmakerUser get self => $_getN(4);
   @$pb.TagNumber(5)
-  set self(MatchmakerMatched_MatchmakerUser v) {
-    setField(5, v);
-  }
-
+  set self(MatchmakerMatched_MatchmakerUser value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasSelf() => $_has(4);
   @$pb.TagNumber(5)
-  void clearSelf() => clearField(5);
+  void clearSelf() => $_clearField(5);
   @$pb.TagNumber(5)
   MatchmakerMatched_MatchmakerUser ensureSelf() => $_ensure(4);
 }
 
+/// Cancel an existing ongoing matchmaking process.
 class MatchmakerRemove extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchmakerRemove',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ticket')
-    ..hasRequiredFields = false;
-
-  MatchmakerRemove._() : super();
   factory MatchmakerRemove({
     $core.String? ticket,
   }) {
-    final _result = create();
-    if (ticket != null) {
-      _result.ticket = ticket;
-    }
-    return _result;
+    final result = create();
+    if (ticket != null) result.ticket = ticket;
+    return result;
   }
-  factory MatchmakerRemove.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchmakerRemove.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchmakerRemove clone() => MatchmakerRemove()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchmakerRemove._();
+
+  factory MatchmakerRemove.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchmakerRemove.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchmakerRemove',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'ticket')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerRemove clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchmakerRemove copyWith(void Function(MatchmakerRemove) updates) =>
       super.copyWith((message) => updates(message as MatchmakerRemove))
-          as MatchmakerRemove; // ignore: deprecated_member_use
+          as MatchmakerRemove;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchmakerRemove create() => MatchmakerRemove._();
+  @$core.override
   MatchmakerRemove createEmptyInstance() => create();
   static $pb.PbList<MatchmakerRemove> createRepeated() =>
       $pb.PbList<MatchmakerRemove>();
@@ -3990,65 +3129,57 @@ class MatchmakerRemove extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<MatchmakerRemove>(create);
   static MatchmakerRemove? _defaultInstance;
 
+  /// The ticket to cancel.
   @$pb.TagNumber(1)
   $core.String get ticket => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ticket($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ticket($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTicket() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTicket() => clearField(1);
+  void clearTicket() => $_clearField(1);
 }
 
+/// A ticket representing a new matchmaking process.
 class MatchmakerTicket extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'MatchmakerTicket',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ticket')
-    ..hasRequiredFields = false;
-
-  MatchmakerTicket._() : super();
   factory MatchmakerTicket({
     $core.String? ticket,
   }) {
-    final _result = create();
-    if (ticket != null) {
-      _result.ticket = ticket;
-    }
-    return _result;
+    final result = create();
+    if (ticket != null) result.ticket = ticket;
+    return result;
   }
-  factory MatchmakerTicket.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory MatchmakerTicket.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  MatchmakerTicket clone() => MatchmakerTicket()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  MatchmakerTicket._();
+
+  factory MatchmakerTicket.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory MatchmakerTicket.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'MatchmakerTicket',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'ticket')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  MatchmakerTicket clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   MatchmakerTicket copyWith(void Function(MatchmakerTicket) updates) =>
       super.copyWith((message) => updates(message as MatchmakerTicket))
-          as MatchmakerTicket; // ignore: deprecated_member_use
+          as MatchmakerTicket;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static MatchmakerTicket create() => MatchmakerTicket._();
+  @$core.override
   MatchmakerTicket createEmptyInstance() => create();
   static $pb.PbList<MatchmakerTicket> createRepeated() =>
       $pb.PbList<MatchmakerTicket>();
@@ -4057,67 +3188,58 @@ class MatchmakerTicket extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<MatchmakerTicket>(create);
   static MatchmakerTicket? _defaultInstance;
 
+  /// The ticket that can be used to cancel matchmaking.
   @$pb.TagNumber(1)
   $core.String get ticket => $_getSZ(0);
   @$pb.TagNumber(1)
-  set ticket($core.String v) {
-    $_setString(0, v);
-  }
-
+  set ticket($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasTicket() => $_has(0);
   @$pb.TagNumber(1)
-  void clearTicket() => clearField(1);
+  void clearTicket() => $_clearField(1);
 }
 
+/// A collection of zero or more notifications.
 class Notifications extends $pb.GeneratedMessage {
+  factory Notifications({
+    $core.Iterable<$0.Notification>? notifications,
+  }) {
+    final result = create();
+    if (notifications != null) result.notifications.addAll(notifications);
+    return result;
+  }
+
+  Notifications._();
+
+  factory Notifications.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Notifications.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Notifications',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'Notifications',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
-    ..pc<$2.Notification>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'notifications',
-        $pb.PbFieldType.PM,
-        subBuilder: $2.Notification.create)
+    ..pPM<$0.Notification>(1, _omitFieldNames ? '' : 'notifications',
+        subBuilder: $0.Notification.create)
     ..hasRequiredFields = false;
 
-  Notifications._() : super();
-  factory Notifications({
-    $core.Iterable<$2.Notification>? notifications,
-  }) {
-    final _result = create();
-    if (notifications != null) {
-      _result.notifications.addAll(notifications);
-    }
-    return _result;
-  }
-  factory Notifications.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Notifications.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Notifications clone() => Notifications()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Notifications clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Notifications copyWith(void Function(Notifications) updates) =>
       super.copyWith((message) => updates(message as Notifications))
-          as Notifications; // ignore: deprecated_member_use
+          as Notifications;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Notifications create() => Notifications._();
+  @$core.override
   Notifications createEmptyInstance() => create();
   static $pb.PbList<Notifications> createRepeated() =>
       $pb.PbList<Notifications>();
@@ -4126,106 +3248,74 @@ class Notifications extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<Notifications>(create);
   static Notifications? _defaultInstance;
 
+  /// Collection of notifications.
   @$pb.TagNumber(1)
-  $core.List<$2.Notification> get notifications => $_getList(0);
+  $pb.PbList<$0.Notification> get notifications => $_getList(0);
 }
 
+/// Incoming information about a party.
 class Party extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Party',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aOB(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'open')
-    ..a<$core.int>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxSize',
-        $pb.PbFieldType.O3)
-    ..aOM<UserPresence>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'self',
-        subBuilder: UserPresence.create)
-    ..aOM<UserPresence>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leader',
-        subBuilder: UserPresence.create)
-    ..pc<UserPresence>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presences',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  Party._() : super();
   factory Party({
     $core.String? partyId,
     $core.bool? open,
+    $core.bool? hidden,
     $core.int? maxSize,
     UserPresence? self,
     UserPresence? leader,
     $core.Iterable<UserPresence>? presences,
+    $core.String? label,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (open != null) {
-      _result.open = open;
-    }
-    if (maxSize != null) {
-      _result.maxSize = maxSize;
-    }
-    if (self != null) {
-      _result.self = self;
-    }
-    if (leader != null) {
-      _result.leader = leader;
-    }
-    if (presences != null) {
-      _result.presences.addAll(presences);
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (open != null) result.open = open;
+    if (hidden != null) result.hidden = hidden;
+    if (maxSize != null) result.maxSize = maxSize;
+    if (self != null) result.self = self;
+    if (leader != null) result.leader = leader;
+    if (presences != null) result.presences.addAll(presences);
+    if (label != null) result.label = label;
+    return result;
   }
-  factory Party.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Party.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Party clone() => Party()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Party._();
+
+  factory Party.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Party.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Party',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOB(2, _omitFieldNames ? '' : 'open')
+    ..aOB(3, _omitFieldNames ? '' : 'hidden')
+    ..aI(4, _omitFieldNames ? '' : 'maxSize')
+    ..aOM<UserPresence>(5, _omitFieldNames ? '' : 'self',
+        subBuilder: UserPresence.create)
+    ..aOM<UserPresence>(6, _omitFieldNames ? '' : 'leader',
+        subBuilder: UserPresence.create)
+    ..pPM<UserPresence>(7, _omitFieldNames ? '' : 'presences',
+        subBuilder: UserPresence.create)
+    ..aOS(8, _omitFieldNames ? '' : 'label')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Party clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Party copyWith(void Function(Party) updates) =>
-      super.copyWith((message) => updates(message as Party))
-          as Party; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Party)) as Party;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Party create() => Party._();
+  @$core.override
   Party createEmptyInstance() => create();
   static $pb.PbList<Party> createRepeated() => $pb.PbList<Party>();
   @$core.pragma('dart2js:noInline')
@@ -4233,130 +3323,134 @@ class Party extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Party>(create);
   static Party? _defaultInstance;
 
+  /// Unique party identifier.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// Open flag.
   @$pb.TagNumber(2)
   $core.bool get open => $_getBF(1);
   @$pb.TagNumber(2)
-  set open($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set open($core.bool value) => $_setBool(1, value);
   @$pb.TagNumber(2)
   $core.bool hasOpen() => $_has(1);
   @$pb.TagNumber(2)
-  void clearOpen() => clearField(2);
+  void clearOpen() => $_clearField(2);
 
+  /// Hidden flag.
   @$pb.TagNumber(3)
-  $core.int get maxSize => $_getIZ(2);
+  $core.bool get hidden => $_getBF(2);
   @$pb.TagNumber(3)
-  set maxSize($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set hidden($core.bool value) => $_setBool(2, value);
   @$pb.TagNumber(3)
-  $core.bool hasMaxSize() => $_has(2);
+  $core.bool hasHidden() => $_has(2);
   @$pb.TagNumber(3)
-  void clearMaxSize() => clearField(3);
+  void clearHidden() => $_clearField(3);
 
+  /// Maximum number of party members.
   @$pb.TagNumber(4)
-  UserPresence get self => $_getN(3);
+  $core.int get maxSize => $_getIZ(3);
   @$pb.TagNumber(4)
-  set self(UserPresence v) {
-    setField(4, v);
-  }
+  set maxSize($core.int value) => $_setSignedInt32(3, value);
+  @$pb.TagNumber(4)
+  $core.bool hasMaxSize() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMaxSize() => $_clearField(4);
 
-  @$pb.TagNumber(4)
-  $core.bool hasSelf() => $_has(3);
-  @$pb.TagNumber(4)
-  void clearSelf() => clearField(4);
-  @$pb.TagNumber(4)
-  UserPresence ensureSelf() => $_ensure(3);
+  /// Self.
+  @$pb.TagNumber(5)
+  UserPresence get self => $_getN(4);
+  @$pb.TagNumber(5)
+  set self(UserPresence value) => $_setField(5, value);
+  @$pb.TagNumber(5)
+  $core.bool hasSelf() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSelf() => $_clearField(5);
+  @$pb.TagNumber(5)
+  UserPresence ensureSelf() => $_ensure(4);
 
-  @$pb.TagNumber(5)
-  UserPresence get leader => $_getN(4);
-  @$pb.TagNumber(5)
-  set leader(UserPresence v) {
-    setField(5, v);
-  }
-
-  @$pb.TagNumber(5)
-  $core.bool hasLeader() => $_has(4);
-  @$pb.TagNumber(5)
-  void clearLeader() => clearField(5);
-  @$pb.TagNumber(5)
-  UserPresence ensureLeader() => $_ensure(4);
-
+  /// Leader.
   @$pb.TagNumber(6)
-  $core.List<UserPresence> get presences => $_getList(5);
+  UserPresence get leader => $_getN(5);
+  @$pb.TagNumber(6)
+  set leader(UserPresence value) => $_setField(6, value);
+  @$pb.TagNumber(6)
+  $core.bool hasLeader() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearLeader() => $_clearField(6);
+  @$pb.TagNumber(6)
+  UserPresence ensureLeader() => $_ensure(5);
+
+  /// All current party members.
+  @$pb.TagNumber(7)
+  $pb.PbList<UserPresence> get presences => $_getList(6);
+
+  /// Label for party listing.
+  @$pb.TagNumber(8)
+  $core.String get label => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set label($core.String value) => $_setString(7, value);
+  @$pb.TagNumber(8)
+  $core.bool hasLabel() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearLabel() => $_clearField(8);
 }
 
+/// Create a party.
 class PartyCreate extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyCreate',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOB(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'open')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxSize',
-        $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
-
-  PartyCreate._() : super();
   factory PartyCreate({
     $core.bool? open,
     $core.int? maxSize,
+    $core.String? label,
+    $core.bool? hidden,
   }) {
-    final _result = create();
-    if (open != null) {
-      _result.open = open;
-    }
-    if (maxSize != null) {
-      _result.maxSize = maxSize;
-    }
-    return _result;
+    final result = create();
+    if (open != null) result.open = open;
+    if (maxSize != null) result.maxSize = maxSize;
+    if (label != null) result.label = label;
+    if (hidden != null) result.hidden = hidden;
+    return result;
   }
-  factory PartyCreate.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyCreate.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyCreate clone() => PartyCreate()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyCreate._();
+
+  factory PartyCreate.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyCreate.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyCreate',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'open')
+    ..aI(2, _omitFieldNames ? '' : 'maxSize')
+    ..aOS(3, _omitFieldNames ? '' : 'label')
+    ..aOB(4, _omitFieldNames ? '' : 'hidden')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyCreate clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyCreate copyWith(void Function(PartyCreate) updates) =>
       super.copyWith((message) => updates(message as PartyCreate))
-          as PartyCreate; // ignore: deprecated_member_use
+          as PartyCreate;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyCreate create() => PartyCreate._();
+  @$core.override
   PartyCreate createEmptyInstance() => create();
   static $pb.PbList<PartyCreate> createRepeated() => $pb.PbList<PartyCreate>();
   @$core.pragma('dart2js:noInline')
@@ -4364,77 +3458,183 @@ class PartyCreate extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyCreate>(create);
   static PartyCreate? _defaultInstance;
 
+  /// Whether or not the party will require join requests to be approved by the party leader.
   @$pb.TagNumber(1)
   $core.bool get open => $_getBF(0);
   @$pb.TagNumber(1)
-  set open($core.bool v) {
-    $_setBool(0, v);
-  }
-
+  set open($core.bool value) => $_setBool(0, value);
   @$pb.TagNumber(1)
   $core.bool hasOpen() => $_has(0);
   @$pb.TagNumber(1)
-  void clearOpen() => clearField(1);
+  void clearOpen() => $_clearField(1);
 
+  /// Maximum number of party members.
   @$pb.TagNumber(2)
   $core.int get maxSize => $_getIZ(1);
   @$pb.TagNumber(2)
-  set maxSize($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set maxSize($core.int value) => $_setSignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMaxSize() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMaxSize() => clearField(2);
+  void clearMaxSize() => $_clearField(2);
+
+  /// Label
+  @$pb.TagNumber(3)
+  $core.String get label => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set label($core.String value) => $_setString(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasLabel() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearLabel() => $_clearField(3);
+
+  /// Whether the party is visible in party listings.
+  @$pb.TagNumber(4)
+  $core.bool get hidden => $_getBF(3);
+  @$pb.TagNumber(4)
+  set hidden($core.bool value) => $_setBool(3, value);
+  @$pb.TagNumber(4)
+  $core.bool hasHidden() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearHidden() => $_clearField(4);
 }
 
-class PartyJoin extends $pb.GeneratedMessage {
+/// Update a party label.
+class PartyUpdate extends $pb.GeneratedMessage {
+  factory PartyUpdate({
+    $core.String? partyId,
+    $core.String? label,
+    $core.bool? open,
+    $core.bool? hidden,
+  }) {
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (label != null) result.label = label;
+    if (open != null) result.open = open;
+    if (hidden != null) result.hidden = hidden;
+    return result;
+  }
+
+  PartyUpdate._();
+
+  factory PartyUpdate.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyUpdate.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyJoin',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'PartyUpdate',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOS(2, _omitFieldNames ? '' : 'label')
+    ..aOB(3, _omitFieldNames ? '' : 'open')
+    ..aOB(4, _omitFieldNames ? '' : 'hidden')
     ..hasRequiredFields = false;
 
-  PartyJoin._() : super();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyUpdate clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyUpdate copyWith(void Function(PartyUpdate) updates) =>
+      super.copyWith((message) => updates(message as PartyUpdate))
+          as PartyUpdate;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PartyUpdate create() => PartyUpdate._();
+  @$core.override
+  PartyUpdate createEmptyInstance() => create();
+  static $pb.PbList<PartyUpdate> createRepeated() => $pb.PbList<PartyUpdate>();
+  @$core.pragma('dart2js:noInline')
+  static PartyUpdate getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PartyUpdate>(create);
+  static PartyUpdate? _defaultInstance;
+
+  /// Party ID.
+  @$pb.TagNumber(1)
+  $core.String get partyId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set partyId($core.String value) => $_setString(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasPartyId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPartyId() => $_clearField(1);
+
+  /// Label to set.
+  @$pb.TagNumber(2)
+  $core.String get label => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set label($core.String value) => $_setString(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasLabel() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearLabel() => $_clearField(2);
+
+  /// Change the party to open or closed.
+  @$pb.TagNumber(3)
+  $core.bool get open => $_getBF(2);
+  @$pb.TagNumber(3)
+  set open($core.bool value) => $_setBool(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasOpen() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearOpen() => $_clearField(3);
+
+  /// Whether the party is visible in party listings.
+  @$pb.TagNumber(4)
+  $core.bool get hidden => $_getBF(3);
+  @$pb.TagNumber(4)
+  set hidden($core.bool value) => $_setBool(3, value);
+  @$pb.TagNumber(4)
+  $core.bool hasHidden() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearHidden() => $_clearField(4);
+}
+
+/// Join a party, or request to join if the party is not open.
+class PartyJoin extends $pb.GeneratedMessage {
   factory PartyJoin({
     $core.String? partyId,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    return result;
   }
-  factory PartyJoin.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyJoin.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyJoin clone() => PartyJoin()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyJoin._();
+
+  factory PartyJoin.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyJoin.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyJoin',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyJoin clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyJoin copyWith(void Function(PartyJoin) updates) =>
-      super.copyWith((message) => updates(message as PartyJoin))
-          as PartyJoin; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as PartyJoin)) as PartyJoin;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyJoin create() => PartyJoin._();
+  @$core.override
   PartyJoin createEmptyInstance() => create();
   static $pb.PbList<PartyJoin> createRepeated() => $pb.PbList<PartyJoin>();
   @$core.pragma('dart2js:noInline')
@@ -4442,65 +3642,56 @@ class PartyJoin extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PartyJoin>(create);
   static PartyJoin? _defaultInstance;
 
+  /// Party ID to join.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 }
 
+/// Leave a party.
 class PartyLeave extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyLeave',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..hasRequiredFields = false;
-
-  PartyLeave._() : super();
   factory PartyLeave({
     $core.String? partyId,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    return result;
   }
-  factory PartyLeave.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyLeave.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyLeave clone() => PartyLeave()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyLeave._();
+
+  factory PartyLeave.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyLeave.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyLeave',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyLeave clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyLeave copyWith(void Function(PartyLeave) updates) =>
-      super.copyWith((message) => updates(message as PartyLeave))
-          as PartyLeave; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as PartyLeave)) as PartyLeave;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyLeave create() => PartyLeave._();
+  @$core.override
   PartyLeave createEmptyInstance() => create();
   static $pb.PbList<PartyLeave> createRepeated() => $pb.PbList<PartyLeave>();
   @$core.pragma('dart2js:noInline')
@@ -4508,75 +3699,61 @@ class PartyLeave extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyLeave>(create);
   static PartyLeave? _defaultInstance;
 
+  /// Party ID to leave.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 }
 
+/// Promote a new party leader.
 class PartyPromote extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyPromote',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aOM<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presence',
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  PartyPromote._() : super();
   factory PartyPromote({
     $core.String? partyId,
     UserPresence? presence,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (presence != null) {
-      _result.presence = presence;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (presence != null) result.presence = presence;
+    return result;
   }
-  factory PartyPromote.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyPromote.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyPromote clone() => PartyPromote()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyPromote._();
+
+  factory PartyPromote.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyPromote.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyPromote',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOM<UserPresence>(2, _omitFieldNames ? '' : 'presence',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyPromote clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyPromote copyWith(void Function(PartyPromote) updates) =>
       super.copyWith((message) => updates(message as PartyPromote))
-          as PartyPromote; // ignore: deprecated_member_use
+          as PartyPromote;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyPromote create() => PartyPromote._();
+  @$core.override
   PartyPromote createEmptyInstance() => create();
   static $pb.PbList<PartyPromote> createRepeated() =>
       $pb.PbList<PartyPromote>();
@@ -4585,89 +3762,73 @@ class PartyPromote extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyPromote>(create);
   static PartyPromote? _defaultInstance;
 
+  /// Party ID to promote a new leader for.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// The presence of an existing party member to promote as the new leader.
   @$pb.TagNumber(2)
   UserPresence get presence => $_getN(1);
   @$pb.TagNumber(2)
-  set presence(UserPresence v) {
-    setField(2, v);
-  }
-
+  set presence(UserPresence value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPresence() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPresence() => clearField(2);
+  void clearPresence() => $_clearField(2);
   @$pb.TagNumber(2)
   UserPresence ensurePresence() => $_ensure(1);
 }
 
+/// Announcement of a new party leader.
 class PartyLeader extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyLeader',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aOM<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presence',
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  PartyLeader._() : super();
   factory PartyLeader({
     $core.String? partyId,
     UserPresence? presence,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (presence != null) {
-      _result.presence = presence;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (presence != null) result.presence = presence;
+    return result;
   }
-  factory PartyLeader.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyLeader.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyLeader clone() => PartyLeader()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyLeader._();
+
+  factory PartyLeader.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyLeader.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyLeader',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOM<UserPresence>(2, _omitFieldNames ? '' : 'presence',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyLeader clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyLeader copyWith(void Function(PartyLeader) updates) =>
       super.copyWith((message) => updates(message as PartyLeader))
-          as PartyLeader; // ignore: deprecated_member_use
+          as PartyLeader;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyLeader create() => PartyLeader._();
+  @$core.override
   PartyLeader createEmptyInstance() => create();
   static $pb.PbList<PartyLeader> createRepeated() => $pb.PbList<PartyLeader>();
   @$core.pragma('dart2js:noInline')
@@ -4675,89 +3836,73 @@ class PartyLeader extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyLeader>(create);
   static PartyLeader? _defaultInstance;
 
+  /// Party ID to announce the new leader for.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// The presence of the new party leader.
   @$pb.TagNumber(2)
   UserPresence get presence => $_getN(1);
   @$pb.TagNumber(2)
-  set presence(UserPresence v) {
-    setField(2, v);
-  }
-
+  set presence(UserPresence value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPresence() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPresence() => clearField(2);
+  void clearPresence() => $_clearField(2);
   @$pb.TagNumber(2)
   UserPresence ensurePresence() => $_ensure(1);
 }
 
+/// Accept a request to join.
 class PartyAccept extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyAccept',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aOM<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presence',
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  PartyAccept._() : super();
   factory PartyAccept({
     $core.String? partyId,
     UserPresence? presence,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (presence != null) {
-      _result.presence = presence;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (presence != null) result.presence = presence;
+    return result;
   }
-  factory PartyAccept.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyAccept.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyAccept clone() => PartyAccept()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyAccept._();
+
+  factory PartyAccept.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyAccept.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyAccept',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOM<UserPresence>(2, _omitFieldNames ? '' : 'presence',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyAccept clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyAccept copyWith(void Function(PartyAccept) updates) =>
       super.copyWith((message) => updates(message as PartyAccept))
-          as PartyAccept; // ignore: deprecated_member_use
+          as PartyAccept;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyAccept create() => PartyAccept._();
+  @$core.override
   PartyAccept createEmptyInstance() => create();
   static $pb.PbList<PartyAccept> createRepeated() => $pb.PbList<PartyAccept>();
   @$core.pragma('dart2js:noInline')
@@ -4765,89 +3910,73 @@ class PartyAccept extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyAccept>(create);
   static PartyAccept? _defaultInstance;
 
+  /// Party ID to accept a join request for.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// The presence to accept as a party member.
   @$pb.TagNumber(2)
   UserPresence get presence => $_getN(1);
   @$pb.TagNumber(2)
-  set presence(UserPresence v) {
-    setField(2, v);
-  }
-
+  set presence(UserPresence value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPresence() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPresence() => clearField(2);
+  void clearPresence() => $_clearField(2);
   @$pb.TagNumber(2)
   UserPresence ensurePresence() => $_ensure(1);
 }
 
+/// Kick a party member, or decline a request to join.
 class PartyRemove extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyRemove',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aOM<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presence',
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  PartyRemove._() : super();
   factory PartyRemove({
     $core.String? partyId,
     UserPresence? presence,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (presence != null) {
-      _result.presence = presence;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (presence != null) result.presence = presence;
+    return result;
   }
-  factory PartyRemove.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyRemove.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyRemove clone() => PartyRemove()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyRemove._();
+
+  factory PartyRemove.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyRemove.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyRemove',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOM<UserPresence>(2, _omitFieldNames ? '' : 'presence',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyRemove clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyRemove copyWith(void Function(PartyRemove) updates) =>
       super.copyWith((message) => updates(message as PartyRemove))
-          as PartyRemove; // ignore: deprecated_member_use
+          as PartyRemove;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyRemove create() => PartyRemove._();
+  @$core.override
   PartyRemove createEmptyInstance() => create();
   static $pb.PbList<PartyRemove> createRepeated() => $pb.PbList<PartyRemove>();
   @$core.pragma('dart2js:noInline')
@@ -4855,79 +3984,68 @@ class PartyRemove extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyRemove>(create);
   static PartyRemove? _defaultInstance;
 
+  /// Party ID to remove/reject from.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// The presence to remove or reject.
   @$pb.TagNumber(2)
   UserPresence get presence => $_getN(1);
   @$pb.TagNumber(2)
-  set presence(UserPresence v) {
-    setField(2, v);
-  }
-
+  set presence(UserPresence value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPresence() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPresence() => clearField(2);
+  void clearPresence() => $_clearField(2);
   @$pb.TagNumber(2)
   UserPresence ensurePresence() => $_ensure(1);
 }
 
+/// End a party, kicking all party members and closing it.
 class PartyClose extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyClose',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..hasRequiredFields = false;
-
-  PartyClose._() : super();
   factory PartyClose({
     $core.String? partyId,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    return result;
   }
-  factory PartyClose.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyClose.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyClose clone() => PartyClose()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyClose._();
+
+  factory PartyClose.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyClose.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyClose',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyClose clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyClose copyWith(void Function(PartyClose) updates) =>
-      super.copyWith((message) => updates(message as PartyClose))
-          as PartyClose; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as PartyClose)) as PartyClose;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyClose create() => PartyClose._();
+  @$core.override
   PartyClose createEmptyInstance() => create();
   static $pb.PbList<PartyClose> createRepeated() => $pb.PbList<PartyClose>();
   @$core.pragma('dart2js:noInline')
@@ -4935,66 +4053,57 @@ class PartyClose extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyClose>(create);
   static PartyClose? _defaultInstance;
 
+  /// Party ID to close.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 }
 
+/// Request a list of pending join requests for a party.
 class PartyJoinRequestList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyJoinRequestList',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..hasRequiredFields = false;
-
-  PartyJoinRequestList._() : super();
   factory PartyJoinRequestList({
     $core.String? partyId,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    return result;
   }
-  factory PartyJoinRequestList.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyJoinRequestList.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyJoinRequestList clone() =>
-      PartyJoinRequestList()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyJoinRequestList._();
+
+  factory PartyJoinRequestList.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyJoinRequestList.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyJoinRequestList',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyJoinRequestList clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyJoinRequestList copyWith(void Function(PartyJoinRequestList) updates) =>
       super.copyWith((message) => updates(message as PartyJoinRequestList))
-          as PartyJoinRequestList; // ignore: deprecated_member_use
+          as PartyJoinRequestList;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyJoinRequestList create() => PartyJoinRequestList._();
+  @$core.override
   PartyJoinRequestList createEmptyInstance() => create();
   static $pb.PbList<PartyJoinRequestList> createRepeated() =>
       $pb.PbList<PartyJoinRequestList>();
@@ -5003,76 +4112,61 @@ class PartyJoinRequestList extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyJoinRequestList>(create);
   static PartyJoinRequestList? _defaultInstance;
 
+  /// Party ID to get a list of join requests for.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 }
 
+/// Incoming notification for one or more new presences attempting to join the party.
 class PartyJoinRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyJoinRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..pc<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presences',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  PartyJoinRequest._() : super();
   factory PartyJoinRequest({
     $core.String? partyId,
     $core.Iterable<UserPresence>? presences,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (presences != null) {
-      _result.presences.addAll(presences);
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (presences != null) result.presences.addAll(presences);
+    return result;
   }
-  factory PartyJoinRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyJoinRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyJoinRequest clone() => PartyJoinRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyJoinRequest._();
+
+  factory PartyJoinRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyJoinRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyJoinRequest',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..pPM<UserPresence>(2, _omitFieldNames ? '' : 'presences',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyJoinRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyJoinRequest copyWith(void Function(PartyJoinRequest) updates) =>
       super.copyWith((message) => updates(message as PartyJoinRequest))
-          as PartyJoinRequest; // ignore: deprecated_member_use
+          as PartyJoinRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyJoinRequest create() => PartyJoinRequest._();
+  @$core.override
   PartyJoinRequest createEmptyInstance() => create();
   static $pb.PbList<PartyJoinRequest> createRepeated() =>
       $pb.PbList<PartyJoinRequest>();
@@ -5081,133 +4175,94 @@ class PartyJoinRequest extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyJoinRequest>(create);
   static PartyJoinRequest? _defaultInstance;
 
+  /// Party ID these presences are attempting to join.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// Presences attempting to join.
   @$pb.TagNumber(2)
-  $core.List<UserPresence> get presences => $_getList(1);
+  $pb.PbList<UserPresence> get presences => $_getList(1);
 }
 
+/// Begin matchmaking as a party.
 class PartyMatchmakerAdd extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyMatchmakerAdd',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'minCount',
-        $pb.PbFieldType.O3)
-    ..a<$core.int>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'maxCount',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'query')
-    ..m<$core.String, $core.String>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'stringProperties',
-        entryClassName: 'PartyMatchmakerAdd.StringPropertiesEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
-        packageName: const $pb.PackageName('nakama.realtime'))
-    ..m<$core.String, $core.double>(
-        6,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'numericProperties',
-        entryClassName: 'PartyMatchmakerAdd.NumericPropertiesEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OD,
-        packageName: const $pb.PackageName('nakama.realtime'))
-    ..aOM<$1.Int32Value>(
-        7,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'countMultiple',
-        subBuilder: $1.Int32Value.create)
-    ..hasRequiredFields = false;
-
-  PartyMatchmakerAdd._() : super();
   factory PartyMatchmakerAdd({
     $core.String? partyId,
     $core.int? minCount,
     $core.int? maxCount,
     $core.String? query,
-    $core.Map<$core.String, $core.String>? stringProperties,
-    $core.Map<$core.String, $core.double>? numericProperties,
+    $core.Iterable<$core.MapEntry<$core.String, $core.String>>?
+        stringProperties,
+    $core.Iterable<$core.MapEntry<$core.String, $core.double>>?
+        numericProperties,
     $1.Int32Value? countMultiple,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (minCount != null) {
-      _result.minCount = minCount;
-    }
-    if (maxCount != null) {
-      _result.maxCount = maxCount;
-    }
-    if (query != null) {
-      _result.query = query;
-    }
-    if (stringProperties != null) {
-      _result.stringProperties.addAll(stringProperties);
-    }
-    if (numericProperties != null) {
-      _result.numericProperties.addAll(numericProperties);
-    }
-    if (countMultiple != null) {
-      _result.countMultiple = countMultiple;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (minCount != null) result.minCount = minCount;
+    if (maxCount != null) result.maxCount = maxCount;
+    if (query != null) result.query = query;
+    if (stringProperties != null)
+      result.stringProperties.addEntries(stringProperties);
+    if (numericProperties != null)
+      result.numericProperties.addEntries(numericProperties);
+    if (countMultiple != null) result.countMultiple = countMultiple;
+    return result;
   }
-  factory PartyMatchmakerAdd.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyMatchmakerAdd.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyMatchmakerAdd clone() => PartyMatchmakerAdd()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyMatchmakerAdd._();
+
+  factory PartyMatchmakerAdd.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyMatchmakerAdd.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyMatchmakerAdd',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aI(2, _omitFieldNames ? '' : 'minCount')
+    ..aI(3, _omitFieldNames ? '' : 'maxCount')
+    ..aOS(4, _omitFieldNames ? '' : 'query')
+    ..m<$core.String, $core.String>(
+        5, _omitFieldNames ? '' : 'stringProperties',
+        entryClassName: 'PartyMatchmakerAdd.StringPropertiesEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OS,
+        packageName: const $pb.PackageName('nakama.realtime'))
+    ..m<$core.String, $core.double>(
+        6, _omitFieldNames ? '' : 'numericProperties',
+        entryClassName: 'PartyMatchmakerAdd.NumericPropertiesEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OD,
+        packageName: const $pb.PackageName('nakama.realtime'))
+    ..aOM<$1.Int32Value>(7, _omitFieldNames ? '' : 'countMultiple',
+        subBuilder: $1.Int32Value.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyMatchmakerAdd clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyMatchmakerAdd copyWith(void Function(PartyMatchmakerAdd) updates) =>
       super.copyWith((message) => updates(message as PartyMatchmakerAdd))
-          as PartyMatchmakerAdd; // ignore: deprecated_member_use
+          as PartyMatchmakerAdd;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyMatchmakerAdd create() => PartyMatchmakerAdd._();
+  @$core.override
   PartyMatchmakerAdd createEmptyInstance() => create();
   static $pb.PbList<PartyMatchmakerAdd> createRepeated() =>
       $pb.PbList<PartyMatchmakerAdd>();
@@ -5216,132 +4271,111 @@ class PartyMatchmakerAdd extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyMatchmakerAdd>(create);
   static PartyMatchmakerAdd? _defaultInstance;
 
+  /// Party ID.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// Minimum total user count to match together.
   @$pb.TagNumber(2)
   $core.int get minCount => $_getIZ(1);
   @$pb.TagNumber(2)
-  set minCount($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set minCount($core.int value) => $_setSignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasMinCount() => $_has(1);
   @$pb.TagNumber(2)
-  void clearMinCount() => clearField(2);
+  void clearMinCount() => $_clearField(2);
 
+  /// Maximum total user count to match together.
   @$pb.TagNumber(3)
   $core.int get maxCount => $_getIZ(2);
   @$pb.TagNumber(3)
-  set maxCount($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set maxCount($core.int value) => $_setSignedInt32(2, value);
   @$pb.TagNumber(3)
   $core.bool hasMaxCount() => $_has(2);
   @$pb.TagNumber(3)
-  void clearMaxCount() => clearField(3);
+  void clearMaxCount() => $_clearField(3);
 
+  /// Filter query used to identify suitable users.
   @$pb.TagNumber(4)
   $core.String get query => $_getSZ(3);
   @$pb.TagNumber(4)
-  set query($core.String v) {
-    $_setString(3, v);
-  }
-
+  set query($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasQuery() => $_has(3);
   @$pb.TagNumber(4)
-  void clearQuery() => clearField(4);
+  void clearQuery() => $_clearField(4);
 
+  /// String properties.
   @$pb.TagNumber(5)
-  $core.Map<$core.String, $core.String> get stringProperties => $_getMap(4);
+  $pb.PbMap<$core.String, $core.String> get stringProperties => $_getMap(4);
 
+  /// Numeric properties.
   @$pb.TagNumber(6)
-  $core.Map<$core.String, $core.double> get numericProperties => $_getMap(5);
+  $pb.PbMap<$core.String, $core.double> get numericProperties => $_getMap(5);
 
+  /// Optional multiple of the count that must be satisfied.
   @$pb.TagNumber(7)
   $1.Int32Value get countMultiple => $_getN(6);
   @$pb.TagNumber(7)
-  set countMultiple($1.Int32Value v) {
-    setField(7, v);
-  }
-
+  set countMultiple($1.Int32Value value) => $_setField(7, value);
   @$pb.TagNumber(7)
   $core.bool hasCountMultiple() => $_has(6);
   @$pb.TagNumber(7)
-  void clearCountMultiple() => clearField(7);
+  void clearCountMultiple() => $_clearField(7);
   @$pb.TagNumber(7)
   $1.Int32Value ensureCountMultiple() => $_ensure(6);
 }
 
+/// Cancel a party matchmaking process using a ticket.
 class PartyMatchmakerRemove extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyMatchmakerRemove',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ticket')
-    ..hasRequiredFields = false;
-
-  PartyMatchmakerRemove._() : super();
   factory PartyMatchmakerRemove({
     $core.String? partyId,
     $core.String? ticket,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (ticket != null) {
-      _result.ticket = ticket;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (ticket != null) result.ticket = ticket;
+    return result;
   }
-  factory PartyMatchmakerRemove.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyMatchmakerRemove.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyMatchmakerRemove clone() =>
-      PartyMatchmakerRemove()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyMatchmakerRemove._();
+
+  factory PartyMatchmakerRemove.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyMatchmakerRemove.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyMatchmakerRemove',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOS(2, _omitFieldNames ? '' : 'ticket')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyMatchmakerRemove clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyMatchmakerRemove copyWith(
           void Function(PartyMatchmakerRemove) updates) =>
       super.copyWith((message) => updates(message as PartyMatchmakerRemove))
-          as PartyMatchmakerRemove; // ignore: deprecated_member_use
+          as PartyMatchmakerRemove;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyMatchmakerRemove create() => PartyMatchmakerRemove._();
+  @$core.override
   PartyMatchmakerRemove createEmptyInstance() => create();
   static $pb.PbList<PartyMatchmakerRemove> createRepeated() =>
       $pb.PbList<PartyMatchmakerRemove>();
@@ -5350,88 +4384,71 @@ class PartyMatchmakerRemove extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyMatchmakerRemove>(create);
   static PartyMatchmakerRemove? _defaultInstance;
 
+  /// Party ID.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// The ticket to cancel.
   @$pb.TagNumber(2)
   $core.String get ticket => $_getSZ(1);
   @$pb.TagNumber(2)
-  set ticket($core.String v) {
-    $_setString(1, v);
-  }
-
+  set ticket($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasTicket() => $_has(1);
   @$pb.TagNumber(2)
-  void clearTicket() => clearField(2);
+  void clearTicket() => $_clearField(2);
 }
 
+/// A response from starting a new party matchmaking process.
 class PartyMatchmakerTicket extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyMatchmakerTicket',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'ticket')
-    ..hasRequiredFields = false;
-
-  PartyMatchmakerTicket._() : super();
   factory PartyMatchmakerTicket({
     $core.String? partyId,
     $core.String? ticket,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (ticket != null) {
-      _result.ticket = ticket;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (ticket != null) result.ticket = ticket;
+    return result;
   }
-  factory PartyMatchmakerTicket.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyMatchmakerTicket.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyMatchmakerTicket clone() =>
-      PartyMatchmakerTicket()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyMatchmakerTicket._();
+
+  factory PartyMatchmakerTicket.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyMatchmakerTicket.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyMatchmakerTicket',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOS(2, _omitFieldNames ? '' : 'ticket')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyMatchmakerTicket clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyMatchmakerTicket copyWith(
           void Function(PartyMatchmakerTicket) updates) =>
       super.copyWith((message) => updates(message as PartyMatchmakerTicket))
-          as PartyMatchmakerTicket; // ignore: deprecated_member_use
+          as PartyMatchmakerTicket;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyMatchmakerTicket create() => PartyMatchmakerTicket._();
+  @$core.override
   PartyMatchmakerTicket createEmptyInstance() => create();
   static $pb.PbList<PartyMatchmakerTicket> createRepeated() =>
       $pb.PbList<PartyMatchmakerTicket>();
@@ -5440,106 +4457,77 @@ class PartyMatchmakerTicket extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyMatchmakerTicket>(create);
   static PartyMatchmakerTicket? _defaultInstance;
 
+  /// Party ID.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// The ticket that can be used to cancel matchmaking.
   @$pb.TagNumber(2)
   $core.String get ticket => $_getSZ(1);
   @$pb.TagNumber(2)
-  set ticket($core.String v) {
-    $_setString(1, v);
-  }
-
+  set ticket($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasTicket() => $_has(1);
   @$pb.TagNumber(2)
-  void clearTicket() => clearField(2);
+  void clearTicket() => $_clearField(2);
 }
 
+/// Incoming party data delivered from the server.
 class PartyData extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyData',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aOM<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presence',
-        subBuilder: UserPresence.create)
-    ..aInt64(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'opCode')
-    ..a<$core.List<$core.int>>(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'data',
-        $pb.PbFieldType.OY)
-    ..hasRequiredFields = false;
-
-  PartyData._() : super();
   factory PartyData({
     $core.String? partyId,
     UserPresence? presence,
     $fixnum.Int64? opCode,
     $core.List<$core.int>? data,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (presence != null) {
-      _result.presence = presence;
-    }
-    if (opCode != null) {
-      _result.opCode = opCode;
-    }
-    if (data != null) {
-      _result.data = data;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (presence != null) result.presence = presence;
+    if (opCode != null) result.opCode = opCode;
+    if (data != null) result.data = data;
+    return result;
   }
-  factory PartyData.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyData.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyData clone() => PartyData()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyData._();
+
+  factory PartyData.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyData.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyData',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aOM<UserPresence>(2, _omitFieldNames ? '' : 'presence',
+        subBuilder: UserPresence.create)
+    ..aInt64(3, _omitFieldNames ? '' : 'opCode')
+    ..a<$core.List<$core.int>>(
+        4, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyData clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyData copyWith(void Function(PartyData) updates) =>
-      super.copyWith((message) => updates(message as PartyData))
-          as PartyData; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as PartyData)) as PartyData;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyData create() => PartyData._();
+  @$core.override
   PartyData createEmptyInstance() => create();
   static $pb.PbList<PartyData> createRepeated() => $pb.PbList<PartyData>();
   @$core.pragma('dart2js:noInline')
@@ -5547,122 +4535,96 @@ class PartyData extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PartyData>(create);
   static PartyData? _defaultInstance;
 
+  /// The party ID.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// A reference to the user presence that sent this data, if any.
   @$pb.TagNumber(2)
   UserPresence get presence => $_getN(1);
   @$pb.TagNumber(2)
-  set presence(UserPresence v) {
-    setField(2, v);
-  }
-
+  set presence(UserPresence value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasPresence() => $_has(1);
   @$pb.TagNumber(2)
-  void clearPresence() => clearField(2);
+  void clearPresence() => $_clearField(2);
   @$pb.TagNumber(2)
   UserPresence ensurePresence() => $_ensure(1);
 
+  /// Op code value.
   @$pb.TagNumber(3)
   $fixnum.Int64 get opCode => $_getI64(2);
   @$pb.TagNumber(3)
-  set opCode($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set opCode($fixnum.Int64 value) => $_setInt64(2, value);
   @$pb.TagNumber(3)
   $core.bool hasOpCode() => $_has(2);
   @$pb.TagNumber(3)
-  void clearOpCode() => clearField(3);
+  void clearOpCode() => $_clearField(3);
 
+  /// Data payload, if any.
   @$pb.TagNumber(4)
   $core.List<$core.int> get data => $_getN(3);
   @$pb.TagNumber(4)
-  set data($core.List<$core.int> v) {
-    $_setBytes(3, v);
-  }
-
+  set data($core.List<$core.int> value) => $_setBytes(3, value);
   @$pb.TagNumber(4)
   $core.bool hasData() => $_has(3);
   @$pb.TagNumber(4)
-  void clearData() => clearField(4);
+  void clearData() => $_clearField(4);
 }
 
+/// Send data to a party.
 class PartyDataSend extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyDataSend',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..aInt64(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'opCode')
-    ..a<$core.List<$core.int>>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'data',
-        $pb.PbFieldType.OY)
-    ..hasRequiredFields = false;
-
-  PartyDataSend._() : super();
   factory PartyDataSend({
     $core.String? partyId,
     $fixnum.Int64? opCode,
     $core.List<$core.int>? data,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (opCode != null) {
-      _result.opCode = opCode;
-    }
-    if (data != null) {
-      _result.data = data;
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (opCode != null) result.opCode = opCode;
+    if (data != null) result.data = data;
+    return result;
   }
-  factory PartyDataSend.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyDataSend.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyDataSend clone() => PartyDataSend()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyDataSend._();
+
+  factory PartyDataSend.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyDataSend.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyDataSend',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..aInt64(2, _omitFieldNames ? '' : 'opCode')
+    ..a<$core.List<$core.int>>(
+        3, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyDataSend clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyDataSend copyWith(void Function(PartyDataSend) updates) =>
       super.copyWith((message) => updates(message as PartyDataSend))
-          as PartyDataSend; // ignore: deprecated_member_use
+          as PartyDataSend;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyDataSend create() => PartyDataSend._();
+  @$core.override
   PartyDataSend createEmptyInstance() => create();
   static $pb.PbList<PartyDataSend> createRepeated() =>
       $pb.PbList<PartyDataSend>();
@@ -5671,111 +4633,85 @@ class PartyDataSend extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyDataSend>(create);
   static PartyDataSend? _defaultInstance;
 
+  /// Party ID to send to.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// Op code value.
   @$pb.TagNumber(2)
   $fixnum.Int64 get opCode => $_getI64(1);
   @$pb.TagNumber(2)
-  set opCode($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set opCode($fixnum.Int64 value) => $_setInt64(1, value);
   @$pb.TagNumber(2)
   $core.bool hasOpCode() => $_has(1);
   @$pb.TagNumber(2)
-  void clearOpCode() => clearField(2);
+  void clearOpCode() => $_clearField(2);
 
+  /// Data payload, if any.
   @$pb.TagNumber(3)
   $core.List<$core.int> get data => $_getN(2);
   @$pb.TagNumber(3)
-  set data($core.List<$core.int> v) {
-    $_setBytes(2, v);
-  }
-
+  set data($core.List<$core.int> value) => $_setBytes(2, value);
   @$pb.TagNumber(3)
   $core.bool hasData() => $_has(2);
   @$pb.TagNumber(3)
-  void clearData() => clearField(3);
+  void clearData() => $_clearField(3);
 }
 
+/// Presence update for a particular party.
 class PartyPresenceEvent extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PartyPresenceEvent',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'partyId')
-    ..pc<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'joins',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..pc<UserPresence>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaves',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  PartyPresenceEvent._() : super();
   factory PartyPresenceEvent({
     $core.String? partyId,
     $core.Iterable<UserPresence>? joins,
     $core.Iterable<UserPresence>? leaves,
   }) {
-    final _result = create();
-    if (partyId != null) {
-      _result.partyId = partyId;
-    }
-    if (joins != null) {
-      _result.joins.addAll(joins);
-    }
-    if (leaves != null) {
-      _result.leaves.addAll(leaves);
-    }
-    return _result;
+    final result = create();
+    if (partyId != null) result.partyId = partyId;
+    if (joins != null) result.joins.addAll(joins);
+    if (leaves != null) result.leaves.addAll(leaves);
+    return result;
   }
-  factory PartyPresenceEvent.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PartyPresenceEvent.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PartyPresenceEvent clone() => PartyPresenceEvent()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  PartyPresenceEvent._();
+
+  factory PartyPresenceEvent.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory PartyPresenceEvent.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'PartyPresenceEvent',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'partyId')
+    ..pPM<UserPresence>(2, _omitFieldNames ? '' : 'joins',
+        subBuilder: UserPresence.create)
+    ..pPM<UserPresence>(3, _omitFieldNames ? '' : 'leaves',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  PartyPresenceEvent clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   PartyPresenceEvent copyWith(void Function(PartyPresenceEvent) updates) =>
       super.copyWith((message) => updates(message as PartyPresenceEvent))
-          as PartyPresenceEvent; // ignore: deprecated_member_use
+          as PartyPresenceEvent;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static PartyPresenceEvent create() => PartyPresenceEvent._();
+  @$core.override
   PartyPresenceEvent createEmptyInstance() => create();
   static $pb.PbList<PartyPresenceEvent> createRepeated() =>
       $pb.PbList<PartyPresenceEvent>();
@@ -5784,58 +4720,57 @@ class PartyPresenceEvent extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<PartyPresenceEvent>(create);
   static PartyPresenceEvent? _defaultInstance;
 
+  /// The party ID.
   @$pb.TagNumber(1)
   $core.String get partyId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set partyId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set partyId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasPartyId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearPartyId() => clearField(1);
+  void clearPartyId() => $_clearField(1);
 
+  /// User presences that have just joined the party.
   @$pb.TagNumber(2)
-  $core.List<UserPresence> get joins => $_getList(1);
+  $pb.PbList<UserPresence> get joins => $_getList(1);
 
+  /// User presences that have just left the party.
   @$pb.TagNumber(3)
-  $core.List<UserPresence> get leaves => $_getList(2);
+  $pb.PbList<UserPresence> get leaves => $_getList(2);
 }
 
+/// Application-level heartbeat and connection check.
 class Ping extends $pb.GeneratedMessage {
+  factory Ping() => create();
+
+  Ping._();
+
+  factory Ping.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Ping.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Ping',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'Ping',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
     ..hasRequiredFields = false;
 
-  Ping._() : super();
-  factory Ping() => create();
-  factory Ping.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Ping.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Ping clone() => Ping()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Ping clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Ping copyWith(void Function(Ping) updates) =>
-      super.copyWith((message) => updates(message as Ping))
-          as Ping; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Ping)) as Ping;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Ping create() => Ping._();
+  @$core.override
   Ping createEmptyInstance() => create();
   static $pb.PbList<Ping> createRepeated() => $pb.PbList<Ping>();
   @$core.pragma('dart2js:noInline')
@@ -5844,39 +4779,38 @@ class Ping extends $pb.GeneratedMessage {
   static Ping? _defaultInstance;
 }
 
+/// Application-level heartbeat and connection check response.
 class Pong extends $pb.GeneratedMessage {
+  factory Pong() => create();
+
+  Pong._();
+
+  factory Pong.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Pong.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Pong',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
+      _omitMessageNames ? '' : 'Pong',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
       createEmptyInstance: create)
     ..hasRequiredFields = false;
 
-  Pong._() : super();
-  factory Pong() => create();
-  factory Pong.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Pong.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Pong clone() => Pong()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Pong clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Pong copyWith(void Function(Pong) updates) =>
-      super.copyWith((message) => updates(message as Pong))
-          as Pong; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Pong)) as Pong;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Pong create() => Pong._();
+  @$core.override
   Pong createEmptyInstance() => create();
   static $pb.PbList<Pong> createRepeated() => $pb.PbList<Pong>();
   @$core.pragma('dart2js:noInline')
@@ -5885,54 +4819,46 @@ class Pong extends $pb.GeneratedMessage {
   static Pong? _defaultInstance;
 }
 
+/// A snapshot of statuses for some set of users.
 class Status extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Status',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..pc<UserPresence>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'presences',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  Status._() : super();
   factory Status({
     $core.Iterable<UserPresence>? presences,
   }) {
-    final _result = create();
-    if (presences != null) {
-      _result.presences.addAll(presences);
-    }
-    return _result;
+    final result = create();
+    if (presences != null) result.presences.addAll(presences);
+    return result;
   }
-  factory Status.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Status.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Status clone() => Status()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Status._();
+
+  factory Status.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Status.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Status',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..pPM<UserPresence>(1, _omitFieldNames ? '' : 'presences',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Status clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Status copyWith(void Function(Status) updates) =>
-      super.copyWith((message) => updates(message as Status))
-          as Status; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Status)) as Status;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Status create() => Status._();
+  @$core.override
   Status createEmptyInstance() => create();
   static $pb.PbList<Status> createRepeated() => $pb.PbList<Status>();
   @$core.pragma('dart2js:noInline')
@@ -5940,65 +4866,54 @@ class Status extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Status>(create);
   static Status? _defaultInstance;
 
+  /// User statuses.
   @$pb.TagNumber(1)
-  $core.List<UserPresence> get presences => $_getList(0);
+  $pb.PbList<UserPresence> get presences => $_getList(0);
 }
 
+/// Start receiving status updates for some set of users.
 class StatusFollow extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StatusFollow',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..pPS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIds')
-    ..pPS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'usernames')
-    ..hasRequiredFields = false;
-
-  StatusFollow._() : super();
   factory StatusFollow({
     $core.Iterable<$core.String>? userIds,
     $core.Iterable<$core.String>? usernames,
   }) {
-    final _result = create();
-    if (userIds != null) {
-      _result.userIds.addAll(userIds);
-    }
-    if (usernames != null) {
-      _result.usernames.addAll(usernames);
-    }
-    return _result;
+    final result = create();
+    if (userIds != null) result.userIds.addAll(userIds);
+    if (usernames != null) result.usernames.addAll(usernames);
+    return result;
   }
-  factory StatusFollow.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StatusFollow.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StatusFollow clone() => StatusFollow()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StatusFollow._();
+
+  factory StatusFollow.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StatusFollow.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StatusFollow',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'userIds')
+    ..pPS(2, _omitFieldNames ? '' : 'usernames')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StatusFollow clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StatusFollow copyWith(void Function(StatusFollow) updates) =>
       super.copyWith((message) => updates(message as StatusFollow))
-          as StatusFollow; // ignore: deprecated_member_use
+          as StatusFollow;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StatusFollow create() => StatusFollow._();
+  @$core.override
   StatusFollow createEmptyInstance() => create();
   static $pb.PbList<StatusFollow> createRepeated() =>
       $pb.PbList<StatusFollow>();
@@ -6007,72 +4922,60 @@ class StatusFollow extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StatusFollow>(create);
   static StatusFollow? _defaultInstance;
 
+  /// User IDs to follow.
   @$pb.TagNumber(1)
-  $core.List<$core.String> get userIds => $_getList(0);
+  $pb.PbList<$core.String> get userIds => $_getList(0);
 
+  /// Usernames to follow.
   @$pb.TagNumber(2)
-  $core.List<$core.String> get usernames => $_getList(1);
+  $pb.PbList<$core.String> get usernames => $_getList(1);
 }
 
+/// A batch of status updates for a given user.
 class StatusPresenceEvent extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StatusPresenceEvent',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..pc<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'joins',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..pc<UserPresence>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaves',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  StatusPresenceEvent._() : super();
   factory StatusPresenceEvent({
     $core.Iterable<UserPresence>? joins,
     $core.Iterable<UserPresence>? leaves,
   }) {
-    final _result = create();
-    if (joins != null) {
-      _result.joins.addAll(joins);
-    }
-    if (leaves != null) {
-      _result.leaves.addAll(leaves);
-    }
-    return _result;
+    final result = create();
+    if (joins != null) result.joins.addAll(joins);
+    if (leaves != null) result.leaves.addAll(leaves);
+    return result;
   }
-  factory StatusPresenceEvent.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StatusPresenceEvent.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StatusPresenceEvent clone() => StatusPresenceEvent()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StatusPresenceEvent._();
+
+  factory StatusPresenceEvent.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StatusPresenceEvent.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StatusPresenceEvent',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..pPM<UserPresence>(2, _omitFieldNames ? '' : 'joins',
+        subBuilder: UserPresence.create)
+    ..pPM<UserPresence>(3, _omitFieldNames ? '' : 'leaves',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StatusPresenceEvent clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StatusPresenceEvent copyWith(void Function(StatusPresenceEvent) updates) =>
       super.copyWith((message) => updates(message as StatusPresenceEvent))
-          as StatusPresenceEvent; // ignore: deprecated_member_use
+          as StatusPresenceEvent;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StatusPresenceEvent create() => StatusPresenceEvent._();
+  @$core.override
   StatusPresenceEvent createEmptyInstance() => create();
   static $pb.PbList<StatusPresenceEvent> createRepeated() =>
       $pb.PbList<StatusPresenceEvent>();
@@ -6081,59 +4984,55 @@ class StatusPresenceEvent extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StatusPresenceEvent>(create);
   static StatusPresenceEvent? _defaultInstance;
 
+  /// New statuses for the user.
   @$pb.TagNumber(2)
-  $core.List<UserPresence> get joins => $_getList(0);
+  $pb.PbList<UserPresence> get joins => $_getList(0);
 
+  /// Previous statuses for the user.
   @$pb.TagNumber(3)
-  $core.List<UserPresence> get leaves => $_getList(1);
+  $pb.PbList<UserPresence> get leaves => $_getList(1);
 }
 
+/// Stop receiving status updates for some set of users.
 class StatusUnfollow extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StatusUnfollow',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..pPS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userIds')
-    ..hasRequiredFields = false;
-
-  StatusUnfollow._() : super();
   factory StatusUnfollow({
     $core.Iterable<$core.String>? userIds,
   }) {
-    final _result = create();
-    if (userIds != null) {
-      _result.userIds.addAll(userIds);
-    }
-    return _result;
+    final result = create();
+    if (userIds != null) result.userIds.addAll(userIds);
+    return result;
   }
-  factory StatusUnfollow.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StatusUnfollow.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StatusUnfollow clone() => StatusUnfollow()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StatusUnfollow._();
+
+  factory StatusUnfollow.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StatusUnfollow.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StatusUnfollow',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'userIds')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StatusUnfollow clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StatusUnfollow copyWith(void Function(StatusUnfollow) updates) =>
       super.copyWith((message) => updates(message as StatusUnfollow))
-          as StatusUnfollow; // ignore: deprecated_member_use
+          as StatusUnfollow;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StatusUnfollow create() => StatusUnfollow._();
+  @$core.override
   StatusUnfollow createEmptyInstance() => create();
   static $pb.PbList<StatusUnfollow> createRepeated() =>
       $pb.PbList<StatusUnfollow>();
@@ -6142,57 +5041,52 @@ class StatusUnfollow extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StatusUnfollow>(create);
   static StatusUnfollow? _defaultInstance;
 
+  /// Users to unfollow.
   @$pb.TagNumber(1)
-  $core.List<$core.String> get userIds => $_getList(0);
+  $pb.PbList<$core.String> get userIds => $_getList(0);
 }
 
+/// Set the user's own status.
 class StatusUpdate extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StatusUpdate',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOM<$1.StringValue>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'status',
-        subBuilder: $1.StringValue.create)
-    ..hasRequiredFields = false;
-
-  StatusUpdate._() : super();
   factory StatusUpdate({
     $1.StringValue? status,
   }) {
-    final _result = create();
-    if (status != null) {
-      _result.status = status;
-    }
-    return _result;
+    final result = create();
+    if (status != null) result.status = status;
+    return result;
   }
-  factory StatusUpdate.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StatusUpdate.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StatusUpdate clone() => StatusUpdate()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StatusUpdate._();
+
+  factory StatusUpdate.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StatusUpdate.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StatusUpdate',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOM<$1.StringValue>(1, _omitFieldNames ? '' : 'status',
+        subBuilder: $1.StringValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StatusUpdate clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StatusUpdate copyWith(void Function(StatusUpdate) updates) =>
       super.copyWith((message) => updates(message as StatusUpdate))
-          as StatusUpdate; // ignore: deprecated_member_use
+          as StatusUpdate;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StatusUpdate create() => StatusUpdate._();
+  @$core.override
   StatusUpdate createEmptyInstance() => create();
   static $pb.PbList<StatusUpdate> createRepeated() =>
       $pb.PbList<StatusUpdate>();
@@ -6201,95 +5095,67 @@ class StatusUpdate extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StatusUpdate>(create);
   static StatusUpdate? _defaultInstance;
 
+  /// Status string to set, if not present the user will appear offline.
   @$pb.TagNumber(1)
   $1.StringValue get status => $_getN(0);
   @$pb.TagNumber(1)
-  set status($1.StringValue v) {
-    setField(1, v);
-  }
-
+  set status($1.StringValue value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasStatus() => $_has(0);
   @$pb.TagNumber(1)
-  void clearStatus() => clearField(1);
+  void clearStatus() => $_clearField(1);
   @$pb.TagNumber(1)
   $1.StringValue ensureStatus() => $_ensure(0);
 }
 
+/// Represents identifying information for a stream.
 class Stream extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Stream',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'mode',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'subject')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'subcontext')
-    ..aOS(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'label')
-    ..hasRequiredFields = false;
-
-  Stream._() : super();
   factory Stream({
     $core.int? mode,
     $core.String? subject,
     $core.String? subcontext,
     $core.String? label,
   }) {
-    final _result = create();
-    if (mode != null) {
-      _result.mode = mode;
-    }
-    if (subject != null) {
-      _result.subject = subject;
-    }
-    if (subcontext != null) {
-      _result.subcontext = subcontext;
-    }
-    if (label != null) {
-      _result.label = label;
-    }
-    return _result;
+    final result = create();
+    if (mode != null) result.mode = mode;
+    if (subject != null) result.subject = subject;
+    if (subcontext != null) result.subcontext = subcontext;
+    if (label != null) result.label = label;
+    return result;
   }
-  factory Stream.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Stream.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  Stream clone() => Stream()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  Stream._();
+
+  factory Stream.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Stream.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Stream',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aI(1, _omitFieldNames ? '' : 'mode')
+    ..aOS(2, _omitFieldNames ? '' : 'subject')
+    ..aOS(3, _omitFieldNames ? '' : 'subcontext')
+    ..aOS(4, _omitFieldNames ? '' : 'label')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Stream clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   Stream copyWith(void Function(Stream) updates) =>
-      super.copyWith((message) => updates(message as Stream))
-          as Stream; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Stream)) as Stream;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Stream create() => Stream._();
+  @$core.override
   Stream createEmptyInstance() => create();
   static $pb.PbList<Stream> createRepeated() => $pb.PbList<Stream>();
   @$core.pragma('dart2js:noInline')
@@ -6297,130 +5163,96 @@ class Stream extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Stream>(create);
   static Stream? _defaultInstance;
 
+  /// Mode identifies the type of stream.
   @$pb.TagNumber(1)
   $core.int get mode => $_getIZ(0);
   @$pb.TagNumber(1)
-  set mode($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set mode($core.int value) => $_setSignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMode() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMode() => clearField(1);
+  void clearMode() => $_clearField(1);
 
+  /// Subject is the primary identifier, if any.
   @$pb.TagNumber(2)
   $core.String get subject => $_getSZ(1);
   @$pb.TagNumber(2)
-  set subject($core.String v) {
-    $_setString(1, v);
-  }
-
+  set subject($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasSubject() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSubject() => clearField(2);
+  void clearSubject() => $_clearField(2);
 
+  /// Subcontext is a secondary identifier, if any.
   @$pb.TagNumber(3)
   $core.String get subcontext => $_getSZ(2);
   @$pb.TagNumber(3)
-  set subcontext($core.String v) {
-    $_setString(2, v);
-  }
-
+  set subcontext($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasSubcontext() => $_has(2);
   @$pb.TagNumber(3)
-  void clearSubcontext() => clearField(3);
+  void clearSubcontext() => $_clearField(3);
 
+  /// The label is an arbitrary identifying string, if the stream has one.
   @$pb.TagNumber(4)
   $core.String get label => $_getSZ(3);
   @$pb.TagNumber(4)
-  set label($core.String v) {
-    $_setString(3, v);
-  }
-
+  set label($core.String value) => $_setString(3, value);
   @$pb.TagNumber(4)
   $core.bool hasLabel() => $_has(3);
   @$pb.TagNumber(4)
-  void clearLabel() => clearField(4);
+  void clearLabel() => $_clearField(4);
 }
 
+/// A data message delivered over a stream.
 class StreamData extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StreamData',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOM<Stream>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'stream',
-        subBuilder: Stream.create)
-    ..aOM<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sender',
-        subBuilder: UserPresence.create)
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'data')
-    ..aOB(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'reliable')
-    ..hasRequiredFields = false;
-
-  StreamData._() : super();
   factory StreamData({
     Stream? stream,
     UserPresence? sender,
     $core.String? data,
     $core.bool? reliable,
   }) {
-    final _result = create();
-    if (stream != null) {
-      _result.stream = stream;
-    }
-    if (sender != null) {
-      _result.sender = sender;
-    }
-    if (data != null) {
-      _result.data = data;
-    }
-    if (reliable != null) {
-      _result.reliable = reliable;
-    }
-    return _result;
+    final result = create();
+    if (stream != null) result.stream = stream;
+    if (sender != null) result.sender = sender;
+    if (data != null) result.data = data;
+    if (reliable != null) result.reliable = reliable;
+    return result;
   }
-  factory StreamData.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StreamData.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StreamData clone() => StreamData()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StreamData._();
+
+  factory StreamData.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StreamData.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StreamData',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOM<Stream>(1, _omitFieldNames ? '' : 'stream', subBuilder: Stream.create)
+    ..aOM<UserPresence>(2, _omitFieldNames ? '' : 'sender',
+        subBuilder: UserPresence.create)
+    ..aOS(3, _omitFieldNames ? '' : 'data')
+    ..aOB(4, _omitFieldNames ? '' : 'reliable')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StreamData clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StreamData copyWith(void Function(StreamData) updates) =>
-      super.copyWith((message) => updates(message as StreamData))
-          as StreamData; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as StreamData)) as StreamData;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StreamData create() => StreamData._();
+  @$core.override
   StreamData createEmptyInstance() => create();
   static $pb.PbList<StreamData> createRepeated() => $pb.PbList<StreamData>();
   @$core.pragma('dart2js:noInline')
@@ -6428,128 +5260,99 @@ class StreamData extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StreamData>(create);
   static StreamData? _defaultInstance;
 
+  /// The stream this data message relates to.
   @$pb.TagNumber(1)
   Stream get stream => $_getN(0);
   @$pb.TagNumber(1)
-  set stream(Stream v) {
-    setField(1, v);
-  }
-
+  set stream(Stream value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasStream() => $_has(0);
   @$pb.TagNumber(1)
-  void clearStream() => clearField(1);
+  void clearStream() => $_clearField(1);
   @$pb.TagNumber(1)
   Stream ensureStream() => $_ensure(0);
 
+  /// The sender, if any.
   @$pb.TagNumber(2)
   UserPresence get sender => $_getN(1);
   @$pb.TagNumber(2)
-  set sender(UserPresence v) {
-    setField(2, v);
-  }
-
+  set sender(UserPresence value) => $_setField(2, value);
   @$pb.TagNumber(2)
   $core.bool hasSender() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSender() => clearField(2);
+  void clearSender() => $_clearField(2);
   @$pb.TagNumber(2)
   UserPresence ensureSender() => $_ensure(1);
 
+  /// Arbitrary contents of the data message.
   @$pb.TagNumber(3)
   $core.String get data => $_getSZ(2);
   @$pb.TagNumber(3)
-  set data($core.String v) {
-    $_setString(2, v);
-  }
-
+  set data($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasData() => $_has(2);
   @$pb.TagNumber(3)
-  void clearData() => clearField(3);
+  void clearData() => $_clearField(3);
 
+  /// True if this data was delivered reliably, false otherwise.
   @$pb.TagNumber(4)
   $core.bool get reliable => $_getBF(3);
   @$pb.TagNumber(4)
-  set reliable($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set reliable($core.bool value) => $_setBool(3, value);
   @$pb.TagNumber(4)
   $core.bool hasReliable() => $_has(3);
   @$pb.TagNumber(4)
-  void clearReliable() => clearField(4);
+  void clearReliable() => $_clearField(4);
 }
 
+/// A set of joins and leaves on a particular stream.
 class StreamPresenceEvent extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StreamPresenceEvent',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOM<Stream>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'stream',
-        subBuilder: Stream.create)
-    ..pc<UserPresence>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'joins',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..pc<UserPresence>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'leaves',
-        $pb.PbFieldType.PM,
-        subBuilder: UserPresence.create)
-    ..hasRequiredFields = false;
-
-  StreamPresenceEvent._() : super();
   factory StreamPresenceEvent({
     Stream? stream,
     $core.Iterable<UserPresence>? joins,
     $core.Iterable<UserPresence>? leaves,
   }) {
-    final _result = create();
-    if (stream != null) {
-      _result.stream = stream;
-    }
-    if (joins != null) {
-      _result.joins.addAll(joins);
-    }
-    if (leaves != null) {
-      _result.leaves.addAll(leaves);
-    }
-    return _result;
+    final result = create();
+    if (stream != null) result.stream = stream;
+    if (joins != null) result.joins.addAll(joins);
+    if (leaves != null) result.leaves.addAll(leaves);
+    return result;
   }
-  factory StreamPresenceEvent.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StreamPresenceEvent.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  StreamPresenceEvent clone() => StreamPresenceEvent()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  StreamPresenceEvent._();
+
+  factory StreamPresenceEvent.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StreamPresenceEvent.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'StreamPresenceEvent',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOM<Stream>(1, _omitFieldNames ? '' : 'stream', subBuilder: Stream.create)
+    ..pPM<UserPresence>(2, _omitFieldNames ? '' : 'joins',
+        subBuilder: UserPresence.create)
+    ..pPM<UserPresence>(3, _omitFieldNames ? '' : 'leaves',
+        subBuilder: UserPresence.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StreamPresenceEvent clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   StreamPresenceEvent copyWith(void Function(StreamPresenceEvent) updates) =>
       super.copyWith((message) => updates(message as StreamPresenceEvent))
-          as StreamPresenceEvent; // ignore: deprecated_member_use
+          as StreamPresenceEvent;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StreamPresenceEvent create() => StreamPresenceEvent._();
+  @$core.override
   StreamPresenceEvent createEmptyInstance() => create();
   static $pb.PbList<StreamPresenceEvent> createRepeated() =>
       $pb.PbList<StreamPresenceEvent>();
@@ -6558,66 +5361,29 @@ class StreamPresenceEvent extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<StreamPresenceEvent>(create);
   static StreamPresenceEvent? _defaultInstance;
 
+  /// The stream this event relates to.
   @$pb.TagNumber(1)
   Stream get stream => $_getN(0);
   @$pb.TagNumber(1)
-  set stream(Stream v) {
-    setField(1, v);
-  }
-
+  set stream(Stream value) => $_setField(1, value);
   @$pb.TagNumber(1)
   $core.bool hasStream() => $_has(0);
   @$pb.TagNumber(1)
-  void clearStream() => clearField(1);
+  void clearStream() => $_clearField(1);
   @$pb.TagNumber(1)
   Stream ensureStream() => $_ensure(0);
 
+  /// Presences joining the stream as part of this event, if any.
   @$pb.TagNumber(2)
-  $core.List<UserPresence> get joins => $_getList(1);
+  $pb.PbList<UserPresence> get joins => $_getList(1);
 
+  /// Presences leaving the stream as part of this event, if any.
   @$pb.TagNumber(3)
-  $core.List<UserPresence> get leaves => $_getList(2);
+  $pb.PbList<UserPresence> get leaves => $_getList(2);
 }
 
+/// A user session associated to a stream, usually through a list operation or a join/leave event.
 class UserPresence extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'UserPresence',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'nakama.realtime'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'userId')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'sessionId')
-    ..aOS(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'username')
-    ..aOB(
-        4,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'persistence')
-    ..aOM<$1.StringValue>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'status',
-        subBuilder: $1.StringValue.create)
-    ..hasRequiredFields = false;
-
-  UserPresence._() : super();
   factory UserPresence({
     $core.String? userId,
     $core.String? sessionId,
@@ -6625,43 +5391,50 @@ class UserPresence extends $pb.GeneratedMessage {
     $core.bool? persistence,
     $1.StringValue? status,
   }) {
-    final _result = create();
-    if (userId != null) {
-      _result.userId = userId;
-    }
-    if (sessionId != null) {
-      _result.sessionId = sessionId;
-    }
-    if (username != null) {
-      _result.username = username;
-    }
-    if (persistence != null) {
-      _result.persistence = persistence;
-    }
-    if (status != null) {
-      _result.status = status;
-    }
-    return _result;
+    final result = create();
+    if (userId != null) result.userId = userId;
+    if (sessionId != null) result.sessionId = sessionId;
+    if (username != null) result.username = username;
+    if (persistence != null) result.persistence = persistence;
+    if (status != null) result.status = status;
+    return result;
   }
-  factory UserPresence.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory UserPresence.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  UserPresence clone() => UserPresence()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  UserPresence._();
+
+  factory UserPresence.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory UserPresence.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'UserPresence',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'nakama.realtime'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'userId')
+    ..aOS(2, _omitFieldNames ? '' : 'sessionId')
+    ..aOS(3, _omitFieldNames ? '' : 'username')
+    ..aOB(4, _omitFieldNames ? '' : 'persistence')
+    ..aOM<$1.StringValue>(5, _omitFieldNames ? '' : 'status',
+        subBuilder: $1.StringValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  UserPresence clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   UserPresence copyWith(void Function(UserPresence) updates) =>
       super.copyWith((message) => updates(message as UserPresence))
-          as UserPresence; // ignore: deprecated_member_use
+          as UserPresence;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static UserPresence create() => UserPresence._();
+  @$core.override
   UserPresence createEmptyInstance() => create();
   static $pb.PbList<UserPresence> createRepeated() =>
       $pb.PbList<UserPresence>();
@@ -6670,65 +5443,60 @@ class UserPresence extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<UserPresence>(create);
   static UserPresence? _defaultInstance;
 
+  /// The user this presence belongs to.
   @$pb.TagNumber(1)
   $core.String get userId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set userId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set userId($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasUserId() => $_has(0);
   @$pb.TagNumber(1)
-  void clearUserId() => clearField(1);
+  void clearUserId() => $_clearField(1);
 
+  /// A unique session ID identifying the particular connection, because the user may have many.
   @$pb.TagNumber(2)
   $core.String get sessionId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set sessionId($core.String v) {
-    $_setString(1, v);
-  }
-
+  set sessionId($core.String value) => $_setString(1, value);
   @$pb.TagNumber(2)
   $core.bool hasSessionId() => $_has(1);
   @$pb.TagNumber(2)
-  void clearSessionId() => clearField(2);
+  void clearSessionId() => $_clearField(2);
 
+  /// The username for display purposes.
   @$pb.TagNumber(3)
   $core.String get username => $_getSZ(2);
   @$pb.TagNumber(3)
-  set username($core.String v) {
-    $_setString(2, v);
-  }
-
+  set username($core.String value) => $_setString(2, value);
   @$pb.TagNumber(3)
   $core.bool hasUsername() => $_has(2);
   @$pb.TagNumber(3)
-  void clearUsername() => clearField(3);
+  void clearUsername() => $_clearField(3);
 
+  /// Whether this presence generates persistent data/messages, if applicable for the stream type.
   @$pb.TagNumber(4)
   $core.bool get persistence => $_getBF(3);
   @$pb.TagNumber(4)
-  set persistence($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set persistence($core.bool value) => $_setBool(3, value);
   @$pb.TagNumber(4)
   $core.bool hasPersistence() => $_has(3);
   @$pb.TagNumber(4)
-  void clearPersistence() => clearField(4);
+  void clearPersistence() => $_clearField(4);
 
+  /// A user-set status message for this stream, if applicable.
   @$pb.TagNumber(5)
   $1.StringValue get status => $_getN(4);
   @$pb.TagNumber(5)
-  set status($1.StringValue v) {
-    setField(5, v);
-  }
-
+  set status($1.StringValue value) => $_setField(5, value);
   @$pb.TagNumber(5)
   $core.bool hasStatus() => $_has(4);
   @$pb.TagNumber(5)
-  void clearStatus() => clearField(5);
+  void clearStatus() => $_clearField(5);
   @$pb.TagNumber(5)
   $1.StringValue ensureStatus() => $_ensure(4);
 }
+
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/nakama/lib/src/api/proto/rtapi/realtime.pbenum.dart
+++ b/nakama/lib/src/api/proto/rtapi/realtime.pbenum.dart
@@ -1,35 +1,36 @@
-///
-//  Generated code. Do not modify.
-//  source: rtapi/realtime.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from rtapi/realtime.proto.
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names
+
 import 'dart:core' as $core;
+
 import 'package:protobuf/protobuf.dart' as $pb;
 
+/// The type of chat channel.
 class ChannelJoin_Type extends $pb.ProtobufEnum {
-  static const ChannelJoin_Type TYPE_UNSPECIFIED = ChannelJoin_Type._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'TYPE_UNSPECIFIED');
-  static const ChannelJoin_Type ROOM = ChannelJoin_Type._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'ROOM');
-  static const ChannelJoin_Type DIRECT_MESSAGE = ChannelJoin_Type._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'DIRECT_MESSAGE');
-  static const ChannelJoin_Type GROUP = ChannelJoin_Type._(
-      3,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'GROUP');
+  /// Default case. Assumed as ROOM type.
+  static const ChannelJoin_Type TYPE_UNSPECIFIED =
+      ChannelJoin_Type._(0, _omitEnumNames ? '' : 'TYPE_UNSPECIFIED');
+
+  /// A room which anyone can join to chat.
+  static const ChannelJoin_Type ROOM =
+      ChannelJoin_Type._(1, _omitEnumNames ? '' : 'ROOM');
+
+  /// A private channel for 1-on-1 chat.
+  static const ChannelJoin_Type DIRECT_MESSAGE =
+      ChannelJoin_Type._(2, _omitEnumNames ? '' : 'DIRECT_MESSAGE');
+
+  /// A channel for group chat.
+  static const ChannelJoin_Type GROUP =
+      ChannelJoin_Type._(3, _omitEnumNames ? '' : 'GROUP');
 
   static const $core.List<ChannelJoin_Type> values = <ChannelJoin_Type>[
     TYPE_UNSPECIFIED,
@@ -38,54 +39,47 @@ class ChannelJoin_Type extends $pb.ProtobufEnum {
     GROUP,
   ];
 
-  static final $core.Map<$core.int, ChannelJoin_Type> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
-  static ChannelJoin_Type? valueOf($core.int value) => _byValue[value];
+  static final $core.List<ChannelJoin_Type?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 3);
+  static ChannelJoin_Type? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const ChannelJoin_Type._($core.int v, $core.String n) : super(v, n);
+  const ChannelJoin_Type._(super.value, super.name);
 }
 
+/// The selection of possible error codes.
 class Error_Code extends $pb.ProtobufEnum {
-  static const Error_Code RUNTIME_EXCEPTION = Error_Code._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'RUNTIME_EXCEPTION');
-  static const Error_Code UNRECOGNIZED_PAYLOAD = Error_Code._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'UNRECOGNIZED_PAYLOAD');
-  static const Error_Code MISSING_PAYLOAD = Error_Code._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'MISSING_PAYLOAD');
-  static const Error_Code BAD_INPUT = Error_Code._(
-      3,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'BAD_INPUT');
-  static const Error_Code MATCH_NOT_FOUND = Error_Code._(
-      4,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'MATCH_NOT_FOUND');
-  static const Error_Code MATCH_JOIN_REJECTED = Error_Code._(
-      5,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'MATCH_JOIN_REJECTED');
-  static const Error_Code RUNTIME_FUNCTION_NOT_FOUND = Error_Code._(
-      6,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'RUNTIME_FUNCTION_NOT_FOUND');
-  static const Error_Code RUNTIME_FUNCTION_EXCEPTION = Error_Code._(
-      7,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'RUNTIME_FUNCTION_EXCEPTION');
+  /// An unexpected result from the server.
+  static const Error_Code RUNTIME_EXCEPTION =
+      Error_Code._(0, _omitEnumNames ? '' : 'RUNTIME_EXCEPTION');
+
+  /// The server received a message which is not recognised.
+  static const Error_Code UNRECOGNIZED_PAYLOAD =
+      Error_Code._(1, _omitEnumNames ? '' : 'UNRECOGNIZED_PAYLOAD');
+
+  /// A message was expected but contains no content.
+  static const Error_Code MISSING_PAYLOAD =
+      Error_Code._(2, _omitEnumNames ? '' : 'MISSING_PAYLOAD');
+
+  /// Fields in the message have an invalid format.
+  static const Error_Code BAD_INPUT =
+      Error_Code._(3, _omitEnumNames ? '' : 'BAD_INPUT');
+
+  /// The match id was not found.
+  static const Error_Code MATCH_NOT_FOUND =
+      Error_Code._(4, _omitEnumNames ? '' : 'MATCH_NOT_FOUND');
+
+  /// The match join was rejected.
+  static const Error_Code MATCH_JOIN_REJECTED =
+      Error_Code._(5, _omitEnumNames ? '' : 'MATCH_JOIN_REJECTED');
+
+  /// The runtime function does not exist on the server.
+  static const Error_Code RUNTIME_FUNCTION_NOT_FOUND =
+      Error_Code._(6, _omitEnumNames ? '' : 'RUNTIME_FUNCTION_NOT_FOUND');
+
+  /// The runtime function executed with an error.
+  static const Error_Code RUNTIME_FUNCTION_EXCEPTION =
+      Error_Code._(7, _omitEnumNames ? '' : 'RUNTIME_FUNCTION_EXCEPTION');
 
   static const $core.List<Error_Code> values = <Error_Code>[
     RUNTIME_EXCEPTION,
@@ -98,9 +92,13 @@ class Error_Code extends $pb.ProtobufEnum {
     RUNTIME_FUNCTION_EXCEPTION,
   ];
 
-  static final $core.Map<$core.int, Error_Code> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
-  static Error_Code? valueOf($core.int value) => _byValue[value];
+  static final $core.List<Error_Code?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 7);
+  static Error_Code? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
 
-  const Error_Code._($core.int v, $core.String n) : super(v, n);
+  const Error_Code._(super.value, super.name);
 }
+
+const $core.bool _omitEnumNames =
+    $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/nakama/lib/src/api/proto/rtapi/realtime.pbjson.dart
+++ b/nakama/lib/src/api/proto/rtapi/realtime.pbjson.dart
@@ -1,20 +1,25 @@
-///
-//  Generated code. Do not modify.
-//  source: rtapi/realtime.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+// Generated from rtapi/realtime.proto.
 
-import 'dart:core' as $core;
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 
 @$core.Deprecated('Use envelopeDescriptor instead')
-const Envelope$json = const {
+const Envelope$json = {
   '1': 'Envelope',
-  '2': const [
-    const {'1': 'cid', '3': 1, '4': 1, '5': 9, '10': 'cid'},
-    const {
+  '2': [
+    {'1': 'cid', '3': 1, '4': 1, '5': 9, '10': 'cid'},
+    {
       '1': 'channel',
       '3': 2,
       '4': 1,
@@ -23,7 +28,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channel'
     },
-    const {
+    {
       '1': 'channel_join',
       '3': 3,
       '4': 1,
@@ -32,7 +37,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channelJoin'
     },
-    const {
+    {
       '1': 'channel_leave',
       '3': 4,
       '4': 1,
@@ -41,7 +46,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channelLeave'
     },
-    const {
+    {
       '1': 'channel_message',
       '3': 5,
       '4': 1,
@@ -50,7 +55,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channelMessage'
     },
-    const {
+    {
       '1': 'channel_message_ack',
       '3': 6,
       '4': 1,
@@ -59,7 +64,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channelMessageAck'
     },
-    const {
+    {
       '1': 'channel_message_send',
       '3': 7,
       '4': 1,
@@ -68,7 +73,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channelMessageSend'
     },
-    const {
+    {
       '1': 'channel_message_update',
       '3': 8,
       '4': 1,
@@ -77,7 +82,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channelMessageUpdate'
     },
-    const {
+    {
       '1': 'channel_message_remove',
       '3': 9,
       '4': 1,
@@ -86,7 +91,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channelMessageRemove'
     },
-    const {
+    {
       '1': 'channel_presence_event',
       '3': 10,
       '4': 1,
@@ -95,7 +100,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'channelPresenceEvent'
     },
-    const {
+    {
       '1': 'error',
       '3': 11,
       '4': 1,
@@ -104,7 +109,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'error'
     },
-    const {
+    {
       '1': 'match',
       '3': 12,
       '4': 1,
@@ -113,7 +118,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'match'
     },
-    const {
+    {
       '1': 'match_create',
       '3': 13,
       '4': 1,
@@ -122,7 +127,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchCreate'
     },
-    const {
+    {
       '1': 'match_data',
       '3': 14,
       '4': 1,
@@ -131,7 +136,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchData'
     },
-    const {
+    {
       '1': 'match_data_send',
       '3': 15,
       '4': 1,
@@ -140,7 +145,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchDataSend'
     },
-    const {
+    {
       '1': 'match_join',
       '3': 16,
       '4': 1,
@@ -149,7 +154,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchJoin'
     },
-    const {
+    {
       '1': 'match_leave',
       '3': 17,
       '4': 1,
@@ -158,7 +163,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchLeave'
     },
-    const {
+    {
       '1': 'match_presence_event',
       '3': 18,
       '4': 1,
@@ -167,7 +172,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchPresenceEvent'
     },
-    const {
+    {
       '1': 'matchmaker_add',
       '3': 19,
       '4': 1,
@@ -176,7 +181,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchmakerAdd'
     },
-    const {
+    {
       '1': 'matchmaker_matched',
       '3': 20,
       '4': 1,
@@ -185,7 +190,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchmakerMatched'
     },
-    const {
+    {
       '1': 'matchmaker_remove',
       '3': 21,
       '4': 1,
@@ -194,7 +199,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchmakerRemove'
     },
-    const {
+    {
       '1': 'matchmaker_ticket',
       '3': 22,
       '4': 1,
@@ -203,7 +208,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'matchmakerTicket'
     },
-    const {
+    {
       '1': 'notifications',
       '3': 23,
       '4': 1,
@@ -212,7 +217,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'notifications'
     },
-    const {
+    {
       '1': 'rpc',
       '3': 24,
       '4': 1,
@@ -221,7 +226,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'rpc'
     },
-    const {
+    {
       '1': 'status',
       '3': 25,
       '4': 1,
@@ -230,7 +235,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'status'
     },
-    const {
+    {
       '1': 'status_follow',
       '3': 26,
       '4': 1,
@@ -239,7 +244,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'statusFollow'
     },
-    const {
+    {
       '1': 'status_presence_event',
       '3': 27,
       '4': 1,
@@ -248,7 +253,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'statusPresenceEvent'
     },
-    const {
+    {
       '1': 'status_unfollow',
       '3': 28,
       '4': 1,
@@ -257,7 +262,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'statusUnfollow'
     },
-    const {
+    {
       '1': 'status_update',
       '3': 29,
       '4': 1,
@@ -266,7 +271,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'statusUpdate'
     },
-    const {
+    {
       '1': 'stream_data',
       '3': 30,
       '4': 1,
@@ -275,7 +280,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'streamData'
     },
-    const {
+    {
       '1': 'stream_presence_event',
       '3': 31,
       '4': 1,
@@ -284,7 +289,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'streamPresenceEvent'
     },
-    const {
+    {
       '1': 'ping',
       '3': 32,
       '4': 1,
@@ -293,7 +298,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'ping'
     },
-    const {
+    {
       '1': 'pong',
       '3': 33,
       '4': 1,
@@ -302,7 +307,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'pong'
     },
-    const {
+    {
       '1': 'party',
       '3': 34,
       '4': 1,
@@ -311,7 +316,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'party'
     },
-    const {
+    {
       '1': 'party_create',
       '3': 35,
       '4': 1,
@@ -320,7 +325,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyCreate'
     },
-    const {
+    {
       '1': 'party_join',
       '3': 36,
       '4': 1,
@@ -329,7 +334,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyJoin'
     },
-    const {
+    {
       '1': 'party_leave',
       '3': 37,
       '4': 1,
@@ -338,7 +343,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyLeave'
     },
-    const {
+    {
       '1': 'party_promote',
       '3': 38,
       '4': 1,
@@ -347,7 +352,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyPromote'
     },
-    const {
+    {
       '1': 'party_leader',
       '3': 39,
       '4': 1,
@@ -356,7 +361,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyLeader'
     },
-    const {
+    {
       '1': 'party_accept',
       '3': 40,
       '4': 1,
@@ -365,7 +370,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyAccept'
     },
-    const {
+    {
       '1': 'party_remove',
       '3': 41,
       '4': 1,
@@ -374,7 +379,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyRemove'
     },
-    const {
+    {
       '1': 'party_close',
       '3': 42,
       '4': 1,
@@ -383,7 +388,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyClose'
     },
-    const {
+    {
       '1': 'party_join_request_list',
       '3': 43,
       '4': 1,
@@ -392,7 +397,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyJoinRequestList'
     },
-    const {
+    {
       '1': 'party_join_request',
       '3': 44,
       '4': 1,
@@ -401,7 +406,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyJoinRequest'
     },
-    const {
+    {
       '1': 'party_matchmaker_add',
       '3': 45,
       '4': 1,
@@ -410,7 +415,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyMatchmakerAdd'
     },
-    const {
+    {
       '1': 'party_matchmaker_remove',
       '3': 46,
       '4': 1,
@@ -419,7 +424,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyMatchmakerRemove'
     },
-    const {
+    {
       '1': 'party_matchmaker_ticket',
       '3': 47,
       '4': 1,
@@ -428,7 +433,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyMatchmakerTicket'
     },
-    const {
+    {
       '1': 'party_data',
       '3': 48,
       '4': 1,
@@ -437,7 +442,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyData'
     },
-    const {
+    {
       '1': 'party_data_send',
       '3': 49,
       '4': 1,
@@ -446,7 +451,7 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyDataSend'
     },
-    const {
+    {
       '1': 'party_presence_event',
       '3': 50,
       '4': 1,
@@ -455,21 +460,96 @@ const Envelope$json = const {
       '9': 0,
       '10': 'partyPresenceEvent'
     },
+    {
+      '1': 'party_update',
+      '3': 51,
+      '4': 1,
+      '5': 11,
+      '6': '.nakama.realtime.PartyUpdate',
+      '9': 0,
+      '10': 'partyUpdate'
+    },
   ],
-  '8': const [
-    const {'1': 'message'},
+  '8': [
+    {'1': 'message'},
   ],
 };
 
 /// Descriptor for `Envelope`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List envelopeDescriptor = $convert.base64Decode(
-    'CghFbnZlbG9wZRIQCgNjaWQYASABKAlSA2NpZBI0CgdjaGFubmVsGAIgASgLMhgubmFrYW1hLnJlYWx0aW1lLkNoYW5uZWxIAFIHY2hhbm5lbBJBCgxjaGFubmVsX2pvaW4YAyABKAsyHC5uYWthbWEucmVhbHRpbWUuQ2hhbm5lbEpvaW5IAFILY2hhbm5lbEpvaW4SRAoNY2hhbm5lbF9sZWF2ZRgEIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5DaGFubmVsTGVhdmVIAFIMY2hhbm5lbExlYXZlEkUKD2NoYW5uZWxfbWVzc2FnZRgFIAEoCzIaLm5ha2FtYS5hcGkuQ2hhbm5lbE1lc3NhZ2VIAFIOY2hhbm5lbE1lc3NhZ2USVAoTY2hhbm5lbF9tZXNzYWdlX2FjaxgGIAEoCzIiLm5ha2FtYS5yZWFsdGltZS5DaGFubmVsTWVzc2FnZUFja0gAUhFjaGFubmVsTWVzc2FnZUFjaxJXChRjaGFubmVsX21lc3NhZ2Vfc2VuZBgHIAEoCzIjLm5ha2FtYS5yZWFsdGltZS5DaGFubmVsTWVzc2FnZVNlbmRIAFISY2hhbm5lbE1lc3NhZ2VTZW5kEl0KFmNoYW5uZWxfbWVzc2FnZV91cGRhdGUYCCABKAsyJS5uYWthbWEucmVhbHRpbWUuQ2hhbm5lbE1lc3NhZ2VVcGRhdGVIAFIUY2hhbm5lbE1lc3NhZ2VVcGRhdGUSXQoWY2hhbm5lbF9tZXNzYWdlX3JlbW92ZRgJIAEoCzIlLm5ha2FtYS5yZWFsdGltZS5DaGFubmVsTWVzc2FnZVJlbW92ZUgAUhRjaGFubmVsTWVzc2FnZVJlbW92ZRJdChZjaGFubmVsX3ByZXNlbmNlX2V2ZW50GAogASgLMiUubmFrYW1hLnJlYWx0aW1lLkNoYW5uZWxQcmVzZW5jZUV2ZW50SABSFGNoYW5uZWxQcmVzZW5jZUV2ZW50Ei4KBWVycm9yGAsgASgLMhYubmFrYW1hLnJlYWx0aW1lLkVycm9ySABSBWVycm9yEi4KBW1hdGNoGAwgASgLMhYubmFrYW1hLnJlYWx0aW1lLk1hdGNoSABSBW1hdGNoEkEKDG1hdGNoX2NyZWF0ZRgNIAEoCzIcLm5ha2FtYS5yZWFsdGltZS5NYXRjaENyZWF0ZUgAUgttYXRjaENyZWF0ZRI7CgptYXRjaF9kYXRhGA4gASgLMhoubmFrYW1hLnJlYWx0aW1lLk1hdGNoRGF0YUgAUgltYXRjaERhdGESSAoPbWF0Y2hfZGF0YV9zZW5kGA8gASgLMh4ubmFrYW1hLnJlYWx0aW1lLk1hdGNoRGF0YVNlbmRIAFINbWF0Y2hEYXRhU2VuZBI7CgptYXRjaF9qb2luGBAgASgLMhoubmFrYW1hLnJlYWx0aW1lLk1hdGNoSm9pbkgAUgltYXRjaEpvaW4SPgoLbWF0Y2hfbGVhdmUYESABKAsyGy5uYWthbWEucmVhbHRpbWUuTWF0Y2hMZWF2ZUgAUgptYXRjaExlYXZlElcKFG1hdGNoX3ByZXNlbmNlX2V2ZW50GBIgASgLMiMubmFrYW1hLnJlYWx0aW1lLk1hdGNoUHJlc2VuY2VFdmVudEgAUhJtYXRjaFByZXNlbmNlRXZlbnQSRwoObWF0Y2htYWtlcl9hZGQYEyABKAsyHi5uYWthbWEucmVhbHRpbWUuTWF0Y2htYWtlckFkZEgAUg1tYXRjaG1ha2VyQWRkElMKEm1hdGNobWFrZXJfbWF0Y2hlZBgUIAEoCzIiLm5ha2FtYS5yZWFsdGltZS5NYXRjaG1ha2VyTWF0Y2hlZEgAUhFtYXRjaG1ha2VyTWF0Y2hlZBJQChFtYXRjaG1ha2VyX3JlbW92ZRgVIAEoCzIhLm5ha2FtYS5yZWFsdGltZS5NYXRjaG1ha2VyUmVtb3ZlSABSEG1hdGNobWFrZXJSZW1vdmUSUAoRbWF0Y2htYWtlcl90aWNrZXQYFiABKAsyIS5uYWthbWEucmVhbHRpbWUuTWF0Y2htYWtlclRpY2tldEgAUhBtYXRjaG1ha2VyVGlja2V0EkYKDW5vdGlmaWNhdGlvbnMYFyABKAsyHi5uYWthbWEucmVhbHRpbWUuTm90aWZpY2F0aW9uc0gAUg1ub3RpZmljYXRpb25zEiMKA3JwYxgYIAEoCzIPLm5ha2FtYS5hcGkuUnBjSABSA3JwYxIxCgZzdGF0dXMYGSABKAsyFy5uYWthbWEucmVhbHRpbWUuU3RhdHVzSABSBnN0YXR1cxJECg1zdGF0dXNfZm9sbG93GBogASgLMh0ubmFrYW1hLnJlYWx0aW1lLlN0YXR1c0ZvbGxvd0gAUgxzdGF0dXNGb2xsb3cSWgoVc3RhdHVzX3ByZXNlbmNlX2V2ZW50GBsgASgLMiQubmFrYW1hLnJlYWx0aW1lLlN0YXR1c1ByZXNlbmNlRXZlbnRIAFITc3RhdHVzUHJlc2VuY2VFdmVudBJKCg9zdGF0dXNfdW5mb2xsb3cYHCABKAsyHy5uYWthbWEucmVhbHRpbWUuU3RhdHVzVW5mb2xsb3dIAFIOc3RhdHVzVW5mb2xsb3cSRAoNc3RhdHVzX3VwZGF0ZRgdIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5TdGF0dXNVcGRhdGVIAFIMc3RhdHVzVXBkYXRlEj4KC3N0cmVhbV9kYXRhGB4gASgLMhsubmFrYW1hLnJlYWx0aW1lLlN0cmVhbURhdGFIAFIKc3RyZWFtRGF0YRJaChVzdHJlYW1fcHJlc2VuY2VfZXZlbnQYHyABKAsyJC5uYWthbWEucmVhbHRpbWUuU3RyZWFtUHJlc2VuY2VFdmVudEgAUhNzdHJlYW1QcmVzZW5jZUV2ZW50EisKBHBpbmcYICABKAsyFS5uYWthbWEucmVhbHRpbWUuUGluZ0gAUgRwaW5nEisKBHBvbmcYISABKAsyFS5uYWthbWEucmVhbHRpbWUuUG9uZ0gAUgRwb25nEi4KBXBhcnR5GCIgASgLMhYubmFrYW1hLnJlYWx0aW1lLlBhcnR5SABSBXBhcnR5EkEKDHBhcnR5X2NyZWF0ZRgjIAEoCzIcLm5ha2FtYS5yZWFsdGltZS5QYXJ0eUNyZWF0ZUgAUgtwYXJ0eUNyZWF0ZRI7CgpwYXJ0eV9qb2luGCQgASgLMhoubmFrYW1hLnJlYWx0aW1lLlBhcnR5Sm9pbkgAUglwYXJ0eUpvaW4SPgoLcGFydHlfbGVhdmUYJSABKAsyGy5uYWthbWEucmVhbHRpbWUuUGFydHlMZWF2ZUgAUgpwYXJ0eUxlYXZlEkQKDXBhcnR5X3Byb21vdGUYJiABKAsyHS5uYWthbWEucmVhbHRpbWUuUGFydHlQcm9tb3RlSABSDHBhcnR5UHJvbW90ZRJBCgxwYXJ0eV9sZWFkZXIYJyABKAsyHC5uYWthbWEucmVhbHRpbWUuUGFydHlMZWFkZXJIAFILcGFydHlMZWFkZXISQQoMcGFydHlfYWNjZXB0GCggASgLMhwubmFrYW1hLnJlYWx0aW1lLlBhcnR5QWNjZXB0SABSC3BhcnR5QWNjZXB0EkEKDHBhcnR5X3JlbW92ZRgpIAEoCzIcLm5ha2FtYS5yZWFsdGltZS5QYXJ0eVJlbW92ZUgAUgtwYXJ0eVJlbW92ZRI+CgtwYXJ0eV9jbG9zZRgqIAEoCzIbLm5ha2FtYS5yZWFsdGltZS5QYXJ0eUNsb3NlSABSCnBhcnR5Q2xvc2USXgoXcGFydHlfam9pbl9yZXF1ZXN0X2xpc3QYKyABKAsyJS5uYWthbWEucmVhbHRpbWUuUGFydHlKb2luUmVxdWVzdExpc3RIAFIUcGFydHlKb2luUmVxdWVzdExpc3QSUQoScGFydHlfam9pbl9yZXF1ZXN0GCwgASgLMiEubmFrYW1hLnJlYWx0aW1lLlBhcnR5Sm9pblJlcXVlc3RIAFIQcGFydHlKb2luUmVxdWVzdBJXChRwYXJ0eV9tYXRjaG1ha2VyX2FkZBgtIAEoCzIjLm5ha2FtYS5yZWFsdGltZS5QYXJ0eU1hdGNobWFrZXJBZGRIAFIScGFydHlNYXRjaG1ha2VyQWRkEmAKF3BhcnR5X21hdGNobWFrZXJfcmVtb3ZlGC4gASgLMiYubmFrYW1hLnJlYWx0aW1lLlBhcnR5TWF0Y2htYWtlclJlbW92ZUgAUhVwYXJ0eU1hdGNobWFrZXJSZW1vdmUSYAoXcGFydHlfbWF0Y2htYWtlcl90aWNrZXQYLyABKAsyJi5uYWthbWEucmVhbHRpbWUuUGFydHlNYXRjaG1ha2VyVGlja2V0SABSFXBhcnR5TWF0Y2htYWtlclRpY2tldBI7CgpwYXJ0eV9kYXRhGDAgASgLMhoubmFrYW1hLnJlYWx0aW1lLlBhcnR5RGF0YUgAUglwYXJ0eURhdGESSAoPcGFydHlfZGF0YV9zZW5kGDEgASgLMh4ubmFrYW1hLnJlYWx0aW1lLlBhcnR5RGF0YVNlbmRIAFINcGFydHlEYXRhU2VuZBJXChRwYXJ0eV9wcmVzZW5jZV9ldmVudBgyIAEoCzIjLm5ha2FtYS5yZWFsdGltZS5QYXJ0eVByZXNlbmNlRXZlbnRIAFIScGFydHlQcmVzZW5jZUV2ZW50QgkKB21lc3NhZ2U=');
+    'CghFbnZlbG9wZRIQCgNjaWQYASABKAlSA2NpZBI0CgdjaGFubmVsGAIgASgLMhgubmFrYW1hLn'
+    'JlYWx0aW1lLkNoYW5uZWxIAFIHY2hhbm5lbBJBCgxjaGFubmVsX2pvaW4YAyABKAsyHC5uYWth'
+    'bWEucmVhbHRpbWUuQ2hhbm5lbEpvaW5IAFILY2hhbm5lbEpvaW4SRAoNY2hhbm5lbF9sZWF2ZR'
+    'gEIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5DaGFubmVsTGVhdmVIAFIMY2hhbm5lbExlYXZlEkUK'
+    'D2NoYW5uZWxfbWVzc2FnZRgFIAEoCzIaLm5ha2FtYS5hcGkuQ2hhbm5lbE1lc3NhZ2VIAFIOY2'
+    'hhbm5lbE1lc3NhZ2USVAoTY2hhbm5lbF9tZXNzYWdlX2FjaxgGIAEoCzIiLm5ha2FtYS5yZWFs'
+    'dGltZS5DaGFubmVsTWVzc2FnZUFja0gAUhFjaGFubmVsTWVzc2FnZUFjaxJXChRjaGFubmVsX2'
+    '1lc3NhZ2Vfc2VuZBgHIAEoCzIjLm5ha2FtYS5yZWFsdGltZS5DaGFubmVsTWVzc2FnZVNlbmRI'
+    'AFISY2hhbm5lbE1lc3NhZ2VTZW5kEl0KFmNoYW5uZWxfbWVzc2FnZV91cGRhdGUYCCABKAsyJS'
+    '5uYWthbWEucmVhbHRpbWUuQ2hhbm5lbE1lc3NhZ2VVcGRhdGVIAFIUY2hhbm5lbE1lc3NhZ2VV'
+    'cGRhdGUSXQoWY2hhbm5lbF9tZXNzYWdlX3JlbW92ZRgJIAEoCzIlLm5ha2FtYS5yZWFsdGltZS'
+    '5DaGFubmVsTWVzc2FnZVJlbW92ZUgAUhRjaGFubmVsTWVzc2FnZVJlbW92ZRJdChZjaGFubmVs'
+    'X3ByZXNlbmNlX2V2ZW50GAogASgLMiUubmFrYW1hLnJlYWx0aW1lLkNoYW5uZWxQcmVzZW5jZU'
+    'V2ZW50SABSFGNoYW5uZWxQcmVzZW5jZUV2ZW50Ei4KBWVycm9yGAsgASgLMhYubmFrYW1hLnJl'
+    'YWx0aW1lLkVycm9ySABSBWVycm9yEi4KBW1hdGNoGAwgASgLMhYubmFrYW1hLnJlYWx0aW1lLk'
+    '1hdGNoSABSBW1hdGNoEkEKDG1hdGNoX2NyZWF0ZRgNIAEoCzIcLm5ha2FtYS5yZWFsdGltZS5N'
+    'YXRjaENyZWF0ZUgAUgttYXRjaENyZWF0ZRI7CgptYXRjaF9kYXRhGA4gASgLMhoubmFrYW1hLn'
+    'JlYWx0aW1lLk1hdGNoRGF0YUgAUgltYXRjaERhdGESSAoPbWF0Y2hfZGF0YV9zZW5kGA8gASgL'
+    'Mh4ubmFrYW1hLnJlYWx0aW1lLk1hdGNoRGF0YVNlbmRIAFINbWF0Y2hEYXRhU2VuZBI7CgptYX'
+    'RjaF9qb2luGBAgASgLMhoubmFrYW1hLnJlYWx0aW1lLk1hdGNoSm9pbkgAUgltYXRjaEpvaW4S'
+    'PgoLbWF0Y2hfbGVhdmUYESABKAsyGy5uYWthbWEucmVhbHRpbWUuTWF0Y2hMZWF2ZUgAUgptYX'
+    'RjaExlYXZlElcKFG1hdGNoX3ByZXNlbmNlX2V2ZW50GBIgASgLMiMubmFrYW1hLnJlYWx0aW1l'
+    'Lk1hdGNoUHJlc2VuY2VFdmVudEgAUhJtYXRjaFByZXNlbmNlRXZlbnQSRwoObWF0Y2htYWtlcl'
+    '9hZGQYEyABKAsyHi5uYWthbWEucmVhbHRpbWUuTWF0Y2htYWtlckFkZEgAUg1tYXRjaG1ha2Vy'
+    'QWRkElMKEm1hdGNobWFrZXJfbWF0Y2hlZBgUIAEoCzIiLm5ha2FtYS5yZWFsdGltZS5NYXRjaG'
+    '1ha2VyTWF0Y2hlZEgAUhFtYXRjaG1ha2VyTWF0Y2hlZBJQChFtYXRjaG1ha2VyX3JlbW92ZRgV'
+    'IAEoCzIhLm5ha2FtYS5yZWFsdGltZS5NYXRjaG1ha2VyUmVtb3ZlSABSEG1hdGNobWFrZXJSZW'
+    '1vdmUSUAoRbWF0Y2htYWtlcl90aWNrZXQYFiABKAsyIS5uYWthbWEucmVhbHRpbWUuTWF0Y2ht'
+    'YWtlclRpY2tldEgAUhBtYXRjaG1ha2VyVGlja2V0EkYKDW5vdGlmaWNhdGlvbnMYFyABKAsyHi'
+    '5uYWthbWEucmVhbHRpbWUuTm90aWZpY2F0aW9uc0gAUg1ub3RpZmljYXRpb25zEiMKA3JwYxgY'
+    'IAEoCzIPLm5ha2FtYS5hcGkuUnBjSABSA3JwYxIxCgZzdGF0dXMYGSABKAsyFy5uYWthbWEucm'
+    'VhbHRpbWUuU3RhdHVzSABSBnN0YXR1cxJECg1zdGF0dXNfZm9sbG93GBogASgLMh0ubmFrYW1h'
+    'LnJlYWx0aW1lLlN0YXR1c0ZvbGxvd0gAUgxzdGF0dXNGb2xsb3cSWgoVc3RhdHVzX3ByZXNlbm'
+    'NlX2V2ZW50GBsgASgLMiQubmFrYW1hLnJlYWx0aW1lLlN0YXR1c1ByZXNlbmNlRXZlbnRIAFIT'
+    'c3RhdHVzUHJlc2VuY2VFdmVudBJKCg9zdGF0dXNfdW5mb2xsb3cYHCABKAsyHy5uYWthbWEucm'
+    'VhbHRpbWUuU3RhdHVzVW5mb2xsb3dIAFIOc3RhdHVzVW5mb2xsb3cSRAoNc3RhdHVzX3VwZGF0'
+    'ZRgdIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5TdGF0dXNVcGRhdGVIAFIMc3RhdHVzVXBkYXRlEj'
+    '4KC3N0cmVhbV9kYXRhGB4gASgLMhsubmFrYW1hLnJlYWx0aW1lLlN0cmVhbURhdGFIAFIKc3Ry'
+    'ZWFtRGF0YRJaChVzdHJlYW1fcHJlc2VuY2VfZXZlbnQYHyABKAsyJC5uYWthbWEucmVhbHRpbW'
+    'UuU3RyZWFtUHJlc2VuY2VFdmVudEgAUhNzdHJlYW1QcmVzZW5jZUV2ZW50EisKBHBpbmcYICAB'
+    'KAsyFS5uYWthbWEucmVhbHRpbWUuUGluZ0gAUgRwaW5nEisKBHBvbmcYISABKAsyFS5uYWthbW'
+    'EucmVhbHRpbWUuUG9uZ0gAUgRwb25nEi4KBXBhcnR5GCIgASgLMhYubmFrYW1hLnJlYWx0aW1l'
+    'LlBhcnR5SABSBXBhcnR5EkEKDHBhcnR5X2NyZWF0ZRgjIAEoCzIcLm5ha2FtYS5yZWFsdGltZS'
+    '5QYXJ0eUNyZWF0ZUgAUgtwYXJ0eUNyZWF0ZRI7CgpwYXJ0eV9qb2luGCQgASgLMhoubmFrYW1h'
+    'LnJlYWx0aW1lLlBhcnR5Sm9pbkgAUglwYXJ0eUpvaW4SPgoLcGFydHlfbGVhdmUYJSABKAsyGy'
+    '5uYWthbWEucmVhbHRpbWUuUGFydHlMZWF2ZUgAUgpwYXJ0eUxlYXZlEkQKDXBhcnR5X3Byb21v'
+    'dGUYJiABKAsyHS5uYWthbWEucmVhbHRpbWUuUGFydHlQcm9tb3RlSABSDHBhcnR5UHJvbW90ZR'
+    'JBCgxwYXJ0eV9sZWFkZXIYJyABKAsyHC5uYWthbWEucmVhbHRpbWUuUGFydHlMZWFkZXJIAFIL'
+    'cGFydHlMZWFkZXISQQoMcGFydHlfYWNjZXB0GCggASgLMhwubmFrYW1hLnJlYWx0aW1lLlBhcn'
+    'R5QWNjZXB0SABSC3BhcnR5QWNjZXB0EkEKDHBhcnR5X3JlbW92ZRgpIAEoCzIcLm5ha2FtYS5y'
+    'ZWFsdGltZS5QYXJ0eVJlbW92ZUgAUgtwYXJ0eVJlbW92ZRI+CgtwYXJ0eV9jbG9zZRgqIAEoCz'
+    'IbLm5ha2FtYS5yZWFsdGltZS5QYXJ0eUNsb3NlSABSCnBhcnR5Q2xvc2USXgoXcGFydHlfam9p'
+    'bl9yZXF1ZXN0X2xpc3QYKyABKAsyJS5uYWthbWEucmVhbHRpbWUuUGFydHlKb2luUmVxdWVzdE'
+    'xpc3RIAFIUcGFydHlKb2luUmVxdWVzdExpc3QSUQoScGFydHlfam9pbl9yZXF1ZXN0GCwgASgL'
+    'MiEubmFrYW1hLnJlYWx0aW1lLlBhcnR5Sm9pblJlcXVlc3RIAFIQcGFydHlKb2luUmVxdWVzdB'
+    'JXChRwYXJ0eV9tYXRjaG1ha2VyX2FkZBgtIAEoCzIjLm5ha2FtYS5yZWFsdGltZS5QYXJ0eU1h'
+    'dGNobWFrZXJBZGRIAFIScGFydHlNYXRjaG1ha2VyQWRkEmAKF3BhcnR5X21hdGNobWFrZXJfcm'
+    'Vtb3ZlGC4gASgLMiYubmFrYW1hLnJlYWx0aW1lLlBhcnR5TWF0Y2htYWtlclJlbW92ZUgAUhVw'
+    'YXJ0eU1hdGNobWFrZXJSZW1vdmUSYAoXcGFydHlfbWF0Y2htYWtlcl90aWNrZXQYLyABKAsyJi'
+    '5uYWthbWEucmVhbHRpbWUuUGFydHlNYXRjaG1ha2VyVGlja2V0SABSFXBhcnR5TWF0Y2htYWtl'
+    'clRpY2tldBI7CgpwYXJ0eV9kYXRhGDAgASgLMhoubmFrYW1hLnJlYWx0aW1lLlBhcnR5RGF0YU'
+    'gAUglwYXJ0eURhdGESSAoPcGFydHlfZGF0YV9zZW5kGDEgASgLMh4ubmFrYW1hLnJlYWx0aW1l'
+    'LlBhcnR5RGF0YVNlbmRIAFINcGFydHlEYXRhU2VuZBJXChRwYXJ0eV9wcmVzZW5jZV9ldmVudB'
+    'gyIAEoCzIjLm5ha2FtYS5yZWFsdGltZS5QYXJ0eVByZXNlbmNlRXZlbnRIAFIScGFydHlQcmVz'
+    'ZW5jZUV2ZW50EkEKDHBhcnR5X3VwZGF0ZRgzIAEoCzIcLm5ha2FtYS5yZWFsdGltZS5QYXJ0eV'
+    'VwZGF0ZUgAUgtwYXJ0eVVwZGF0ZUIJCgdtZXNzYWdl');
+
 @$core.Deprecated('Use channelDescriptor instead')
-const Channel$json = const {
+const Channel$json = {
   '1': 'Channel',
-  '2': const [
-    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
-    const {
+  '2': [
+    {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    {
       '1': 'presences',
       '3': 2,
       '4': 3,
@@ -477,7 +557,7 @@ const Channel$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'presences'
     },
-    const {
+    {
       '1': 'self',
       '3': 3,
       '4': 1,
@@ -485,23 +565,28 @@ const Channel$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'self'
     },
-    const {'1': 'room_name', '3': 4, '4': 1, '5': 9, '10': 'roomName'},
-    const {'1': 'group_id', '3': 5, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_id_one', '3': 6, '4': 1, '5': 9, '10': 'userIdOne'},
-    const {'1': 'user_id_two', '3': 7, '4': 1, '5': 9, '10': 'userIdTwo'},
+    {'1': 'room_name', '3': 4, '4': 1, '5': 9, '10': 'roomName'},
+    {'1': 'group_id', '3': 5, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_id_one', '3': 6, '4': 1, '5': 9, '10': 'userIdOne'},
+    {'1': 'user_id_two', '3': 7, '4': 1, '5': 9, '10': 'userIdTwo'},
   ],
 };
 
 /// Descriptor for `Channel`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelDescriptor = $convert.base64Decode(
-    'CgdDaGFubmVsEg4KAmlkGAEgASgJUgJpZBI7CglwcmVzZW5jZXMYAiADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUglwcmVzZW5jZXMSMQoEc2VsZhgDIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSBHNlbGYSGwoJcm9vbV9uYW1lGAQgASgJUghyb29tTmFtZRIZCghncm91cF9pZBgFIAEoCVIHZ3JvdXBJZBIeCgt1c2VyX2lkX29uZRgGIAEoCVIJdXNlcklkT25lEh4KC3VzZXJfaWRfdHdvGAcgASgJUgl1c2VySWRUd28=');
+    'CgdDaGFubmVsEg4KAmlkGAEgASgJUgJpZBI7CglwcmVzZW5jZXMYAiADKAsyHS5uYWthbWEucm'
+    'VhbHRpbWUuVXNlclByZXNlbmNlUglwcmVzZW5jZXMSMQoEc2VsZhgDIAEoCzIdLm5ha2FtYS5y'
+    'ZWFsdGltZS5Vc2VyUHJlc2VuY2VSBHNlbGYSGwoJcm9vbV9uYW1lGAQgASgJUghyb29tTmFtZR'
+    'IZCghncm91cF9pZBgFIAEoCVIHZ3JvdXBJZBIeCgt1c2VyX2lkX29uZRgGIAEoCVIJdXNlcklk'
+    'T25lEh4KC3VzZXJfaWRfdHdvGAcgASgJUgl1c2VySWRUd28=');
+
 @$core.Deprecated('Use channelJoinDescriptor instead')
-const ChannelJoin$json = const {
+const ChannelJoin$json = {
   '1': 'ChannelJoin',
-  '2': const [
-    const {'1': 'target', '3': 1, '4': 1, '5': 9, '10': 'target'},
-    const {'1': 'type', '3': 2, '4': 1, '5': 5, '10': 'type'},
-    const {
+  '2': [
+    {'1': 'target', '3': 1, '4': 1, '5': 9, '10': 'target'},
+    {'1': 'type', '3': 2, '4': 1, '5': 5, '10': 'type'},
+    {
       '1': 'persistence',
       '3': 3,
       '4': 1,
@@ -509,7 +594,7 @@ const ChannelJoin$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'persistence'
     },
-    const {
+    {
       '1': 'hidden',
       '3': 4,
       '4': 1,
@@ -518,41 +603,47 @@ const ChannelJoin$json = const {
       '10': 'hidden'
     },
   ],
-  '4': const [ChannelJoin_Type$json],
+  '4': [ChannelJoin_Type$json],
 };
 
 @$core.Deprecated('Use channelJoinDescriptor instead')
-const ChannelJoin_Type$json = const {
+const ChannelJoin_Type$json = {
   '1': 'Type',
-  '2': const [
-    const {'1': 'TYPE_UNSPECIFIED', '2': 0},
-    const {'1': 'ROOM', '2': 1},
-    const {'1': 'DIRECT_MESSAGE', '2': 2},
-    const {'1': 'GROUP', '2': 3},
+  '2': [
+    {'1': 'TYPE_UNSPECIFIED', '2': 0},
+    {'1': 'ROOM', '2': 1},
+    {'1': 'DIRECT_MESSAGE', '2': 2},
+    {'1': 'GROUP', '2': 3},
   ],
 };
 
 /// Descriptor for `ChannelJoin`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelJoinDescriptor = $convert.base64Decode(
-    'CgtDaGFubmVsSm9pbhIWCgZ0YXJnZXQYASABKAlSBnRhcmdldBISCgR0eXBlGAIgASgFUgR0eXBlEjwKC3BlcnNpc3RlbmNlGAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVILcGVyc2lzdGVuY2USMgoGaGlkZGVuGAQgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIGaGlkZGVuIkUKBFR5cGUSFAoQVFlQRV9VTlNQRUNJRklFRBAAEggKBFJPT00QARISCg5ESVJFQ1RfTUVTU0FHRRACEgkKBUdST1VQEAM=');
+    'CgtDaGFubmVsSm9pbhIWCgZ0YXJnZXQYASABKAlSBnRhcmdldBISCgR0eXBlGAIgASgFUgR0eX'
+    'BlEjwKC3BlcnNpc3RlbmNlGAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVILcGVy'
+    'c2lzdGVuY2USMgoGaGlkZGVuGAQgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIGaG'
+    'lkZGVuIkUKBFR5cGUSFAoQVFlQRV9VTlNQRUNJRklFRBAAEggKBFJPT00QARISCg5ESVJFQ1Rf'
+    'TUVTU0FHRRACEgkKBUdST1VQEAM=');
+
 @$core.Deprecated('Use channelLeaveDescriptor instead')
-const ChannelLeave$json = const {
+const ChannelLeave$json = {
   '1': 'ChannelLeave',
-  '2': const [
-    const {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
+  '2': [
+    {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
   ],
 };
 
 /// Descriptor for `ChannelLeave`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelLeaveDescriptor = $convert.base64Decode(
     'CgxDaGFubmVsTGVhdmUSHQoKY2hhbm5lbF9pZBgBIAEoCVIJY2hhbm5lbElk');
+
 @$core.Deprecated('Use channelMessageAckDescriptor instead')
-const ChannelMessageAck$json = const {
+const ChannelMessageAck$json = {
   '1': 'ChannelMessageAck',
-  '2': const [
-    const {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
-    const {'1': 'message_id', '3': 2, '4': 1, '5': 9, '10': 'messageId'},
-    const {
+  '2': [
+    {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
+    {'1': 'message_id', '3': 2, '4': 1, '5': 9, '10': 'messageId'},
+    {
       '1': 'code',
       '3': 3,
       '4': 1,
@@ -560,8 +651,8 @@ const ChannelMessageAck$json = const {
       '6': '.google.protobuf.Int32Value',
       '10': 'code'
     },
-    const {'1': 'username', '3': 4, '4': 1, '5': 9, '10': 'username'},
-    const {
+    {'1': 'username', '3': 4, '4': 1, '5': 9, '10': 'username'},
+    {
       '1': 'create_time',
       '3': 5,
       '4': 1,
@@ -569,7 +660,7 @@ const ChannelMessageAck$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'createTime'
     },
-    const {
+    {
       '1': 'update_time',
       '3': 6,
       '4': 1,
@@ -577,7 +668,7 @@ const ChannelMessageAck$json = const {
       '6': '.google.protobuf.Timestamp',
       '10': 'updateTime'
     },
-    const {
+    {
       '1': 'persistent',
       '3': 7,
       '4': 1,
@@ -585,59 +676,74 @@ const ChannelMessageAck$json = const {
       '6': '.google.protobuf.BoolValue',
       '10': 'persistent'
     },
-    const {'1': 'room_name', '3': 8, '4': 1, '5': 9, '10': 'roomName'},
-    const {'1': 'group_id', '3': 9, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_id_one', '3': 10, '4': 1, '5': 9, '10': 'userIdOne'},
-    const {'1': 'user_id_two', '3': 11, '4': 1, '5': 9, '10': 'userIdTwo'},
+    {'1': 'room_name', '3': 8, '4': 1, '5': 9, '10': 'roomName'},
+    {'1': 'group_id', '3': 9, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_id_one', '3': 10, '4': 1, '5': 9, '10': 'userIdOne'},
+    {'1': 'user_id_two', '3': 11, '4': 1, '5': 9, '10': 'userIdTwo'},
   ],
 };
 
 /// Descriptor for `ChannelMessageAck`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelMessageAckDescriptor = $convert.base64Decode(
-    'ChFDaGFubmVsTWVzc2FnZUFjaxIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSHQoKbWVzc2FnZV9pZBgCIAEoCVIJbWVzc2FnZUlkEi8KBGNvZGUYAyABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVIEY29kZRIaCgh1c2VybmFtZRgEIAEoCVIIdXNlcm5hbWUSOwoLY3JlYXRlX3RpbWUYBSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgpjcmVhdGVUaW1lEjsKC3VwZGF0ZV90aW1lGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKdXBkYXRlVGltZRI6CgpwZXJzaXN0ZW50GAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIKcGVyc2lzdGVudBIbCglyb29tX25hbWUYCCABKAlSCHJvb21OYW1lEhkKCGdyb3VwX2lkGAkgASgJUgdncm91cElkEh4KC3VzZXJfaWRfb25lGAogASgJUgl1c2VySWRPbmUSHgoLdXNlcl9pZF90d28YCyABKAlSCXVzZXJJZFR3bw==');
+    'ChFDaGFubmVsTWVzc2FnZUFjaxIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSHQoKbW'
+    'Vzc2FnZV9pZBgCIAEoCVIJbWVzc2FnZUlkEi8KBGNvZGUYAyABKAsyGy5nb29nbGUucHJvdG9i'
+    'dWYuSW50MzJWYWx1ZVIEY29kZRIaCgh1c2VybmFtZRgEIAEoCVIIdXNlcm5hbWUSOwoLY3JlYX'
+    'RlX3RpbWUYBSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgpjcmVhdGVUaW1lEjsK'
+    'C3VwZGF0ZV90aW1lGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIKdXBkYXRlVG'
+    'ltZRI6CgpwZXJzaXN0ZW50GAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLkJvb2xWYWx1ZVIKcGVy'
+    'c2lzdGVudBIbCglyb29tX25hbWUYCCABKAlSCHJvb21OYW1lEhkKCGdyb3VwX2lkGAkgASgJUg'
+    'dncm91cElkEh4KC3VzZXJfaWRfb25lGAogASgJUgl1c2VySWRPbmUSHgoLdXNlcl9pZF90d28Y'
+    'CyABKAlSCXVzZXJJZFR3bw==');
+
 @$core.Deprecated('Use channelMessageSendDescriptor instead')
-const ChannelMessageSend$json = const {
+const ChannelMessageSend$json = {
   '1': 'ChannelMessageSend',
-  '2': const [
-    const {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
-    const {'1': 'content', '3': 2, '4': 1, '5': 9, '10': 'content'},
+  '2': [
+    {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
+    {'1': 'content', '3': 2, '4': 1, '5': 9, '10': 'content'},
   ],
 };
 
 /// Descriptor for `ChannelMessageSend`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelMessageSendDescriptor = $convert.base64Decode(
-    'ChJDaGFubmVsTWVzc2FnZVNlbmQSHQoKY2hhbm5lbF9pZBgBIAEoCVIJY2hhbm5lbElkEhgKB2NvbnRlbnQYAiABKAlSB2NvbnRlbnQ=');
+    'ChJDaGFubmVsTWVzc2FnZVNlbmQSHQoKY2hhbm5lbF9pZBgBIAEoCVIJY2hhbm5lbElkEhgKB2'
+    'NvbnRlbnQYAiABKAlSB2NvbnRlbnQ=');
+
 @$core.Deprecated('Use channelMessageUpdateDescriptor instead')
-const ChannelMessageUpdate$json = const {
+const ChannelMessageUpdate$json = {
   '1': 'ChannelMessageUpdate',
-  '2': const [
-    const {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
-    const {'1': 'message_id', '3': 2, '4': 1, '5': 9, '10': 'messageId'},
-    const {'1': 'content', '3': 3, '4': 1, '5': 9, '10': 'content'},
+  '2': [
+    {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
+    {'1': 'message_id', '3': 2, '4': 1, '5': 9, '10': 'messageId'},
+    {'1': 'content', '3': 3, '4': 1, '5': 9, '10': 'content'},
   ],
 };
 
 /// Descriptor for `ChannelMessageUpdate`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelMessageUpdateDescriptor = $convert.base64Decode(
-    'ChRDaGFubmVsTWVzc2FnZVVwZGF0ZRIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSHQoKbWVzc2FnZV9pZBgCIAEoCVIJbWVzc2FnZUlkEhgKB2NvbnRlbnQYAyABKAlSB2NvbnRlbnQ=');
+    'ChRDaGFubmVsTWVzc2FnZVVwZGF0ZRIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSHQ'
+    'oKbWVzc2FnZV9pZBgCIAEoCVIJbWVzc2FnZUlkEhgKB2NvbnRlbnQYAyABKAlSB2NvbnRlbnQ=');
+
 @$core.Deprecated('Use channelMessageRemoveDescriptor instead')
-const ChannelMessageRemove$json = const {
+const ChannelMessageRemove$json = {
   '1': 'ChannelMessageRemove',
-  '2': const [
-    const {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
-    const {'1': 'message_id', '3': 2, '4': 1, '5': 9, '10': 'messageId'},
+  '2': [
+    {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
+    {'1': 'message_id', '3': 2, '4': 1, '5': 9, '10': 'messageId'},
   ],
 };
 
 /// Descriptor for `ChannelMessageRemove`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelMessageRemoveDescriptor = $convert.base64Decode(
-    'ChRDaGFubmVsTWVzc2FnZVJlbW92ZRIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSHQoKbWVzc2FnZV9pZBgCIAEoCVIJbWVzc2FnZUlk');
+    'ChRDaGFubmVsTWVzc2FnZVJlbW92ZRIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSHQ'
+    'oKbWVzc2FnZV9pZBgCIAEoCVIJbWVzc2FnZUlk');
+
 @$core.Deprecated('Use channelPresenceEventDescriptor instead')
-const ChannelPresenceEvent$json = const {
+const ChannelPresenceEvent$json = {
   '1': 'ChannelPresenceEvent',
-  '2': const [
-    const {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
-    const {
+  '2': [
+    {'1': 'channel_id', '3': 1, '4': 1, '5': 9, '10': 'channelId'},
+    {
       '1': 'joins',
       '3': 2,
       '4': 3,
@@ -645,7 +751,7 @@ const ChannelPresenceEvent$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'joins'
     },
-    const {
+    {
       '1': 'leaves',
       '3': 3,
       '4': 3,
@@ -653,23 +759,29 @@ const ChannelPresenceEvent$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'leaves'
     },
-    const {'1': 'room_name', '3': 4, '4': 1, '5': 9, '10': 'roomName'},
-    const {'1': 'group_id', '3': 5, '4': 1, '5': 9, '10': 'groupId'},
-    const {'1': 'user_id_one', '3': 6, '4': 1, '5': 9, '10': 'userIdOne'},
-    const {'1': 'user_id_two', '3': 7, '4': 1, '5': 9, '10': 'userIdTwo'},
+    {'1': 'room_name', '3': 4, '4': 1, '5': 9, '10': 'roomName'},
+    {'1': 'group_id', '3': 5, '4': 1, '5': 9, '10': 'groupId'},
+    {'1': 'user_id_one', '3': 6, '4': 1, '5': 9, '10': 'userIdOne'},
+    {'1': 'user_id_two', '3': 7, '4': 1, '5': 9, '10': 'userIdTwo'},
   ],
 };
 
 /// Descriptor for `ChannelPresenceEvent`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List channelPresenceEventDescriptor = $convert.base64Decode(
-    'ChRDaGFubmVsUHJlc2VuY2VFdmVudBIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSMwoFam9pbnMYAiADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgVqb2lucxI1CgZsZWF2ZXMYAyADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgZsZWF2ZXMSGwoJcm9vbV9uYW1lGAQgASgJUghyb29tTmFtZRIZCghncm91cF9pZBgFIAEoCVIHZ3JvdXBJZBIeCgt1c2VyX2lkX29uZRgGIAEoCVIJdXNlcklkT25lEh4KC3VzZXJfaWRfdHdvGAcgASgJUgl1c2VySWRUd28=');
+    'ChRDaGFubmVsUHJlc2VuY2VFdmVudBIdCgpjaGFubmVsX2lkGAEgASgJUgljaGFubmVsSWQSMw'
+    'oFam9pbnMYAiADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgVqb2lucxI1CgZs'
+    'ZWF2ZXMYAyADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgZsZWF2ZXMSGwoJcm'
+    '9vbV9uYW1lGAQgASgJUghyb29tTmFtZRIZCghncm91cF9pZBgFIAEoCVIHZ3JvdXBJZBIeCgt1'
+    'c2VyX2lkX29uZRgGIAEoCVIJdXNlcklkT25lEh4KC3VzZXJfaWRfdHdvGAcgASgJUgl1c2VySW'
+    'RUd28=');
+
 @$core.Deprecated('Use errorDescriptor instead')
-const Error$json = const {
+const Error$json = {
   '1': 'Error',
-  '2': const [
-    const {'1': 'code', '3': 1, '4': 1, '5': 5, '10': 'code'},
-    const {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
-    const {
+  '2': [
+    {'1': 'code', '3': 1, '4': 1, '5': 5, '10': 'code'},
+    {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+    {
       '1': 'context',
       '3': 3,
       '4': 3,
@@ -678,45 +790,52 @@ const Error$json = const {
       '10': 'context'
     },
   ],
-  '3': const [Error_ContextEntry$json],
-  '4': const [Error_Code$json],
+  '3': [Error_ContextEntry$json],
+  '4': [Error_Code$json],
 };
 
 @$core.Deprecated('Use errorDescriptor instead')
-const Error_ContextEntry$json = const {
+const Error_ContextEntry$json = {
   '1': 'ContextEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 @$core.Deprecated('Use errorDescriptor instead')
-const Error_Code$json = const {
+const Error_Code$json = {
   '1': 'Code',
-  '2': const [
-    const {'1': 'RUNTIME_EXCEPTION', '2': 0},
-    const {'1': 'UNRECOGNIZED_PAYLOAD', '2': 1},
-    const {'1': 'MISSING_PAYLOAD', '2': 2},
-    const {'1': 'BAD_INPUT', '2': 3},
-    const {'1': 'MATCH_NOT_FOUND', '2': 4},
-    const {'1': 'MATCH_JOIN_REJECTED', '2': 5},
-    const {'1': 'RUNTIME_FUNCTION_NOT_FOUND', '2': 6},
-    const {'1': 'RUNTIME_FUNCTION_EXCEPTION', '2': 7},
+  '2': [
+    {'1': 'RUNTIME_EXCEPTION', '2': 0},
+    {'1': 'UNRECOGNIZED_PAYLOAD', '2': 1},
+    {'1': 'MISSING_PAYLOAD', '2': 2},
+    {'1': 'BAD_INPUT', '2': 3},
+    {'1': 'MATCH_NOT_FOUND', '2': 4},
+    {'1': 'MATCH_JOIN_REJECTED', '2': 5},
+    {'1': 'RUNTIME_FUNCTION_NOT_FOUND', '2': 6},
+    {'1': 'RUNTIME_FUNCTION_EXCEPTION', '2': 7},
   ],
 };
 
 /// Descriptor for `Error`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List errorDescriptor = $convert.base64Decode(
-    'CgVFcnJvchISCgRjb2RlGAEgASgFUgRjb2RlEhgKB21lc3NhZ2UYAiABKAlSB21lc3NhZ2USPQoHY29udGV4dBgDIAMoCzIjLm5ha2FtYS5yZWFsdGltZS5FcnJvci5Db250ZXh0RW50cnlSB2NvbnRleHQaOgoMQ29udGV4dEVudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAEiyQEKBENvZGUSFQoRUlVOVElNRV9FWENFUFRJT04QABIYChRVTlJFQ09HTklaRURfUEFZTE9BRBABEhMKD01JU1NJTkdfUEFZTE9BRBACEg0KCUJBRF9JTlBVVBADEhMKD01BVENIX05PVF9GT1VORBAEEhcKE01BVENIX0pPSU5fUkVKRUNURUQQBRIeChpSVU5USU1FX0ZVTkNUSU9OX05PVF9GT1VORBAGEh4KGlJVTlRJTUVfRlVOQ1RJT05fRVhDRVBUSU9OEAc=');
+    'CgVFcnJvchISCgRjb2RlGAEgASgFUgRjb2RlEhgKB21lc3NhZ2UYAiABKAlSB21lc3NhZ2USPQ'
+    'oHY29udGV4dBgDIAMoCzIjLm5ha2FtYS5yZWFsdGltZS5FcnJvci5Db250ZXh0RW50cnlSB2Nv'
+    'bnRleHQaOgoMQ29udGV4dEVudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUg'
+    'V2YWx1ZToCOAEiyQEKBENvZGUSFQoRUlVOVElNRV9FWENFUFRJT04QABIYChRVTlJFQ09HTkla'
+    'RURfUEFZTE9BRBABEhMKD01JU1NJTkdfUEFZTE9BRBACEg0KCUJBRF9JTlBVVBADEhMKD01BVE'
+    'NIX05PVF9GT1VORBAEEhcKE01BVENIX0pPSU5fUkVKRUNURUQQBRIeChpSVU5USU1FX0ZVTkNU'
+    'SU9OX05PVF9GT1VORBAGEh4KGlJVTlRJTUVfRlVOQ1RJT05fRVhDRVBUSU9OEAc=');
+
 @$core.Deprecated('Use matchDescriptor instead')
-const Match$json = const {
+const Match$json = {
   '1': 'Match',
-  '2': const [
-    const {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
-    const {'1': 'authoritative', '3': 2, '4': 1, '5': 8, '10': 'authoritative'},
-    const {
+  '2': [
+    {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
+    {'1': 'authoritative', '3': 2, '4': 1, '5': 8, '10': 'authoritative'},
+    {
       '1': 'label',
       '3': 3,
       '4': 1,
@@ -724,8 +843,8 @@ const Match$json = const {
       '6': '.google.protobuf.StringValue',
       '10': 'label'
     },
-    const {'1': 'size', '3': 4, '4': 1, '5': 5, '10': 'size'},
-    const {
+    {'1': 'size', '3': 4, '4': 1, '5': 5, '10': 'size'},
+    {
       '1': 'presences',
       '3': 5,
       '4': 3,
@@ -733,7 +852,7 @@ const Match$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'presences'
     },
-    const {
+    {
       '1': 'self',
       '3': 6,
       '4': 1,
@@ -746,24 +865,30 @@ const Match$json = const {
 
 /// Descriptor for `Match`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchDescriptor = $convert.base64Decode(
-    'CgVNYXRjaBIZCghtYXRjaF9pZBgBIAEoCVIHbWF0Y2hJZBIkCg1hdXRob3JpdGF0aXZlGAIgASgIUg1hdXRob3JpdGF0aXZlEjIKBWxhYmVsGAMgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1ZhbHVlUgVsYWJlbBISCgRzaXplGAQgASgFUgRzaXplEjsKCXByZXNlbmNlcxgFIAMoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCXByZXNlbmNlcxIxCgRzZWxmGAYgASgLMh0ubmFrYW1hLnJlYWx0aW1lLlVzZXJQcmVzZW5jZVIEc2VsZg==');
+    'CgVNYXRjaBIZCghtYXRjaF9pZBgBIAEoCVIHbWF0Y2hJZBIkCg1hdXRob3JpdGF0aXZlGAIgAS'
+    'gIUg1hdXRob3JpdGF0aXZlEjIKBWxhYmVsGAMgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmlu'
+    'Z1ZhbHVlUgVsYWJlbBISCgRzaXplGAQgASgFUgRzaXplEjsKCXByZXNlbmNlcxgFIAMoCzIdLm'
+    '5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCXByZXNlbmNlcxIxCgRzZWxmGAYgASgLMh0u'
+    'bmFrYW1hLnJlYWx0aW1lLlVzZXJQcmVzZW5jZVIEc2VsZg==');
+
 @$core.Deprecated('Use matchCreateDescriptor instead')
-const MatchCreate$json = const {
+const MatchCreate$json = {
   '1': 'MatchCreate',
-  '2': const [
-    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
   ],
 };
 
 /// Descriptor for `MatchCreate`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchCreateDescriptor =
     $convert.base64Decode('CgtNYXRjaENyZWF0ZRISCgRuYW1lGAEgASgJUgRuYW1l');
+
 @$core.Deprecated('Use matchDataDescriptor instead')
-const MatchData$json = const {
+const MatchData$json = {
   '1': 'MatchData',
-  '2': const [
-    const {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
-    const {
+  '2': [
+    {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
+    {
       '1': 'presence',
       '3': 2,
       '4': 1,
@@ -771,23 +896,27 @@ const MatchData$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'presence'
     },
-    const {'1': 'op_code', '3': 3, '4': 1, '5': 3, '10': 'opCode'},
-    const {'1': 'data', '3': 4, '4': 1, '5': 12, '10': 'data'},
-    const {'1': 'reliable', '3': 5, '4': 1, '5': 8, '10': 'reliable'},
+    {'1': 'op_code', '3': 3, '4': 1, '5': 3, '10': 'opCode'},
+    {'1': 'data', '3': 4, '4': 1, '5': 12, '10': 'data'},
+    {'1': 'reliable', '3': 5, '4': 1, '5': 8, '10': 'reliable'},
   ],
 };
 
 /// Descriptor for `MatchData`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchDataDescriptor = $convert.base64Decode(
-    'CglNYXRjaERhdGESGQoIbWF0Y2hfaWQYASABKAlSB21hdGNoSWQSOQoIcHJlc2VuY2UYAiABKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUghwcmVzZW5jZRIXCgdvcF9jb2RlGAMgASgDUgZvcENvZGUSEgoEZGF0YRgEIAEoDFIEZGF0YRIaCghyZWxpYWJsZRgFIAEoCFIIcmVsaWFibGU=');
+    'CglNYXRjaERhdGESGQoIbWF0Y2hfaWQYASABKAlSB21hdGNoSWQSOQoIcHJlc2VuY2UYAiABKA'
+    'syHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUghwcmVzZW5jZRIXCgdvcF9jb2RlGAMg'
+    'ASgDUgZvcENvZGUSEgoEZGF0YRgEIAEoDFIEZGF0YRIaCghyZWxpYWJsZRgFIAEoCFIIcmVsaW'
+    'FibGU=');
+
 @$core.Deprecated('Use matchDataSendDescriptor instead')
-const MatchDataSend$json = const {
+const MatchDataSend$json = {
   '1': 'MatchDataSend',
-  '2': const [
-    const {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
-    const {'1': 'op_code', '3': 2, '4': 1, '5': 3, '10': 'opCode'},
-    const {'1': 'data', '3': 3, '4': 1, '5': 12, '10': 'data'},
-    const {
+  '2': [
+    {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
+    {'1': 'op_code', '3': 2, '4': 1, '5': 3, '10': 'opCode'},
+    {'1': 'data', '3': 3, '4': 1, '5': 12, '10': 'data'},
+    {
       '1': 'presences',
       '3': 4,
       '4': 3,
@@ -795,20 +924,24 @@ const MatchDataSend$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'presences'
     },
-    const {'1': 'reliable', '3': 5, '4': 1, '5': 8, '10': 'reliable'},
+    {'1': 'reliable', '3': 5, '4': 1, '5': 8, '10': 'reliable'},
   ],
 };
 
 /// Descriptor for `MatchDataSend`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchDataSendDescriptor = $convert.base64Decode(
-    'Cg1NYXRjaERhdGFTZW5kEhkKCG1hdGNoX2lkGAEgASgJUgdtYXRjaElkEhcKB29wX2NvZGUYAiABKANSBm9wQ29kZRISCgRkYXRhGAMgASgMUgRkYXRhEjsKCXByZXNlbmNlcxgEIAMoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCXByZXNlbmNlcxIaCghyZWxpYWJsZRgFIAEoCFIIcmVsaWFibGU=');
+    'Cg1NYXRjaERhdGFTZW5kEhkKCG1hdGNoX2lkGAEgASgJUgdtYXRjaElkEhcKB29wX2NvZGUYAi'
+    'ABKANSBm9wQ29kZRISCgRkYXRhGAMgASgMUgRkYXRhEjsKCXByZXNlbmNlcxgEIAMoCzIdLm5h'
+    'a2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCXByZXNlbmNlcxIaCghyZWxpYWJsZRgFIAEoCF'
+    'IIcmVsaWFibGU=');
+
 @$core.Deprecated('Use matchJoinDescriptor instead')
-const MatchJoin$json = const {
+const MatchJoin$json = {
   '1': 'MatchJoin',
-  '2': const [
-    const {'1': 'match_id', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'matchId'},
-    const {'1': 'token', '3': 2, '4': 1, '5': 9, '9': 0, '10': 'token'},
-    const {
+  '2': [
+    {'1': 'match_id', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'matchId'},
+    {'1': 'token', '3': 2, '4': 1, '5': 9, '9': 0, '10': 'token'},
+    {
       '1': 'metadata',
       '3': 3,
       '4': 3,
@@ -817,42 +950,47 @@ const MatchJoin$json = const {
       '10': 'metadata'
     },
   ],
-  '3': const [MatchJoin_MetadataEntry$json],
-  '8': const [
-    const {'1': 'id'},
+  '3': [MatchJoin_MetadataEntry$json],
+  '8': [
+    {'1': 'id'},
   ],
 };
 
 @$core.Deprecated('Use matchJoinDescriptor instead')
-const MatchJoin_MetadataEntry$json = const {
+const MatchJoin_MetadataEntry$json = {
   '1': 'MetadataEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `MatchJoin`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchJoinDescriptor = $convert.base64Decode(
-    'CglNYXRjaEpvaW4SGwoIbWF0Y2hfaWQYASABKAlIAFIHbWF0Y2hJZBIWCgV0b2tlbhgCIAEoCUgAUgV0b2tlbhJECghtZXRhZGF0YRgDIAMoCzIoLm5ha2FtYS5yZWFsdGltZS5NYXRjaEpvaW4uTWV0YWRhdGFFbnRyeVIIbWV0YWRhdGEaOwoNTWV0YWRhdGFFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgBQgQKAmlk');
+    'CglNYXRjaEpvaW4SGwoIbWF0Y2hfaWQYASABKAlIAFIHbWF0Y2hJZBIWCgV0b2tlbhgCIAEoCU'
+    'gAUgV0b2tlbhJECghtZXRhZGF0YRgDIAMoCzIoLm5ha2FtYS5yZWFsdGltZS5NYXRjaEpvaW4u'
+    'TWV0YWRhdGFFbnRyeVIIbWV0YWRhdGEaOwoNTWV0YWRhdGFFbnRyeRIQCgNrZXkYASABKAlSA2'
+    'tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgBQgQKAmlk');
+
 @$core.Deprecated('Use matchLeaveDescriptor instead')
-const MatchLeave$json = const {
+const MatchLeave$json = {
   '1': 'MatchLeave',
-  '2': const [
-    const {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
+  '2': [
+    {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
   ],
 };
 
 /// Descriptor for `MatchLeave`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchLeaveDescriptor = $convert
     .base64Decode('CgpNYXRjaExlYXZlEhkKCG1hdGNoX2lkGAEgASgJUgdtYXRjaElk');
+
 @$core.Deprecated('Use matchPresenceEventDescriptor instead')
-const MatchPresenceEvent$json = const {
+const MatchPresenceEvent$json = {
   '1': 'MatchPresenceEvent',
-  '2': const [
-    const {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
-    const {
+  '2': [
+    {'1': 'match_id', '3': 1, '4': 1, '5': 9, '10': 'matchId'},
+    {
       '1': 'joins',
       '3': 2,
       '4': 3,
@@ -860,7 +998,7 @@ const MatchPresenceEvent$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'joins'
     },
-    const {
+    {
       '1': 'leaves',
       '3': 3,
       '4': 3,
@@ -873,15 +1011,18 @@ const MatchPresenceEvent$json = const {
 
 /// Descriptor for `MatchPresenceEvent`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchPresenceEventDescriptor = $convert.base64Decode(
-    'ChJNYXRjaFByZXNlbmNlRXZlbnQSGQoIbWF0Y2hfaWQYASABKAlSB21hdGNoSWQSMwoFam9pbnMYAiADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgVqb2lucxI1CgZsZWF2ZXMYAyADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgZsZWF2ZXM=');
+    'ChJNYXRjaFByZXNlbmNlRXZlbnQSGQoIbWF0Y2hfaWQYASABKAlSB21hdGNoSWQSMwoFam9pbn'
+    'MYAiADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgVqb2lucxI1CgZsZWF2ZXMY'
+    'AyADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgZsZWF2ZXM=');
+
 @$core.Deprecated('Use matchmakerAddDescriptor instead')
-const MatchmakerAdd$json = const {
+const MatchmakerAdd$json = {
   '1': 'MatchmakerAdd',
-  '2': const [
-    const {'1': 'min_count', '3': 1, '4': 1, '5': 5, '10': 'minCount'},
-    const {'1': 'max_count', '3': 2, '4': 1, '5': 5, '10': 'maxCount'},
-    const {'1': 'query', '3': 3, '4': 1, '5': 9, '10': 'query'},
-    const {
+  '2': [
+    {'1': 'min_count', '3': 1, '4': 1, '5': 5, '10': 'minCount'},
+    {'1': 'max_count', '3': 2, '4': 1, '5': 5, '10': 'maxCount'},
+    {'1': 'query', '3': 3, '4': 1, '5': 9, '10': 'query'},
+    {
       '1': 'string_properties',
       '3': 4,
       '4': 3,
@@ -889,7 +1030,7 @@ const MatchmakerAdd$json = const {
       '6': '.nakama.realtime.MatchmakerAdd.StringPropertiesEntry',
       '10': 'stringProperties'
     },
-    const {
+    {
       '1': 'numeric_properties',
       '3': 5,
       '4': 3,
@@ -897,7 +1038,7 @@ const MatchmakerAdd$json = const {
       '6': '.nakama.realtime.MatchmakerAdd.NumericPropertiesEntry',
       '10': 'numericProperties'
     },
-    const {
+    {
       '1': 'count_multiple',
       '3': 6,
       '4': 1,
@@ -906,43 +1047,53 @@ const MatchmakerAdd$json = const {
       '10': 'countMultiple'
     },
   ],
-  '3': const [
+  '3': [
     MatchmakerAdd_StringPropertiesEntry$json,
     MatchmakerAdd_NumericPropertiesEntry$json
   ],
 };
 
 @$core.Deprecated('Use matchmakerAddDescriptor instead')
-const MatchmakerAdd_StringPropertiesEntry$json = const {
+const MatchmakerAdd_StringPropertiesEntry$json = {
   '1': 'StringPropertiesEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 @$core.Deprecated('Use matchmakerAddDescriptor instead')
-const MatchmakerAdd_NumericPropertiesEntry$json = const {
+const MatchmakerAdd_NumericPropertiesEntry$json = {
   '1': 'NumericPropertiesEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 1, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 1, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `MatchmakerAdd`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchmakerAddDescriptor = $convert.base64Decode(
-    'Cg1NYXRjaG1ha2VyQWRkEhsKCW1pbl9jb3VudBgBIAEoBVIIbWluQ291bnQSGwoJbWF4X2NvdW50GAIgASgFUghtYXhDb3VudBIUCgVxdWVyeRgDIAEoCVIFcXVlcnkSYQoRc3RyaW5nX3Byb3BlcnRpZXMYBCADKAsyNC5uYWthbWEucmVhbHRpbWUuTWF0Y2htYWtlckFkZC5TdHJpbmdQcm9wZXJ0aWVzRW50cnlSEHN0cmluZ1Byb3BlcnRpZXMSZAoSbnVtZXJpY19wcm9wZXJ0aWVzGAUgAygLMjUubmFrYW1hLnJlYWx0aW1lLk1hdGNobWFrZXJBZGQuTnVtZXJpY1Byb3BlcnRpZXNFbnRyeVIRbnVtZXJpY1Byb3BlcnRpZXMSQgoOY291bnRfbXVsdGlwbGUYBiABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVINY291bnRNdWx0aXBsZRpDChVTdHJpbmdQcm9wZXJ0aWVzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4ARpEChZOdW1lcmljUHJvcGVydGllc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgBUgV2YWx1ZToCOAE=');
+    'Cg1NYXRjaG1ha2VyQWRkEhsKCW1pbl9jb3VudBgBIAEoBVIIbWluQ291bnQSGwoJbWF4X2NvdW'
+    '50GAIgASgFUghtYXhDb3VudBIUCgVxdWVyeRgDIAEoCVIFcXVlcnkSYQoRc3RyaW5nX3Byb3Bl'
+    'cnRpZXMYBCADKAsyNC5uYWthbWEucmVhbHRpbWUuTWF0Y2htYWtlckFkZC5TdHJpbmdQcm9wZX'
+    'J0aWVzRW50cnlSEHN0cmluZ1Byb3BlcnRpZXMSZAoSbnVtZXJpY19wcm9wZXJ0aWVzGAUgAygL'
+    'MjUubmFrYW1hLnJlYWx0aW1lLk1hdGNobWFrZXJBZGQuTnVtZXJpY1Byb3BlcnRpZXNFbnRyeV'
+    'IRbnVtZXJpY1Byb3BlcnRpZXMSQgoOY291bnRfbXVsdGlwbGUYBiABKAsyGy5nb29nbGUucHJv'
+    'dG9idWYuSW50MzJWYWx1ZVINY291bnRNdWx0aXBsZRpDChVTdHJpbmdQcm9wZXJ0aWVzRW50cn'
+    'kSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4ARpEChZOdW1lcmlj'
+    'UHJvcGVydGllc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgBUgV2YWx1ZT'
+    'oCOAE=');
+
 @$core.Deprecated('Use matchmakerMatchedDescriptor instead')
-const MatchmakerMatched$json = const {
+const MatchmakerMatched$json = {
   '1': 'MatchmakerMatched',
-  '2': const [
-    const {'1': 'ticket', '3': 1, '4': 1, '5': 9, '10': 'ticket'},
-    const {'1': 'match_id', '3': 2, '4': 1, '5': 9, '9': 0, '10': 'matchId'},
-    const {'1': 'token', '3': 3, '4': 1, '5': 9, '9': 0, '10': 'token'},
-    const {
+  '2': [
+    {'1': 'ticket', '3': 1, '4': 1, '5': 9, '10': 'ticket'},
+    {'1': 'match_id', '3': 2, '4': 1, '5': 9, '9': 0, '10': 'matchId'},
+    {'1': 'token', '3': 3, '4': 1, '5': 9, '9': 0, '10': 'token'},
+    {
       '1': 'users',
       '3': 4,
       '4': 3,
@@ -950,7 +1101,7 @@ const MatchmakerMatched$json = const {
       '6': '.nakama.realtime.MatchmakerMatched.MatchmakerUser',
       '10': 'users'
     },
-    const {
+    {
       '1': 'self',
       '3': 5,
       '4': 1,
@@ -959,17 +1110,17 @@ const MatchmakerMatched$json = const {
       '10': 'self'
     },
   ],
-  '3': const [MatchmakerMatched_MatchmakerUser$json],
-  '8': const [
-    const {'1': 'id'},
+  '3': [MatchmakerMatched_MatchmakerUser$json],
+  '8': [
+    {'1': 'id'},
   ],
 };
 
 @$core.Deprecated('Use matchmakerMatchedDescriptor instead')
-const MatchmakerMatched_MatchmakerUser$json = const {
+const MatchmakerMatched_MatchmakerUser$json = {
   '1': 'MatchmakerUser',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'presence',
       '3': 1,
       '4': 1,
@@ -977,8 +1128,8 @@ const MatchmakerMatched_MatchmakerUser$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'presence'
     },
-    const {'1': 'party_id', '3': 2, '4': 1, '5': 9, '10': 'partyId'},
-    const {
+    {'1': 'party_id', '3': 2, '4': 1, '5': 9, '10': 'partyId'},
+    {
       '1': 'string_properties',
       '3': 5,
       '4': 3,
@@ -987,7 +1138,7 @@ const MatchmakerMatched_MatchmakerUser$json = const {
           '.nakama.realtime.MatchmakerMatched.MatchmakerUser.StringPropertiesEntry',
       '10': 'stringProperties'
     },
-    const {
+    {
       '1': 'numeric_properties',
       '3': 6,
       '4': 3,
@@ -997,62 +1148,78 @@ const MatchmakerMatched_MatchmakerUser$json = const {
       '10': 'numericProperties'
     },
   ],
-  '3': const [
+  '3': [
     MatchmakerMatched_MatchmakerUser_StringPropertiesEntry$json,
     MatchmakerMatched_MatchmakerUser_NumericPropertiesEntry$json
   ],
 };
 
 @$core.Deprecated('Use matchmakerMatchedDescriptor instead')
-const MatchmakerMatched_MatchmakerUser_StringPropertiesEntry$json = const {
+const MatchmakerMatched_MatchmakerUser_StringPropertiesEntry$json = {
   '1': 'StringPropertiesEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 @$core.Deprecated('Use matchmakerMatchedDescriptor instead')
-const MatchmakerMatched_MatchmakerUser_NumericPropertiesEntry$json = const {
+const MatchmakerMatched_MatchmakerUser_NumericPropertiesEntry$json = {
   '1': 'NumericPropertiesEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 1, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 1, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `MatchmakerMatched`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchmakerMatchedDescriptor = $convert.base64Decode(
-    'ChFNYXRjaG1ha2VyTWF0Y2hlZBIWCgZ0aWNrZXQYASABKAlSBnRpY2tldBIbCghtYXRjaF9pZBgCIAEoCUgAUgdtYXRjaElkEhYKBXRva2VuGAMgASgJSABSBXRva2VuEkcKBXVzZXJzGAQgAygLMjEubmFrYW1hLnJlYWx0aW1lLk1hdGNobWFrZXJNYXRjaGVkLk1hdGNobWFrZXJVc2VyUgV1c2VycxJFCgRzZWxmGAUgASgLMjEubmFrYW1hLnJlYWx0aW1lLk1hdGNobWFrZXJNYXRjaGVkLk1hdGNobWFrZXJVc2VyUgRzZWxmGuADCg5NYXRjaG1ha2VyVXNlchI5CghwcmVzZW5jZRgBIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCHByZXNlbmNlEhkKCHBhcnR5X2lkGAIgASgJUgdwYXJ0eUlkEnQKEXN0cmluZ19wcm9wZXJ0aWVzGAUgAygLMkcubmFrYW1hLnJlYWx0aW1lLk1hdGNobWFrZXJNYXRjaGVkLk1hdGNobWFrZXJVc2VyLlN0cmluZ1Byb3BlcnRpZXNFbnRyeVIQc3RyaW5nUHJvcGVydGllcxJ3ChJudW1lcmljX3Byb3BlcnRpZXMYBiADKAsySC5uYWthbWEucmVhbHRpbWUuTWF0Y2htYWtlck1hdGNoZWQuTWF0Y2htYWtlclVzZXIuTnVtZXJpY1Byb3BlcnRpZXNFbnRyeVIRbnVtZXJpY1Byb3BlcnRpZXMaQwoVU3RyaW5nUHJvcGVydGllc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAEaRAoWTnVtZXJpY1Byb3BlcnRpZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoAVIFdmFsdWU6AjgBQgQKAmlk');
+    'ChFNYXRjaG1ha2VyTWF0Y2hlZBIWCgZ0aWNrZXQYASABKAlSBnRpY2tldBIbCghtYXRjaF9pZB'
+    'gCIAEoCUgAUgdtYXRjaElkEhYKBXRva2VuGAMgASgJSABSBXRva2VuEkcKBXVzZXJzGAQgAygL'
+    'MjEubmFrYW1hLnJlYWx0aW1lLk1hdGNobWFrZXJNYXRjaGVkLk1hdGNobWFrZXJVc2VyUgV1c2'
+    'VycxJFCgRzZWxmGAUgASgLMjEubmFrYW1hLnJlYWx0aW1lLk1hdGNobWFrZXJNYXRjaGVkLk1h'
+    'dGNobWFrZXJVc2VyUgRzZWxmGuADCg5NYXRjaG1ha2VyVXNlchI5CghwcmVzZW5jZRgBIAEoCz'
+    'IdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCHByZXNlbmNlEhkKCHBhcnR5X2lkGAIg'
+    'ASgJUgdwYXJ0eUlkEnQKEXN0cmluZ19wcm9wZXJ0aWVzGAUgAygLMkcubmFrYW1hLnJlYWx0aW'
+    '1lLk1hdGNobWFrZXJNYXRjaGVkLk1hdGNobWFrZXJVc2VyLlN0cmluZ1Byb3BlcnRpZXNFbnRy'
+    'eVIQc3RyaW5nUHJvcGVydGllcxJ3ChJudW1lcmljX3Byb3BlcnRpZXMYBiADKAsySC5uYWthbW'
+    'EucmVhbHRpbWUuTWF0Y2htYWtlck1hdGNoZWQuTWF0Y2htYWtlclVzZXIuTnVtZXJpY1Byb3Bl'
+    'cnRpZXNFbnRyeVIRbnVtZXJpY1Byb3BlcnRpZXMaQwoVU3RyaW5nUHJvcGVydGllc0VudHJ5Eh'
+    'AKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAEaRAoWTnVtZXJpY1By'
+    'b3BlcnRpZXNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoAVIFdmFsdWU6Aj'
+    'gBQgQKAmlk');
+
 @$core.Deprecated('Use matchmakerRemoveDescriptor instead')
-const MatchmakerRemove$json = const {
+const MatchmakerRemove$json = {
   '1': 'MatchmakerRemove',
-  '2': const [
-    const {'1': 'ticket', '3': 1, '4': 1, '5': 9, '10': 'ticket'},
+  '2': [
+    {'1': 'ticket', '3': 1, '4': 1, '5': 9, '10': 'ticket'},
   ],
 };
 
 /// Descriptor for `MatchmakerRemove`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchmakerRemoveDescriptor = $convert
     .base64Decode('ChBNYXRjaG1ha2VyUmVtb3ZlEhYKBnRpY2tldBgBIAEoCVIGdGlja2V0');
+
 @$core.Deprecated('Use matchmakerTicketDescriptor instead')
-const MatchmakerTicket$json = const {
+const MatchmakerTicket$json = {
   '1': 'MatchmakerTicket',
-  '2': const [
-    const {'1': 'ticket', '3': 1, '4': 1, '5': 9, '10': 'ticket'},
+  '2': [
+    {'1': 'ticket', '3': 1, '4': 1, '5': 9, '10': 'ticket'},
   ],
 };
 
 /// Descriptor for `MatchmakerTicket`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List matchmakerTicketDescriptor = $convert
     .base64Decode('ChBNYXRjaG1ha2VyVGlja2V0EhYKBnRpY2tldBgBIAEoCVIGdGlja2V0');
+
 @$core.Deprecated('Use notificationsDescriptor instead')
-const Notifications$json = const {
+const Notifications$json = {
   '1': 'Notifications',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'notifications',
       '3': 1,
       '4': 3,
@@ -1065,84 +1232,116 @@ const Notifications$json = const {
 
 /// Descriptor for `Notifications`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List notificationsDescriptor = $convert.base64Decode(
-    'Cg1Ob3RpZmljYXRpb25zEj4KDW5vdGlmaWNhdGlvbnMYASADKAsyGC5uYWthbWEuYXBpLk5vdGlmaWNhdGlvblINbm90aWZpY2F0aW9ucw==');
+    'Cg1Ob3RpZmljYXRpb25zEj4KDW5vdGlmaWNhdGlvbnMYASADKAsyGC5uYWthbWEuYXBpLk5vdG'
+    'lmaWNhdGlvblINbm90aWZpY2F0aW9ucw==');
+
 @$core.Deprecated('Use partyDescriptor instead')
-const Party$json = const {
+const Party$json = {
   '1': 'Party',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {'1': 'open', '3': 2, '4': 1, '5': 8, '10': 'open'},
-    const {'1': 'max_size', '3': 3, '4': 1, '5': 5, '10': 'maxSize'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {'1': 'open', '3': 2, '4': 1, '5': 8, '10': 'open'},
+    {'1': 'hidden', '3': 3, '4': 1, '5': 8, '10': 'hidden'},
+    {'1': 'max_size', '3': 4, '4': 1, '5': 5, '10': 'maxSize'},
+    {
       '1': 'self',
-      '3': 4,
+      '3': 5,
       '4': 1,
       '5': 11,
       '6': '.nakama.realtime.UserPresence',
       '10': 'self'
     },
-    const {
+    {
       '1': 'leader',
-      '3': 5,
+      '3': 6,
       '4': 1,
       '5': 11,
       '6': '.nakama.realtime.UserPresence',
       '10': 'leader'
     },
-    const {
+    {
       '1': 'presences',
-      '3': 6,
+      '3': 7,
       '4': 3,
       '5': 11,
       '6': '.nakama.realtime.UserPresence',
       '10': 'presences'
     },
+    {'1': 'label', '3': 8, '4': 1, '5': 9, '10': 'label'},
   ],
 };
 
 /// Descriptor for `Party`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyDescriptor = $convert.base64Decode(
-    'CgVQYXJ0eRIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBISCgRvcGVuGAIgASgIUgRvcGVuEhkKCG1heF9zaXplGAMgASgFUgdtYXhTaXplEjEKBHNlbGYYBCABKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgRzZWxmEjUKBmxlYWRlchgFIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSBmxlYWRlchI7CglwcmVzZW5jZXMYBiADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUglwcmVzZW5jZXM=');
+    'CgVQYXJ0eRIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBISCgRvcGVuGAIgASgIUgRvcGVuEh'
+    'YKBmhpZGRlbhgDIAEoCFIGaGlkZGVuEhkKCG1heF9zaXplGAQgASgFUgdtYXhTaXplEjEKBHNl'
+    'bGYYBSABKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgRzZWxmEjUKBmxlYWRlch'
+    'gGIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSBmxlYWRlchI7CglwcmVzZW5j'
+    'ZXMYByADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUglwcmVzZW5jZXMSFAoFbG'
+    'FiZWwYCCABKAlSBWxhYmVs');
+
 @$core.Deprecated('Use partyCreateDescriptor instead')
-const PartyCreate$json = const {
+const PartyCreate$json = {
   '1': 'PartyCreate',
-  '2': const [
-    const {'1': 'open', '3': 1, '4': 1, '5': 8, '10': 'open'},
-    const {'1': 'max_size', '3': 2, '4': 1, '5': 5, '10': 'maxSize'},
+  '2': [
+    {'1': 'open', '3': 1, '4': 1, '5': 8, '10': 'open'},
+    {'1': 'max_size', '3': 2, '4': 1, '5': 5, '10': 'maxSize'},
+    {'1': 'label', '3': 3, '4': 1, '5': 9, '10': 'label'},
+    {'1': 'hidden', '3': 4, '4': 1, '5': 8, '10': 'hidden'},
   ],
 };
 
 /// Descriptor for `PartyCreate`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyCreateDescriptor = $convert.base64Decode(
-    'CgtQYXJ0eUNyZWF0ZRISCgRvcGVuGAEgASgIUgRvcGVuEhkKCG1heF9zaXplGAIgASgFUgdtYXhTaXpl');
+    'CgtQYXJ0eUNyZWF0ZRISCgRvcGVuGAEgASgIUgRvcGVuEhkKCG1heF9zaXplGAIgASgFUgdtYX'
+    'hTaXplEhQKBWxhYmVsGAMgASgJUgVsYWJlbBIWCgZoaWRkZW4YBCABKAhSBmhpZGRlbg==');
+
+@$core.Deprecated('Use partyUpdateDescriptor instead')
+const PartyUpdate$json = {
+  '1': 'PartyUpdate',
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {'1': 'label', '3': 2, '4': 1, '5': 9, '10': 'label'},
+    {'1': 'open', '3': 3, '4': 1, '5': 8, '10': 'open'},
+    {'1': 'hidden', '3': 4, '4': 1, '5': 8, '10': 'hidden'},
+  ],
+};
+
+/// Descriptor for `PartyUpdate`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List partyUpdateDescriptor = $convert.base64Decode(
+    'CgtQYXJ0eVVwZGF0ZRIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBIUCgVsYWJlbBgCIAEoCV'
+    'IFbGFiZWwSEgoEb3BlbhgDIAEoCFIEb3BlbhIWCgZoaWRkZW4YBCABKAhSBmhpZGRlbg==');
+
 @$core.Deprecated('Use partyJoinDescriptor instead')
-const PartyJoin$json = const {
+const PartyJoin$json = {
   '1': 'PartyJoin',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
   ],
 };
 
 /// Descriptor for `PartyJoin`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyJoinDescriptor = $convert
     .base64Decode('CglQYXJ0eUpvaW4SGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQ=');
+
 @$core.Deprecated('Use partyLeaveDescriptor instead')
-const PartyLeave$json = const {
+const PartyLeave$json = {
   '1': 'PartyLeave',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
   ],
 };
 
 /// Descriptor for `PartyLeave`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyLeaveDescriptor = $convert
     .base64Decode('CgpQYXJ0eUxlYXZlEhkKCHBhcnR5X2lkGAEgASgJUgdwYXJ0eUlk');
+
 @$core.Deprecated('Use partyPromoteDescriptor instead')
-const PartyPromote$json = const {
+const PartyPromote$json = {
   '1': 'PartyPromote',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {
       '1': 'presence',
       '3': 2,
       '4': 1,
@@ -1155,13 +1354,15 @@ const PartyPromote$json = const {
 
 /// Descriptor for `PartyPromote`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyPromoteDescriptor = $convert.base64Decode(
-    'CgxQYXJ0eVByb21vdGUSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSOQoIcHJlc2VuY2UYAiABKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUghwcmVzZW5jZQ==');
+    'CgxQYXJ0eVByb21vdGUSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSOQoIcHJlc2VuY2UYAi'
+    'ABKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUghwcmVzZW5jZQ==');
+
 @$core.Deprecated('Use partyLeaderDescriptor instead')
-const PartyLeader$json = const {
+const PartyLeader$json = {
   '1': 'PartyLeader',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {
       '1': 'presence',
       '3': 2,
       '4': 1,
@@ -1174,13 +1375,15 @@ const PartyLeader$json = const {
 
 /// Descriptor for `PartyLeader`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyLeaderDescriptor = $convert.base64Decode(
-    'CgtQYXJ0eUxlYWRlchIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBI5CghwcmVzZW5jZRgCIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCHByZXNlbmNl');
+    'CgtQYXJ0eUxlYWRlchIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBI5CghwcmVzZW5jZRgCIA'
+    'EoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCHByZXNlbmNl');
+
 @$core.Deprecated('Use partyAcceptDescriptor instead')
-const PartyAccept$json = const {
+const PartyAccept$json = {
   '1': 'PartyAccept',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {
       '1': 'presence',
       '3': 2,
       '4': 1,
@@ -1193,13 +1396,15 @@ const PartyAccept$json = const {
 
 /// Descriptor for `PartyAccept`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyAcceptDescriptor = $convert.base64Decode(
-    'CgtQYXJ0eUFjY2VwdBIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBI5CghwcmVzZW5jZRgCIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCHByZXNlbmNl');
+    'CgtQYXJ0eUFjY2VwdBIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBI5CghwcmVzZW5jZRgCIA'
+    'EoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCHByZXNlbmNl');
+
 @$core.Deprecated('Use partyRemoveDescriptor instead')
-const PartyRemove$json = const {
+const PartyRemove$json = {
   '1': 'PartyRemove',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {
       '1': 'presence',
       '3': 2,
       '4': 1,
@@ -1212,23 +1417,26 @@ const PartyRemove$json = const {
 
 /// Descriptor for `PartyRemove`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyRemoveDescriptor = $convert.base64Decode(
-    'CgtQYXJ0eVJlbW92ZRIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBI5CghwcmVzZW5jZRgCIAEoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCHByZXNlbmNl');
+    'CgtQYXJ0eVJlbW92ZRIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZBI5CghwcmVzZW5jZRgCIA'
+    'EoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCHByZXNlbmNl');
+
 @$core.Deprecated('Use partyCloseDescriptor instead')
-const PartyClose$json = const {
+const PartyClose$json = {
   '1': 'PartyClose',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
   ],
 };
 
 /// Descriptor for `PartyClose`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyCloseDescriptor = $convert
     .base64Decode('CgpQYXJ0eUNsb3NlEhkKCHBhcnR5X2lkGAEgASgJUgdwYXJ0eUlk');
+
 @$core.Deprecated('Use partyJoinRequestListDescriptor instead')
-const PartyJoinRequestList$json = const {
+const PartyJoinRequestList$json = {
   '1': 'PartyJoinRequestList',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
   ],
 };
 
@@ -1236,12 +1444,13 @@ const PartyJoinRequestList$json = const {
 final $typed_data.Uint8List partyJoinRequestListDescriptor =
     $convert.base64Decode(
         'ChRQYXJ0eUpvaW5SZXF1ZXN0TGlzdBIZCghwYXJ0eV9pZBgBIAEoCVIHcGFydHlJZA==');
+
 @$core.Deprecated('Use partyJoinRequestDescriptor instead')
-const PartyJoinRequest$json = const {
+const PartyJoinRequest$json = {
   '1': 'PartyJoinRequest',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {
       '1': 'presences',
       '3': 2,
       '4': 3,
@@ -1254,16 +1463,18 @@ const PartyJoinRequest$json = const {
 
 /// Descriptor for `PartyJoinRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyJoinRequestDescriptor = $convert.base64Decode(
-    'ChBQYXJ0eUpvaW5SZXF1ZXN0EhkKCHBhcnR5X2lkGAEgASgJUgdwYXJ0eUlkEjsKCXByZXNlbmNlcxgCIAMoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCXByZXNlbmNlcw==');
+    'ChBQYXJ0eUpvaW5SZXF1ZXN0EhkKCHBhcnR5X2lkGAEgASgJUgdwYXJ0eUlkEjsKCXByZXNlbm'
+    'NlcxgCIAMoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSCXByZXNlbmNlcw==');
+
 @$core.Deprecated('Use partyMatchmakerAddDescriptor instead')
-const PartyMatchmakerAdd$json = const {
+const PartyMatchmakerAdd$json = {
   '1': 'PartyMatchmakerAdd',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {'1': 'min_count', '3': 2, '4': 1, '5': 5, '10': 'minCount'},
-    const {'1': 'max_count', '3': 3, '4': 1, '5': 5, '10': 'maxCount'},
-    const {'1': 'query', '3': 4, '4': 1, '5': 9, '10': 'query'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {'1': 'min_count', '3': 2, '4': 1, '5': 5, '10': 'minCount'},
+    {'1': 'max_count', '3': 3, '4': 1, '5': 5, '10': 'maxCount'},
+    {'1': 'query', '3': 4, '4': 1, '5': 9, '10': 'query'},
+    {
       '1': 'string_properties',
       '3': 5,
       '4': 3,
@@ -1271,7 +1482,7 @@ const PartyMatchmakerAdd$json = const {
       '6': '.nakama.realtime.PartyMatchmakerAdd.StringPropertiesEntry',
       '10': 'stringProperties'
     },
-    const {
+    {
       '1': 'numeric_properties',
       '3': 6,
       '4': 3,
@@ -1279,7 +1490,7 @@ const PartyMatchmakerAdd$json = const {
       '6': '.nakama.realtime.PartyMatchmakerAdd.NumericPropertiesEntry',
       '10': 'numericProperties'
     },
-    const {
+    {
       '1': 'count_multiple',
       '3': 7,
       '4': 1,
@@ -1288,65 +1499,79 @@ const PartyMatchmakerAdd$json = const {
       '10': 'countMultiple'
     },
   ],
-  '3': const [
+  '3': [
     PartyMatchmakerAdd_StringPropertiesEntry$json,
     PartyMatchmakerAdd_NumericPropertiesEntry$json
   ],
 };
 
 @$core.Deprecated('Use partyMatchmakerAddDescriptor instead')
-const PartyMatchmakerAdd_StringPropertiesEntry$json = const {
+const PartyMatchmakerAdd_StringPropertiesEntry$json = {
   '1': 'StringPropertiesEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 @$core.Deprecated('Use partyMatchmakerAddDescriptor instead')
-const PartyMatchmakerAdd_NumericPropertiesEntry$json = const {
+const PartyMatchmakerAdd_NumericPropertiesEntry$json = {
   '1': 'NumericPropertiesEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 1, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 1, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `PartyMatchmakerAdd`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyMatchmakerAddDescriptor = $convert.base64Decode(
-    'ChJQYXJ0eU1hdGNobWFrZXJBZGQSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSGwoJbWluX2NvdW50GAIgASgFUghtaW5Db3VudBIbCgltYXhfY291bnQYAyABKAVSCG1heENvdW50EhQKBXF1ZXJ5GAQgASgJUgVxdWVyeRJmChFzdHJpbmdfcHJvcGVydGllcxgFIAMoCzI5Lm5ha2FtYS5yZWFsdGltZS5QYXJ0eU1hdGNobWFrZXJBZGQuU3RyaW5nUHJvcGVydGllc0VudHJ5UhBzdHJpbmdQcm9wZXJ0aWVzEmkKEm51bWVyaWNfcHJvcGVydGllcxgGIAMoCzI6Lm5ha2FtYS5yZWFsdGltZS5QYXJ0eU1hdGNobWFrZXJBZGQuTnVtZXJpY1Byb3BlcnRpZXNFbnRyeVIRbnVtZXJpY1Byb3BlcnRpZXMSQgoOY291bnRfbXVsdGlwbGUYByABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYWx1ZVINY291bnRNdWx0aXBsZRpDChVTdHJpbmdQcm9wZXJ0aWVzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4ARpEChZOdW1lcmljUHJvcGVydGllc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgBUgV2YWx1ZToCOAE=');
+    'ChJQYXJ0eU1hdGNobWFrZXJBZGQSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSGwoJbWluX2'
+    'NvdW50GAIgASgFUghtaW5Db3VudBIbCgltYXhfY291bnQYAyABKAVSCG1heENvdW50EhQKBXF1'
+    'ZXJ5GAQgASgJUgVxdWVyeRJmChFzdHJpbmdfcHJvcGVydGllcxgFIAMoCzI5Lm5ha2FtYS5yZW'
+    'FsdGltZS5QYXJ0eU1hdGNobWFrZXJBZGQuU3RyaW5nUHJvcGVydGllc0VudHJ5UhBzdHJpbmdQ'
+    'cm9wZXJ0aWVzEmkKEm51bWVyaWNfcHJvcGVydGllcxgGIAMoCzI6Lm5ha2FtYS5yZWFsdGltZS'
+    '5QYXJ0eU1hdGNobWFrZXJBZGQuTnVtZXJpY1Byb3BlcnRpZXNFbnRyeVIRbnVtZXJpY1Byb3Bl'
+    'cnRpZXMSQgoOY291bnRfbXVsdGlwbGUYByABKAsyGy5nb29nbGUucHJvdG9idWYuSW50MzJWYW'
+    'x1ZVINY291bnRNdWx0aXBsZRpDChVTdHJpbmdQcm9wZXJ0aWVzRW50cnkSEAoDa2V5GAEgASgJ'
+    'UgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4ARpEChZOdW1lcmljUHJvcGVydGllc0VudH'
+    'J5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgBUgV2YWx1ZToCOAE=');
+
 @$core.Deprecated('Use partyMatchmakerRemoveDescriptor instead')
-const PartyMatchmakerRemove$json = const {
+const PartyMatchmakerRemove$json = {
   '1': 'PartyMatchmakerRemove',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {'1': 'ticket', '3': 2, '4': 1, '5': 9, '10': 'ticket'},
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {'1': 'ticket', '3': 2, '4': 1, '5': 9, '10': 'ticket'},
   ],
 };
 
 /// Descriptor for `PartyMatchmakerRemove`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyMatchmakerRemoveDescriptor = $convert.base64Decode(
-    'ChVQYXJ0eU1hdGNobWFrZXJSZW1vdmUSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSFgoGdGlja2V0GAIgASgJUgZ0aWNrZXQ=');
+    'ChVQYXJ0eU1hdGNobWFrZXJSZW1vdmUSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSFgoGdG'
+    'lja2V0GAIgASgJUgZ0aWNrZXQ=');
+
 @$core.Deprecated('Use partyMatchmakerTicketDescriptor instead')
-const PartyMatchmakerTicket$json = const {
+const PartyMatchmakerTicket$json = {
   '1': 'PartyMatchmakerTicket',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {'1': 'ticket', '3': 2, '4': 1, '5': 9, '10': 'ticket'},
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {'1': 'ticket', '3': 2, '4': 1, '5': 9, '10': 'ticket'},
   ],
 };
 
 /// Descriptor for `PartyMatchmakerTicket`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyMatchmakerTicketDescriptor = $convert.base64Decode(
-    'ChVQYXJ0eU1hdGNobWFrZXJUaWNrZXQSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSFgoGdGlja2V0GAIgASgJUgZ0aWNrZXQ=');
+    'ChVQYXJ0eU1hdGNobWFrZXJUaWNrZXQSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSFgoGdG'
+    'lja2V0GAIgASgJUgZ0aWNrZXQ=');
+
 @$core.Deprecated('Use partyDataDescriptor instead')
-const PartyData$json = const {
+const PartyData$json = {
   '1': 'PartyData',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {
       '1': 'presence',
       '3': 2,
       '4': 1,
@@ -1354,33 +1579,38 @@ const PartyData$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'presence'
     },
-    const {'1': 'op_code', '3': 3, '4': 1, '5': 3, '10': 'opCode'},
-    const {'1': 'data', '3': 4, '4': 1, '5': 12, '10': 'data'},
+    {'1': 'op_code', '3': 3, '4': 1, '5': 3, '10': 'opCode'},
+    {'1': 'data', '3': 4, '4': 1, '5': 12, '10': 'data'},
   ],
 };
 
 /// Descriptor for `PartyData`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyDataDescriptor = $convert.base64Decode(
-    'CglQYXJ0eURhdGESGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSOQoIcHJlc2VuY2UYAiABKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUghwcmVzZW5jZRIXCgdvcF9jb2RlGAMgASgDUgZvcENvZGUSEgoEZGF0YRgEIAEoDFIEZGF0YQ==');
+    'CglQYXJ0eURhdGESGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSOQoIcHJlc2VuY2UYAiABKA'
+    'syHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUghwcmVzZW5jZRIXCgdvcF9jb2RlGAMg'
+    'ASgDUgZvcENvZGUSEgoEZGF0YRgEIAEoDFIEZGF0YQ==');
+
 @$core.Deprecated('Use partyDataSendDescriptor instead')
-const PartyDataSend$json = const {
+const PartyDataSend$json = {
   '1': 'PartyDataSend',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {'1': 'op_code', '3': 2, '4': 1, '5': 3, '10': 'opCode'},
-    const {'1': 'data', '3': 3, '4': 1, '5': 12, '10': 'data'},
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {'1': 'op_code', '3': 2, '4': 1, '5': 3, '10': 'opCode'},
+    {'1': 'data', '3': 3, '4': 1, '5': 12, '10': 'data'},
   ],
 };
 
 /// Descriptor for `PartyDataSend`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyDataSendDescriptor = $convert.base64Decode(
-    'Cg1QYXJ0eURhdGFTZW5kEhkKCHBhcnR5X2lkGAEgASgJUgdwYXJ0eUlkEhcKB29wX2NvZGUYAiABKANSBm9wQ29kZRISCgRkYXRhGAMgASgMUgRkYXRh');
+    'Cg1QYXJ0eURhdGFTZW5kEhkKCHBhcnR5X2lkGAEgASgJUgdwYXJ0eUlkEhcKB29wX2NvZGUYAi'
+    'ABKANSBm9wQ29kZRISCgRkYXRhGAMgASgMUgRkYXRh');
+
 @$core.Deprecated('Use partyPresenceEventDescriptor instead')
-const PartyPresenceEvent$json = const {
+const PartyPresenceEvent$json = {
   '1': 'PartyPresenceEvent',
-  '2': const [
-    const {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
-    const {
+  '2': [
+    {'1': 'party_id', '3': 1, '4': 1, '5': 9, '10': 'partyId'},
+    {
       '1': 'joins',
       '3': 2,
       '4': 3,
@@ -1388,7 +1618,7 @@ const PartyPresenceEvent$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'joins'
     },
-    const {
+    {
       '1': 'leaves',
       '3': 3,
       '4': 3,
@@ -1401,26 +1631,31 @@ const PartyPresenceEvent$json = const {
 
 /// Descriptor for `PartyPresenceEvent`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List partyPresenceEventDescriptor = $convert.base64Decode(
-    'ChJQYXJ0eVByZXNlbmNlRXZlbnQSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSMwoFam9pbnMYAiADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgVqb2lucxI1CgZsZWF2ZXMYAyADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgZsZWF2ZXM=');
+    'ChJQYXJ0eVByZXNlbmNlRXZlbnQSGQoIcGFydHlfaWQYASABKAlSB3BhcnR5SWQSMwoFam9pbn'
+    'MYAiADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgVqb2lucxI1CgZsZWF2ZXMY'
+    'AyADKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgZsZWF2ZXM=');
+
 @$core.Deprecated('Use pingDescriptor instead')
-const Ping$json = const {
+const Ping$json = {
   '1': 'Ping',
 };
 
 /// Descriptor for `Ping`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List pingDescriptor = $convert.base64Decode('CgRQaW5n');
+
 @$core.Deprecated('Use pongDescriptor instead')
-const Pong$json = const {
+const Pong$json = {
   '1': 'Pong',
 };
 
 /// Descriptor for `Pong`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List pongDescriptor = $convert.base64Decode('CgRQb25n');
+
 @$core.Deprecated('Use statusDescriptor instead')
-const Status$json = const {
+const Status$json = {
   '1': 'Status',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'presences',
       '3': 1,
       '4': 3,
@@ -1433,24 +1668,28 @@ const Status$json = const {
 
 /// Descriptor for `Status`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List statusDescriptor = $convert.base64Decode(
-    'CgZTdGF0dXMSOwoJcHJlc2VuY2VzGAEgAygLMh0ubmFrYW1hLnJlYWx0aW1lLlVzZXJQcmVzZW5jZVIJcHJlc2VuY2Vz');
+    'CgZTdGF0dXMSOwoJcHJlc2VuY2VzGAEgAygLMh0ubmFrYW1hLnJlYWx0aW1lLlVzZXJQcmVzZW'
+    '5jZVIJcHJlc2VuY2Vz');
+
 @$core.Deprecated('Use statusFollowDescriptor instead')
-const StatusFollow$json = const {
+const StatusFollow$json = {
   '1': 'StatusFollow',
-  '2': const [
-    const {'1': 'user_ids', '3': 1, '4': 3, '5': 9, '10': 'userIds'},
-    const {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
+  '2': [
+    {'1': 'user_ids', '3': 1, '4': 3, '5': 9, '10': 'userIds'},
+    {'1': 'usernames', '3': 2, '4': 3, '5': 9, '10': 'usernames'},
   ],
 };
 
 /// Descriptor for `StatusFollow`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List statusFollowDescriptor = $convert.base64Decode(
-    'CgxTdGF0dXNGb2xsb3cSGQoIdXNlcl9pZHMYASADKAlSB3VzZXJJZHMSHAoJdXNlcm5hbWVzGAIgAygJUgl1c2VybmFtZXM=');
+    'CgxTdGF0dXNGb2xsb3cSGQoIdXNlcl9pZHMYASADKAlSB3VzZXJJZHMSHAoJdXNlcm5hbWVzGA'
+    'IgAygJUgl1c2VybmFtZXM=');
+
 @$core.Deprecated('Use statusPresenceEventDescriptor instead')
-const StatusPresenceEvent$json = const {
+const StatusPresenceEvent$json = {
   '1': 'StatusPresenceEvent',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'joins',
       '3': 2,
       '4': 3,
@@ -1458,7 +1697,7 @@ const StatusPresenceEvent$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'joins'
     },
-    const {
+    {
       '1': 'leaves',
       '3': 3,
       '4': 3,
@@ -1471,23 +1710,27 @@ const StatusPresenceEvent$json = const {
 
 /// Descriptor for `StatusPresenceEvent`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List statusPresenceEventDescriptor = $convert.base64Decode(
-    'ChNTdGF0dXNQcmVzZW5jZUV2ZW50EjMKBWpvaW5zGAIgAygLMh0ubmFrYW1hLnJlYWx0aW1lLlVzZXJQcmVzZW5jZVIFam9pbnMSNQoGbGVhdmVzGAMgAygLMh0ubmFrYW1hLnJlYWx0aW1lLlVzZXJQcmVzZW5jZVIGbGVhdmVz');
+    'ChNTdGF0dXNQcmVzZW5jZUV2ZW50EjMKBWpvaW5zGAIgAygLMh0ubmFrYW1hLnJlYWx0aW1lLl'
+    'VzZXJQcmVzZW5jZVIFam9pbnMSNQoGbGVhdmVzGAMgAygLMh0ubmFrYW1hLnJlYWx0aW1lLlVz'
+    'ZXJQcmVzZW5jZVIGbGVhdmVz');
+
 @$core.Deprecated('Use statusUnfollowDescriptor instead')
-const StatusUnfollow$json = const {
+const StatusUnfollow$json = {
   '1': 'StatusUnfollow',
-  '2': const [
-    const {'1': 'user_ids', '3': 1, '4': 3, '5': 9, '10': 'userIds'},
+  '2': [
+    {'1': 'user_ids', '3': 1, '4': 3, '5': 9, '10': 'userIds'},
   ],
 };
 
 /// Descriptor for `StatusUnfollow`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List statusUnfollowDescriptor = $convert.base64Decode(
     'Cg5TdGF0dXNVbmZvbGxvdxIZCgh1c2VyX2lkcxgBIAMoCVIHdXNlcklkcw==');
+
 @$core.Deprecated('Use statusUpdateDescriptor instead')
-const StatusUpdate$json = const {
+const StatusUpdate$json = {
   '1': 'StatusUpdate',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'status',
       '3': 1,
       '4': 1,
@@ -1500,26 +1743,30 @@ const StatusUpdate$json = const {
 
 /// Descriptor for `StatusUpdate`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List statusUpdateDescriptor = $convert.base64Decode(
-    'CgxTdGF0dXNVcGRhdGUSNAoGc3RhdHVzGAEgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1ZhbHVlUgZzdGF0dXM=');
+    'CgxTdGF0dXNVcGRhdGUSNAoGc3RhdHVzGAEgASgLMhwuZ29vZ2xlLnByb3RvYnVmLlN0cmluZ1'
+    'ZhbHVlUgZzdGF0dXM=');
+
 @$core.Deprecated('Use streamDescriptor instead')
-const Stream$json = const {
+const Stream$json = {
   '1': 'Stream',
-  '2': const [
-    const {'1': 'mode', '3': 1, '4': 1, '5': 5, '10': 'mode'},
-    const {'1': 'subject', '3': 2, '4': 1, '5': 9, '10': 'subject'},
-    const {'1': 'subcontext', '3': 3, '4': 1, '5': 9, '10': 'subcontext'},
-    const {'1': 'label', '3': 4, '4': 1, '5': 9, '10': 'label'},
+  '2': [
+    {'1': 'mode', '3': 1, '4': 1, '5': 5, '10': 'mode'},
+    {'1': 'subject', '3': 2, '4': 1, '5': 9, '10': 'subject'},
+    {'1': 'subcontext', '3': 3, '4': 1, '5': 9, '10': 'subcontext'},
+    {'1': 'label', '3': 4, '4': 1, '5': 9, '10': 'label'},
   ],
 };
 
 /// Descriptor for `Stream`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List streamDescriptor = $convert.base64Decode(
-    'CgZTdHJlYW0SEgoEbW9kZRgBIAEoBVIEbW9kZRIYCgdzdWJqZWN0GAIgASgJUgdzdWJqZWN0Eh4KCnN1YmNvbnRleHQYAyABKAlSCnN1YmNvbnRleHQSFAoFbGFiZWwYBCABKAlSBWxhYmVs');
+    'CgZTdHJlYW0SEgoEbW9kZRgBIAEoBVIEbW9kZRIYCgdzdWJqZWN0GAIgASgJUgdzdWJqZWN0Eh'
+    '4KCnN1YmNvbnRleHQYAyABKAlSCnN1YmNvbnRleHQSFAoFbGFiZWwYBCABKAlSBWxhYmVs');
+
 @$core.Deprecated('Use streamDataDescriptor instead')
-const StreamData$json = const {
+const StreamData$json = {
   '1': 'StreamData',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'stream',
       '3': 1,
       '4': 1,
@@ -1527,7 +1774,7 @@ const StreamData$json = const {
       '6': '.nakama.realtime.Stream',
       '10': 'stream'
     },
-    const {
+    {
       '1': 'sender',
       '3': 2,
       '4': 1,
@@ -1535,19 +1782,22 @@ const StreamData$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'sender'
     },
-    const {'1': 'data', '3': 3, '4': 1, '5': 9, '10': 'data'},
-    const {'1': 'reliable', '3': 4, '4': 1, '5': 8, '10': 'reliable'},
+    {'1': 'data', '3': 3, '4': 1, '5': 9, '10': 'data'},
+    {'1': 'reliable', '3': 4, '4': 1, '5': 8, '10': 'reliable'},
   ],
 };
 
 /// Descriptor for `StreamData`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List streamDataDescriptor = $convert.base64Decode(
-    'CgpTdHJlYW1EYXRhEi8KBnN0cmVhbRgBIAEoCzIXLm5ha2FtYS5yZWFsdGltZS5TdHJlYW1SBnN0cmVhbRI1CgZzZW5kZXIYAiABKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgZzZW5kZXISEgoEZGF0YRgDIAEoCVIEZGF0YRIaCghyZWxpYWJsZRgEIAEoCFIIcmVsaWFibGU=');
+    'CgpTdHJlYW1EYXRhEi8KBnN0cmVhbRgBIAEoCzIXLm5ha2FtYS5yZWFsdGltZS5TdHJlYW1SBn'
+    'N0cmVhbRI1CgZzZW5kZXIYAiABKAsyHS5uYWthbWEucmVhbHRpbWUuVXNlclByZXNlbmNlUgZz'
+    'ZW5kZXISEgoEZGF0YRgDIAEoCVIEZGF0YRIaCghyZWxpYWJsZRgEIAEoCFIIcmVsaWFibGU=');
+
 @$core.Deprecated('Use streamPresenceEventDescriptor instead')
-const StreamPresenceEvent$json = const {
+const StreamPresenceEvent$json = {
   '1': 'StreamPresenceEvent',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'stream',
       '3': 1,
       '4': 1,
@@ -1555,7 +1805,7 @@ const StreamPresenceEvent$json = const {
       '6': '.nakama.realtime.Stream',
       '10': 'stream'
     },
-    const {
+    {
       '1': 'joins',
       '3': 2,
       '4': 3,
@@ -1563,7 +1813,7 @@ const StreamPresenceEvent$json = const {
       '6': '.nakama.realtime.UserPresence',
       '10': 'joins'
     },
-    const {
+    {
       '1': 'leaves',
       '3': 3,
       '4': 3,
@@ -1576,16 +1826,20 @@ const StreamPresenceEvent$json = const {
 
 /// Descriptor for `StreamPresenceEvent`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List streamPresenceEventDescriptor = $convert.base64Decode(
-    'ChNTdHJlYW1QcmVzZW5jZUV2ZW50Ei8KBnN0cmVhbRgBIAEoCzIXLm5ha2FtYS5yZWFsdGltZS5TdHJlYW1SBnN0cmVhbRIzCgVqb2lucxgCIAMoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSBWpvaW5zEjUKBmxlYXZlcxgDIAMoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2VuY2VSBmxlYXZlcw==');
+    'ChNTdHJlYW1QcmVzZW5jZUV2ZW50Ei8KBnN0cmVhbRgBIAEoCzIXLm5ha2FtYS5yZWFsdGltZS'
+    '5TdHJlYW1SBnN0cmVhbRIzCgVqb2lucxgCIAMoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJl'
+    'c2VuY2VSBWpvaW5zEjUKBmxlYXZlcxgDIAMoCzIdLm5ha2FtYS5yZWFsdGltZS5Vc2VyUHJlc2'
+    'VuY2VSBmxlYXZlcw==');
+
 @$core.Deprecated('Use userPresenceDescriptor instead')
-const UserPresence$json = const {
+const UserPresence$json = {
   '1': 'UserPresence',
-  '2': const [
-    const {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
-    const {'1': 'session_id', '3': 2, '4': 1, '5': 9, '10': 'sessionId'},
-    const {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
-    const {'1': 'persistence', '3': 4, '4': 1, '5': 8, '10': 'persistence'},
-    const {
+  '2': [
+    {'1': 'user_id', '3': 1, '4': 1, '5': 9, '10': 'userId'},
+    {'1': 'session_id', '3': 2, '4': 1, '5': 9, '10': 'sessionId'},
+    {'1': 'username', '3': 3, '4': 1, '5': 9, '10': 'username'},
+    {'1': 'persistence', '3': 4, '4': 1, '5': 8, '10': 'persistence'},
+    {
       '1': 'status',
       '3': 5,
       '4': 1,
@@ -1598,4 +1852,7 @@ const UserPresence$json = const {
 
 /// Descriptor for `UserPresence`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List userPresenceDescriptor = $convert.base64Decode(
-    'CgxVc2VyUHJlc2VuY2USFwoHdXNlcl9pZBgBIAEoCVIGdXNlcklkEh0KCnNlc3Npb25faWQYAiABKAlSCXNlc3Npb25JZBIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWUSIAoLcGVyc2lzdGVuY2UYBCABKAhSC3BlcnNpc3RlbmNlEjQKBnN0YXR1cxgFIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi5TdHJpbmdWYWx1ZVIGc3RhdHVz');
+    'CgxVc2VyUHJlc2VuY2USFwoHdXNlcl9pZBgBIAEoCVIGdXNlcklkEh0KCnNlc3Npb25faWQYAi'
+    'ABKAlSCXNlc3Npb25JZBIaCgh1c2VybmFtZRgDIAEoCVIIdXNlcm5hbWUSIAoLcGVyc2lzdGVu'
+    'Y2UYBCABKAhSC3BlcnNpc3RlbmNlEjQKBnN0YXR1cxgFIAEoCzIcLmdvb2dsZS5wcm90b2J1Zi'
+    '5TdHJpbmdWYWx1ZVIGc3RhdHVz');

--- a/nakama/lib/src/api/rtapi.dart
+++ b/nakama/lib/src/api/rtapi.dart
@@ -1,5 +1,3 @@
-library api;
-
 // In64 used in protobuf
 export 'package:fixnum/fixnum.dart' show Int64;
 

--- a/nakama/lib/src/models/account.dart
+++ b/nakama/lib/src/models/account.dart
@@ -5,7 +5,7 @@ part 'account.freezed.dart';
 part 'account.g.dart';
 
 @freezed
-class Account with _$Account {
+sealed class Account with _$Account {
   const Account._();
 
   const factory Account({
@@ -32,7 +32,7 @@ class Account with _$Account {
 }
 
 @freezed
-class Device with _$Device {
+sealed class Device with _$Device {
   const Device._();
 
   const factory Device({
@@ -49,7 +49,7 @@ class Device with _$Device {
 }
 
 @freezed
-class User with _$User {
+sealed class User with _$User {
   const User._();
 
   const factory User({

--- a/nakama/lib/src/models/account.freezed.dart
+++ b/nakama/lib/src/models/account.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,1041 +9,883 @@ part of 'account.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-Account _$AccountFromJson(Map<String, dynamic> json) {
-  return _Account.fromJson(json);
-}
 
 /// @nodoc
 mixin _$Account {
-  @JsonKey(name: 'wallet')
-  String? get wallet => throw _privateConstructorUsedError;
-  @JsonKey(name: 'email')
-  String? get email => throw _privateConstructorUsedError;
-  @JsonKey(name: 'devices')
-  List<Device>? get devices => throw _privateConstructorUsedError;
-  @JsonKey(name: 'custom_id')
-  String? get customId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'verify_time')
-  DateTime? get verifyTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'disable_time')
-  DateTime? get disableTime => throw _privateConstructorUsedError;
-  User get user => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $AccountCopyWith<Account> get copyWith => throw _privateConstructorUsedError;
+@JsonKey(name: 'wallet') String? get wallet;@JsonKey(name: 'email') String? get email;@JsonKey(name: 'devices') List<Device>? get devices;@JsonKey(name: 'custom_id') String? get customId;@JsonKey(name: 'verify_time') DateTime? get verifyTime;@JsonKey(name: 'disable_time') DateTime? get disableTime; User get user;
+/// Create a copy of Account
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AccountCopyWith<Account> get copyWith => _$AccountCopyWithImpl<Account>(this as Account, _$identity);
+
+  /// Serializes this Account to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Account&&(identical(other.wallet, wallet) || other.wallet == wallet)&&(identical(other.email, email) || other.email == email)&&const DeepCollectionEquality().equals(other.devices, devices)&&(identical(other.customId, customId) || other.customId == customId)&&(identical(other.verifyTime, verifyTime) || other.verifyTime == verifyTime)&&(identical(other.disableTime, disableTime) || other.disableTime == disableTime)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,wallet,email,const DeepCollectionEquality().hash(devices),customId,verifyTime,disableTime,user);
+
+@override
+String toString() {
+  return 'Account(wallet: $wallet, email: $email, devices: $devices, customId: $customId, verifyTime: $verifyTime, disableTime: $disableTime, user: $user)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $AccountCopyWith<$Res> {
-  factory $AccountCopyWith(Account value, $Res Function(Account) then) =
-      _$AccountCopyWithImpl<$Res, Account>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'wallet') String? wallet,
-      @JsonKey(name: 'email') String? email,
-      @JsonKey(name: 'devices') List<Device>? devices,
-      @JsonKey(name: 'custom_id') String? customId,
-      @JsonKey(name: 'verify_time') DateTime? verifyTime,
-      @JsonKey(name: 'disable_time') DateTime? disableTime,
-      User user});
+abstract mixin class $AccountCopyWith<$Res>  {
+  factory $AccountCopyWith(Account value, $Res Function(Account) _then) = _$AccountCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'wallet') String? wallet,@JsonKey(name: 'email') String? email,@JsonKey(name: 'devices') List<Device>? devices,@JsonKey(name: 'custom_id') String? customId,@JsonKey(name: 'verify_time') DateTime? verifyTime,@JsonKey(name: 'disable_time') DateTime? disableTime, User user
+});
 
-  $UserCopyWith<$Res> get user;
+
+$UserCopyWith<$Res> get user;
+
 }
-
 /// @nodoc
-class _$AccountCopyWithImpl<$Res, $Val extends Account>
+class _$AccountCopyWithImpl<$Res>
     implements $AccountCopyWith<$Res> {
-  _$AccountCopyWithImpl(this._value, this._then);
+  _$AccountCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Account _self;
+  final $Res Function(Account) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? wallet = freezed,
-    Object? email = freezed,
-    Object? devices = freezed,
-    Object? customId = freezed,
-    Object? verifyTime = freezed,
-    Object? disableTime = freezed,
-    Object? user = null,
-  }) {
-    return _then(_value.copyWith(
-      wallet: freezed == wallet
-          ? _value.wallet
-          : wallet // ignore: cast_nullable_to_non_nullable
-              as String?,
-      email: freezed == email
-          ? _value.email
-          : email // ignore: cast_nullable_to_non_nullable
-              as String?,
-      devices: freezed == devices
-          ? _value.devices
-          : devices // ignore: cast_nullable_to_non_nullable
-              as List<Device>?,
-      customId: freezed == customId
-          ? _value.customId
-          : customId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      verifyTime: freezed == verifyTime
-          ? _value.verifyTime
-          : verifyTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      disableTime: freezed == disableTime
-          ? _value.disableTime
-          : disableTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      user: null == user
-          ? _value.user
-          : user // ignore: cast_nullable_to_non_nullable
-              as User,
-    ) as $Val);
-  }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $UserCopyWith<$Res> get user {
-    return $UserCopyWith<$Res>(_value.user, (value) {
-      return _then(_value.copyWith(user: value) as $Val);
-    });
-  }
+/// Create a copy of Account
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? wallet = freezed,Object? email = freezed,Object? devices = freezed,Object? customId = freezed,Object? verifyTime = freezed,Object? disableTime = freezed,Object? user = null,}) {
+  return _then(_self.copyWith(
+wallet: freezed == wallet ? _self.wallet : wallet // ignore: cast_nullable_to_non_nullable
+as String?,email: freezed == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String?,devices: freezed == devices ? _self.devices : devices // ignore: cast_nullable_to_non_nullable
+as List<Device>?,customId: freezed == customId ? _self.customId : customId // ignore: cast_nullable_to_non_nullable
+as String?,verifyTime: freezed == verifyTime ? _self.verifyTime : verifyTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,disableTime: freezed == disableTime ? _self.disableTime : disableTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+/// Create a copy of Account
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$AccountImplCopyWith<$Res> implements $AccountCopyWith<$Res> {
-  factory _$$AccountImplCopyWith(
-          _$AccountImpl value, $Res Function(_$AccountImpl) then) =
-      __$$AccountImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'wallet') String? wallet,
-      @JsonKey(name: 'email') String? email,
-      @JsonKey(name: 'devices') List<Device>? devices,
-      @JsonKey(name: 'custom_id') String? customId,
-      @JsonKey(name: 'verify_time') DateTime? verifyTime,
-      @JsonKey(name: 'disable_time') DateTime? disableTime,
-      User user});
 
-  @override
-  $UserCopyWith<$Res> get user;
+/// Adds pattern-matching-related methods to [Account].
+extension AccountPatterns on Account {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Account value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Account() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Account value)  $default,){
+final _that = this;
+switch (_that) {
+case _Account():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Account value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Account() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'wallet')  String? wallet, @JsonKey(name: 'email')  String? email, @JsonKey(name: 'devices')  List<Device>? devices, @JsonKey(name: 'custom_id')  String? customId, @JsonKey(name: 'verify_time')  DateTime? verifyTime, @JsonKey(name: 'disable_time')  DateTime? disableTime,  User user)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Account() when $default != null:
+return $default(_that.wallet,_that.email,_that.devices,_that.customId,_that.verifyTime,_that.disableTime,_that.user);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'wallet')  String? wallet, @JsonKey(name: 'email')  String? email, @JsonKey(name: 'devices')  List<Device>? devices, @JsonKey(name: 'custom_id')  String? customId, @JsonKey(name: 'verify_time')  DateTime? verifyTime, @JsonKey(name: 'disable_time')  DateTime? disableTime,  User user)  $default,) {final _that = this;
+switch (_that) {
+case _Account():
+return $default(_that.wallet,_that.email,_that.devices,_that.customId,_that.verifyTime,_that.disableTime,_that.user);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'wallet')  String? wallet, @JsonKey(name: 'email')  String? email, @JsonKey(name: 'devices')  List<Device>? devices, @JsonKey(name: 'custom_id')  String? customId, @JsonKey(name: 'verify_time')  DateTime? verifyTime, @JsonKey(name: 'disable_time')  DateTime? disableTime,  User user)?  $default,) {final _that = this;
+switch (_that) {
+case _Account() when $default != null:
+return $default(_that.wallet,_that.email,_that.devices,_that.customId,_that.verifyTime,_that.disableTime,_that.user);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$AccountImplCopyWithImpl<$Res>
-    extends _$AccountCopyWithImpl<$Res, _$AccountImpl>
-    implements _$$AccountImplCopyWith<$Res> {
-  __$$AccountImplCopyWithImpl(
-      _$AccountImpl _value, $Res Function(_$AccountImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? wallet = freezed,
-    Object? email = freezed,
-    Object? devices = freezed,
-    Object? customId = freezed,
-    Object? verifyTime = freezed,
-    Object? disableTime = freezed,
-    Object? user = null,
-  }) {
-    return _then(_$AccountImpl(
-      wallet: freezed == wallet
-          ? _value.wallet
-          : wallet // ignore: cast_nullable_to_non_nullable
-              as String?,
-      email: freezed == email
-          ? _value.email
-          : email // ignore: cast_nullable_to_non_nullable
-              as String?,
-      devices: freezed == devices
-          ? _value._devices
-          : devices // ignore: cast_nullable_to_non_nullable
-              as List<Device>?,
-      customId: freezed == customId
-          ? _value.customId
-          : customId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      verifyTime: freezed == verifyTime
-          ? _value.verifyTime
-          : verifyTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      disableTime: freezed == disableTime
-          ? _value.disableTime
-          : disableTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      user: null == user
-          ? _value.user
-          : user // ignore: cast_nullable_to_non_nullable
-              as User,
-    ));
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$AccountImpl extends _Account {
-  const _$AccountImpl(
-      {@JsonKey(name: 'wallet') this.wallet,
-      @JsonKey(name: 'email') this.email,
-      @JsonKey(name: 'devices') final List<Device>? devices,
-      @JsonKey(name: 'custom_id') this.customId,
-      @JsonKey(name: 'verify_time') this.verifyTime,
-      @JsonKey(name: 'disable_time') this.disableTime,
-      required this.user})
-      : _devices = devices,
-        super._();
 
-  factory _$AccountImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AccountImplFromJson(json);
+class _Account extends Account {
+  const _Account({@JsonKey(name: 'wallet') this.wallet, @JsonKey(name: 'email') this.email, @JsonKey(name: 'devices') final  List<Device>? devices, @JsonKey(name: 'custom_id') this.customId, @JsonKey(name: 'verify_time') this.verifyTime, @JsonKey(name: 'disable_time') this.disableTime, required this.user}): _devices = devices,super._();
+  factory _Account.fromJson(Map<String, dynamic> json) => _$AccountFromJson(json);
 
-  @override
-  @JsonKey(name: 'wallet')
-  final String? wallet;
-  @override
-  @JsonKey(name: 'email')
-  final String? email;
-  final List<Device>? _devices;
-  @override
-  @JsonKey(name: 'devices')
-  List<Device>? get devices {
-    final value = _devices;
-    if (value == null) return null;
-    if (_devices is EqualUnmodifiableListView) return _devices;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  @JsonKey(name: 'custom_id')
-  final String? customId;
-  @override
-  @JsonKey(name: 'verify_time')
-  final DateTime? verifyTime;
-  @override
-  @JsonKey(name: 'disable_time')
-  final DateTime? disableTime;
-  @override
-  final User user;
-
-  @override
-  String toString() {
-    return 'Account(wallet: $wallet, email: $email, devices: $devices, customId: $customId, verifyTime: $verifyTime, disableTime: $disableTime, user: $user)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$AccountImpl &&
-            (identical(other.wallet, wallet) || other.wallet == wallet) &&
-            (identical(other.email, email) || other.email == email) &&
-            const DeepCollectionEquality().equals(other._devices, _devices) &&
-            (identical(other.customId, customId) ||
-                other.customId == customId) &&
-            (identical(other.verifyTime, verifyTime) ||
-                other.verifyTime == verifyTime) &&
-            (identical(other.disableTime, disableTime) ||
-                other.disableTime == disableTime) &&
-            (identical(other.user, user) || other.user == user));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      wallet,
-      email,
-      const DeepCollectionEquality().hash(_devices),
-      customId,
-      verifyTime,
-      disableTime,
-      user);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$AccountImplCopyWith<_$AccountImpl> get copyWith =>
-      __$$AccountImplCopyWithImpl<_$AccountImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$AccountImplToJson(
-      this,
-    );
-  }
+@override@JsonKey(name: 'wallet') final  String? wallet;
+@override@JsonKey(name: 'email') final  String? email;
+ final  List<Device>? _devices;
+@override@JsonKey(name: 'devices') List<Device>? get devices {
+  final value = _devices;
+  if (value == null) return null;
+  if (_devices is EqualUnmodifiableListView) return _devices;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _Account extends Account {
-  const factory _Account(
-      {@JsonKey(name: 'wallet') final String? wallet,
-      @JsonKey(name: 'email') final String? email,
-      @JsonKey(name: 'devices') final List<Device>? devices,
-      @JsonKey(name: 'custom_id') final String? customId,
-      @JsonKey(name: 'verify_time') final DateTime? verifyTime,
-      @JsonKey(name: 'disable_time') final DateTime? disableTime,
-      required final User user}) = _$AccountImpl;
-  const _Account._() : super._();
+@override@JsonKey(name: 'custom_id') final  String? customId;
+@override@JsonKey(name: 'verify_time') final  DateTime? verifyTime;
+@override@JsonKey(name: 'disable_time') final  DateTime? disableTime;
+@override final  User user;
 
-  factory _Account.fromJson(Map<String, dynamic> json) = _$AccountImpl.fromJson;
+/// Create a copy of Account
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AccountCopyWith<_Account> get copyWith => __$AccountCopyWithImpl<_Account>(this, _$identity);
 
-  @override
-  @JsonKey(name: 'wallet')
-  String? get wallet;
-  @override
-  @JsonKey(name: 'email')
-  String? get email;
-  @override
-  @JsonKey(name: 'devices')
-  List<Device>? get devices;
-  @override
-  @JsonKey(name: 'custom_id')
-  String? get customId;
-  @override
-  @JsonKey(name: 'verify_time')
-  DateTime? get verifyTime;
-  @override
-  @JsonKey(name: 'disable_time')
-  DateTime? get disableTime;
-  @override
-  User get user;
-  @override
-  @JsonKey(ignore: true)
-  _$$AccountImplCopyWith<_$AccountImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$AccountToJson(this, );
 }
 
-Device _$DeviceFromJson(Map<String, dynamic> json) {
-  return _Device.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Account&&(identical(other.wallet, wallet) || other.wallet == wallet)&&(identical(other.email, email) || other.email == email)&&const DeepCollectionEquality().equals(other._devices, _devices)&&(identical(other.customId, customId) || other.customId == customId)&&(identical(other.verifyTime, verifyTime) || other.verifyTime == verifyTime)&&(identical(other.disableTime, disableTime) || other.disableTime == disableTime)&&(identical(other.user, user) || other.user == user));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,wallet,email,const DeepCollectionEquality().hash(_devices),customId,verifyTime,disableTime,user);
+
+@override
+String toString() {
+  return 'Account(wallet: $wallet, email: $email, devices: $devices, customId: $customId, verifyTime: $verifyTime, disableTime: $disableTime, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AccountCopyWith<$Res> implements $AccountCopyWith<$Res> {
+  factory _$AccountCopyWith(_Account value, $Res Function(_Account) _then) = __$AccountCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'wallet') String? wallet,@JsonKey(name: 'email') String? email,@JsonKey(name: 'devices') List<Device>? devices,@JsonKey(name: 'custom_id') String? customId,@JsonKey(name: 'verify_time') DateTime? verifyTime,@JsonKey(name: 'disable_time') DateTime? disableTime, User user
+});
+
+
+@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$AccountCopyWithImpl<$Res>
+    implements _$AccountCopyWith<$Res> {
+  __$AccountCopyWithImpl(this._self, this._then);
+
+  final _Account _self;
+  final $Res Function(_Account) _then;
+
+/// Create a copy of Account
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? wallet = freezed,Object? email = freezed,Object? devices = freezed,Object? customId = freezed,Object? verifyTime = freezed,Object? disableTime = freezed,Object? user = null,}) {
+  return _then(_Account(
+wallet: freezed == wallet ? _self.wallet : wallet // ignore: cast_nullable_to_non_nullable
+as String?,email: freezed == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String?,devices: freezed == devices ? _self._devices : devices // ignore: cast_nullable_to_non_nullable
+as List<Device>?,customId: freezed == customId ? _self.customId : customId // ignore: cast_nullable_to_non_nullable
+as String?,verifyTime: freezed == verifyTime ? _self.verifyTime : verifyTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,disableTime: freezed == disableTime ? _self.disableTime : disableTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+
+/// Create a copy of Account
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$Device {
-  String get id => throw _privateConstructorUsedError;
-  Map<String, dynamic>? get vars => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $DeviceCopyWith<Device> get copyWith => throw _privateConstructorUsedError;
+ String get id; Map<String, dynamic>? get vars;
+/// Create a copy of Device
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DeviceCopyWith<Device> get copyWith => _$DeviceCopyWithImpl<Device>(this as Device, _$identity);
+
+  /// Serializes this Device to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Device&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.vars, vars));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(vars));
+
+@override
+String toString() {
+  return 'Device(id: $id, vars: $vars)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $DeviceCopyWith<$Res> {
-  factory $DeviceCopyWith(Device value, $Res Function(Device) then) =
-      _$DeviceCopyWithImpl<$Res, Device>;
-  @useResult
-  $Res call({String id, Map<String, dynamic>? vars});
-}
+abstract mixin class $DeviceCopyWith<$Res>  {
+  factory $DeviceCopyWith(Device value, $Res Function(Device) _then) = _$DeviceCopyWithImpl;
+@useResult
+$Res call({
+ String id, Map<String, dynamic>? vars
+});
 
+
+
+
+}
 /// @nodoc
-class _$DeviceCopyWithImpl<$Res, $Val extends Device>
+class _$DeviceCopyWithImpl<$Res>
     implements $DeviceCopyWith<$Res> {
-  _$DeviceCopyWithImpl(this._value, this._then);
+  _$DeviceCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Device _self;
+  final $Res Function(Device) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? vars = freezed,
-  }) {
-    return _then(_value.copyWith(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      vars: freezed == vars
-          ? _value.vars
-          : vars // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-    ) as $Val);
-  }
+/// Create a copy of Device
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? vars = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,vars: freezed == vars ? _self.vars : vars // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$DeviceImplCopyWith<$Res> implements $DeviceCopyWith<$Res> {
-  factory _$$DeviceImplCopyWith(
-          _$DeviceImpl value, $Res Function(_$DeviceImpl) then) =
-      __$$DeviceImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String id, Map<String, dynamic>? vars});
 }
 
-/// @nodoc
-class __$$DeviceImplCopyWithImpl<$Res>
-    extends _$DeviceCopyWithImpl<$Res, _$DeviceImpl>
-    implements _$$DeviceImplCopyWith<$Res> {
-  __$$DeviceImplCopyWithImpl(
-      _$DeviceImpl _value, $Res Function(_$DeviceImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? vars = freezed,
-  }) {
-    return _then(_$DeviceImpl(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      vars: freezed == vars
-          ? _value._vars
-          : vars // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Device].
+extension DevicePatterns on Device {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Device value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Device() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Device value)  $default,){
+final _that = this;
+switch (_that) {
+case _Device():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Device value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Device() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  Map<String, dynamic>? vars)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Device() when $default != null:
+return $default(_that.id,_that.vars);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  Map<String, dynamic>? vars)  $default,) {final _that = this;
+switch (_that) {
+case _Device():
+return $default(_that.id,_that.vars);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  Map<String, dynamic>? vars)?  $default,) {final _that = this;
+switch (_that) {
+case _Device() when $default != null:
+return $default(_that.id,_that.vars);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$DeviceImpl extends _Device {
-  const _$DeviceImpl({required this.id, final Map<String, dynamic>? vars})
-      : _vars = vars,
-        super._();
 
-  factory _$DeviceImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DeviceImplFromJson(json);
+class _Device extends Device {
+  const _Device({required this.id, final  Map<String, dynamic>? vars}): _vars = vars,super._();
+  factory _Device.fromJson(Map<String, dynamic> json) => _$DeviceFromJson(json);
 
-  @override
-  final String id;
-  final Map<String, dynamic>? _vars;
-  @override
-  Map<String, dynamic>? get vars {
-    final value = _vars;
-    if (value == null) return null;
-    if (_vars is EqualUnmodifiableMapView) return _vars;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
-
-  @override
-  String toString() {
-    return 'Device(id: $id, vars: $vars)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$DeviceImpl &&
-            (identical(other.id, id) || other.id == id) &&
-            const DeepCollectionEquality().equals(other._vars, _vars));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, id, const DeepCollectionEquality().hash(_vars));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$DeviceImplCopyWith<_$DeviceImpl> get copyWith =>
-      __$$DeviceImplCopyWithImpl<_$DeviceImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$DeviceImplToJson(
-      this,
-    );
-  }
+@override final  String id;
+ final  Map<String, dynamic>? _vars;
+@override Map<String, dynamic>? get vars {
+  final value = _vars;
+  if (value == null) return null;
+  if (_vars is EqualUnmodifiableMapView) return _vars;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
 }
 
-abstract class _Device extends Device {
-  const factory _Device(
-      {required final String id,
-      final Map<String, dynamic>? vars}) = _$DeviceImpl;
-  const _Device._() : super._();
 
-  factory _Device.fromJson(Map<String, dynamic> json) = _$DeviceImpl.fromJson;
+/// Create a copy of Device
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$DeviceCopyWith<_Device> get copyWith => __$DeviceCopyWithImpl<_Device>(this, _$identity);
 
-  @override
-  String get id;
-  @override
-  Map<String, dynamic>? get vars;
-  @override
-  @JsonKey(ignore: true)
-  _$$DeviceImplCopyWith<_$DeviceImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$DeviceToJson(this, );
 }
 
-User _$UserFromJson(Map<String, dynamic> json) {
-  return _User.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Device&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._vars, _vars));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_vars));
+
+@override
+String toString() {
+  return 'Device(id: $id, vars: $vars)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$DeviceCopyWith<$Res> implements $DeviceCopyWith<$Res> {
+  factory _$DeviceCopyWith(_Device value, $Res Function(_Device) _then) = __$DeviceCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, Map<String, dynamic>? vars
+});
+
+
+
+
+}
+/// @nodoc
+class __$DeviceCopyWithImpl<$Res>
+    implements _$DeviceCopyWith<$Res> {
+  __$DeviceCopyWithImpl(this._self, this._then);
+
+  final _Device _self;
+  final $Res Function(_Device) _then;
+
+/// Create a copy of Device
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? vars = freezed,}) {
+  return _then(_Device(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,vars: freezed == vars ? _self._vars : vars // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$User {
-  @JsonKey(name: 'id')
-  String get id => throw _privateConstructorUsedError;
-  @JsonKey(name: 'username')
-  String? get username => throw _privateConstructorUsedError;
-  @JsonKey(name: 'display_name')
-  String? get displayName => throw _privateConstructorUsedError;
-  @JsonKey(name: 'avatar_url')
-  String? get avatarUrl => throw _privateConstructorUsedError;
-  @JsonKey(name: 'lang_tag')
-  String? get langTag => throw _privateConstructorUsedError;
-  @JsonKey(name: 'location')
-  String? get location => throw _privateConstructorUsedError;
-  @JsonKey(name: 'timezone')
-  String? get timezone => throw _privateConstructorUsedError;
-  @JsonKey(name: 'metadata')
-  String? get metadata => throw _privateConstructorUsedError;
-  @JsonKey(name: 'facebook_id')
-  String? get facebookId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'google_id')
-  String? get googleId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'gamecenter_id')
-  String? get gamecenterId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'steam_id')
-  String? get steamId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'online')
-  bool get online => throw _privateConstructorUsedError;
-  @JsonKey(name: 'edge_count')
-  int get edgeCount => throw _privateConstructorUsedError;
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'update_time')
-  DateTime? get updateTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'facebook_instant_game_id')
-  String? get facebookInstantGameId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'apple_id')
-  String? get appleId => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $UserCopyWith<User> get copyWith => throw _privateConstructorUsedError;
+@JsonKey(name: 'id') String get id;@JsonKey(name: 'username') String? get username;@JsonKey(name: 'display_name') String? get displayName;@JsonKey(name: 'avatar_url') String? get avatarUrl;@JsonKey(name: 'lang_tag') String? get langTag;@JsonKey(name: 'location') String? get location;@JsonKey(name: 'timezone') String? get timezone;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'facebook_id') String? get facebookId;@JsonKey(name: 'google_id') String? get googleId;@JsonKey(name: 'gamecenter_id') String? get gamecenterId;@JsonKey(name: 'steam_id') String? get steamId;@JsonKey(name: 'online') bool get online;@JsonKey(name: 'edge_count') int get edgeCount;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;@JsonKey(name: 'facebook_instant_game_id') String? get facebookInstantGameId;@JsonKey(name: 'apple_id') String? get appleId;
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserCopyWith<User> get copyWith => _$UserCopyWithImpl<User>(this as User, _$identity);
+
+  /// Serializes this User to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is User&&(identical(other.id, id) || other.id == id)&&(identical(other.username, username) || other.username == username)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl)&&(identical(other.langTag, langTag) || other.langTag == langTag)&&(identical(other.location, location) || other.location == location)&&(identical(other.timezone, timezone) || other.timezone == timezone)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.facebookId, facebookId) || other.facebookId == facebookId)&&(identical(other.googleId, googleId) || other.googleId == googleId)&&(identical(other.gamecenterId, gamecenterId) || other.gamecenterId == gamecenterId)&&(identical(other.steamId, steamId) || other.steamId == steamId)&&(identical(other.online, online) || other.online == online)&&(identical(other.edgeCount, edgeCount) || other.edgeCount == edgeCount)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime)&&(identical(other.facebookInstantGameId, facebookInstantGameId) || other.facebookInstantGameId == facebookInstantGameId)&&(identical(other.appleId, appleId) || other.appleId == appleId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,username,displayName,avatarUrl,langTag,location,timezone,metadata,facebookId,googleId,gamecenterId,steamId,online,edgeCount,createTime,updateTime,facebookInstantGameId,appleId);
+
+@override
+String toString() {
+  return 'User(id: $id, username: $username, displayName: $displayName, avatarUrl: $avatarUrl, langTag: $langTag, location: $location, timezone: $timezone, metadata: $metadata, facebookId: $facebookId, googleId: $googleId, gamecenterId: $gamecenterId, steamId: $steamId, online: $online, edgeCount: $edgeCount, createTime: $createTime, updateTime: $updateTime, facebookInstantGameId: $facebookInstantGameId, appleId: $appleId)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $UserCopyWith<$Res> {
-  factory $UserCopyWith(User value, $Res Function(User) then) =
-      _$UserCopyWithImpl<$Res, User>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'id') String id,
-      @JsonKey(name: 'username') String? username,
-      @JsonKey(name: 'display_name') String? displayName,
-      @JsonKey(name: 'avatar_url') String? avatarUrl,
-      @JsonKey(name: 'lang_tag') String? langTag,
-      @JsonKey(name: 'location') String? location,
-      @JsonKey(name: 'timezone') String? timezone,
-      @JsonKey(name: 'metadata') String? metadata,
-      @JsonKey(name: 'facebook_id') String? facebookId,
-      @JsonKey(name: 'google_id') String? googleId,
-      @JsonKey(name: 'gamecenter_id') String? gamecenterId,
-      @JsonKey(name: 'steam_id') String? steamId,
-      @JsonKey(name: 'online') bool online,
-      @JsonKey(name: 'edge_count') int edgeCount,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'update_time') DateTime? updateTime,
-      @JsonKey(name: 'facebook_instant_game_id') String? facebookInstantGameId,
-      @JsonKey(name: 'apple_id') String? appleId});
-}
+abstract mixin class $UserCopyWith<$Res>  {
+  factory $UserCopyWith(User value, $Res Function(User) _then) = _$UserCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'id') String id,@JsonKey(name: 'username') String? username,@JsonKey(name: 'display_name') String? displayName,@JsonKey(name: 'avatar_url') String? avatarUrl,@JsonKey(name: 'lang_tag') String? langTag,@JsonKey(name: 'location') String? location,@JsonKey(name: 'timezone') String? timezone,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'facebook_id') String? facebookId,@JsonKey(name: 'google_id') String? googleId,@JsonKey(name: 'gamecenter_id') String? gamecenterId,@JsonKey(name: 'steam_id') String? steamId,@JsonKey(name: 'online') bool online,@JsonKey(name: 'edge_count') int edgeCount,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'facebook_instant_game_id') String? facebookInstantGameId,@JsonKey(name: 'apple_id') String? appleId
+});
 
+
+
+
+}
 /// @nodoc
-class _$UserCopyWithImpl<$Res, $Val extends User>
+class _$UserCopyWithImpl<$Res>
     implements $UserCopyWith<$Res> {
-  _$UserCopyWithImpl(this._value, this._then);
+  _$UserCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final User _self;
+  final $Res Function(User) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? username = freezed,
-    Object? displayName = freezed,
-    Object? avatarUrl = freezed,
-    Object? langTag = freezed,
-    Object? location = freezed,
-    Object? timezone = freezed,
-    Object? metadata = freezed,
-    Object? facebookId = freezed,
-    Object? googleId = freezed,
-    Object? gamecenterId = freezed,
-    Object? steamId = freezed,
-    Object? online = null,
-    Object? edgeCount = null,
-    Object? createTime = freezed,
-    Object? updateTime = freezed,
-    Object? facebookInstantGameId = freezed,
-    Object? appleId = freezed,
-  }) {
-    return _then(_value.copyWith(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      username: freezed == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String?,
-      displayName: freezed == displayName
-          ? _value.displayName
-          : displayName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      avatarUrl: freezed == avatarUrl
-          ? _value.avatarUrl
-          : avatarUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      langTag: freezed == langTag
-          ? _value.langTag
-          : langTag // ignore: cast_nullable_to_non_nullable
-              as String?,
-      location: freezed == location
-          ? _value.location
-          : location // ignore: cast_nullable_to_non_nullable
-              as String?,
-      timezone: freezed == timezone
-          ? _value.timezone
-          : timezone // ignore: cast_nullable_to_non_nullable
-              as String?,
-      metadata: freezed == metadata
-          ? _value.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as String?,
-      facebookId: freezed == facebookId
-          ? _value.facebookId
-          : facebookId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      googleId: freezed == googleId
-          ? _value.googleId
-          : googleId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      gamecenterId: freezed == gamecenterId
-          ? _value.gamecenterId
-          : gamecenterId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      steamId: freezed == steamId
-          ? _value.steamId
-          : steamId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      online: null == online
-          ? _value.online
-          : online // ignore: cast_nullable_to_non_nullable
-              as bool,
-      edgeCount: null == edgeCount
-          ? _value.edgeCount
-          : edgeCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updateTime: freezed == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      facebookInstantGameId: freezed == facebookInstantGameId
-          ? _value.facebookInstantGameId
-          : facebookInstantGameId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      appleId: freezed == appleId
-          ? _value.appleId
-          : appleId // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? username = freezed,Object? displayName = freezed,Object? avatarUrl = freezed,Object? langTag = freezed,Object? location = freezed,Object? timezone = freezed,Object? metadata = freezed,Object? facebookId = freezed,Object? googleId = freezed,Object? gamecenterId = freezed,Object? steamId = freezed,Object? online = null,Object? edgeCount = null,Object? createTime = freezed,Object? updateTime = freezed,Object? facebookInstantGameId = freezed,Object? appleId = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String?,displayName: freezed == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
+as String?,avatarUrl: freezed == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String?,langTag: freezed == langTag ? _self.langTag : langTag // ignore: cast_nullable_to_non_nullable
+as String?,location: freezed == location ? _self.location : location // ignore: cast_nullable_to_non_nullable
+as String?,timezone: freezed == timezone ? _self.timezone : timezone // ignore: cast_nullable_to_non_nullable
+as String?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,facebookId: freezed == facebookId ? _self.facebookId : facebookId // ignore: cast_nullable_to_non_nullable
+as String?,googleId: freezed == googleId ? _self.googleId : googleId // ignore: cast_nullable_to_non_nullable
+as String?,gamecenterId: freezed == gamecenterId ? _self.gamecenterId : gamecenterId // ignore: cast_nullable_to_non_nullable
+as String?,steamId: freezed == steamId ? _self.steamId : steamId // ignore: cast_nullable_to_non_nullable
+as String?,online: null == online ? _self.online : online // ignore: cast_nullable_to_non_nullable
+as bool,edgeCount: null == edgeCount ? _self.edgeCount : edgeCount // ignore: cast_nullable_to_non_nullable
+as int,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,facebookInstantGameId: freezed == facebookInstantGameId ? _self.facebookInstantGameId : facebookInstantGameId // ignore: cast_nullable_to_non_nullable
+as String?,appleId: freezed == appleId ? _self.appleId : appleId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$UserImplCopyWith<$Res> implements $UserCopyWith<$Res> {
-  factory _$$UserImplCopyWith(
-          _$UserImpl value, $Res Function(_$UserImpl) then) =
-      __$$UserImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'id') String id,
-      @JsonKey(name: 'username') String? username,
-      @JsonKey(name: 'display_name') String? displayName,
-      @JsonKey(name: 'avatar_url') String? avatarUrl,
-      @JsonKey(name: 'lang_tag') String? langTag,
-      @JsonKey(name: 'location') String? location,
-      @JsonKey(name: 'timezone') String? timezone,
-      @JsonKey(name: 'metadata') String? metadata,
-      @JsonKey(name: 'facebook_id') String? facebookId,
-      @JsonKey(name: 'google_id') String? googleId,
-      @JsonKey(name: 'gamecenter_id') String? gamecenterId,
-      @JsonKey(name: 'steam_id') String? steamId,
-      @JsonKey(name: 'online') bool online,
-      @JsonKey(name: 'edge_count') int edgeCount,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'update_time') DateTime? updateTime,
-      @JsonKey(name: 'facebook_instant_game_id') String? facebookInstantGameId,
-      @JsonKey(name: 'apple_id') String? appleId});
 }
 
-/// @nodoc
-class __$$UserImplCopyWithImpl<$Res>
-    extends _$UserCopyWithImpl<$Res, _$UserImpl>
-    implements _$$UserImplCopyWith<$Res> {
-  __$$UserImplCopyWithImpl(_$UserImpl _value, $Res Function(_$UserImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? username = freezed,
-    Object? displayName = freezed,
-    Object? avatarUrl = freezed,
-    Object? langTag = freezed,
-    Object? location = freezed,
-    Object? timezone = freezed,
-    Object? metadata = freezed,
-    Object? facebookId = freezed,
-    Object? googleId = freezed,
-    Object? gamecenterId = freezed,
-    Object? steamId = freezed,
-    Object? online = null,
-    Object? edgeCount = null,
-    Object? createTime = freezed,
-    Object? updateTime = freezed,
-    Object? facebookInstantGameId = freezed,
-    Object? appleId = freezed,
-  }) {
-    return _then(_$UserImpl(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      username: freezed == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String?,
-      displayName: freezed == displayName
-          ? _value.displayName
-          : displayName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      avatarUrl: freezed == avatarUrl
-          ? _value.avatarUrl
-          : avatarUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      langTag: freezed == langTag
-          ? _value.langTag
-          : langTag // ignore: cast_nullable_to_non_nullable
-              as String?,
-      location: freezed == location
-          ? _value.location
-          : location // ignore: cast_nullable_to_non_nullable
-              as String?,
-      timezone: freezed == timezone
-          ? _value.timezone
-          : timezone // ignore: cast_nullable_to_non_nullable
-              as String?,
-      metadata: freezed == metadata
-          ? _value.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as String?,
-      facebookId: freezed == facebookId
-          ? _value.facebookId
-          : facebookId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      googleId: freezed == googleId
-          ? _value.googleId
-          : googleId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      gamecenterId: freezed == gamecenterId
-          ? _value.gamecenterId
-          : gamecenterId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      steamId: freezed == steamId
-          ? _value.steamId
-          : steamId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      online: null == online
-          ? _value.online
-          : online // ignore: cast_nullable_to_non_nullable
-              as bool,
-      edgeCount: null == edgeCount
-          ? _value.edgeCount
-          : edgeCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updateTime: freezed == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      facebookInstantGameId: freezed == facebookInstantGameId
-          ? _value.facebookInstantGameId
-          : facebookInstantGameId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      appleId: freezed == appleId
-          ? _value.appleId
-          : appleId // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [User].
+extension UserPatterns on User {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _User value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _User() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _User value)  $default,){
+final _that = this;
+switch (_that) {
+case _User():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _User value)?  $default,){
+final _that = this;
+switch (_that) {
+case _User() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'display_name')  String? displayName, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'lang_tag')  String? langTag, @JsonKey(name: 'location')  String? location, @JsonKey(name: 'timezone')  String? timezone, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'facebook_id')  String? facebookId, @JsonKey(name: 'google_id')  String? googleId, @JsonKey(name: 'gamecenter_id')  String? gamecenterId, @JsonKey(name: 'steam_id')  String? steamId, @JsonKey(name: 'online')  bool online, @JsonKey(name: 'edge_count')  int edgeCount, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'facebook_instant_game_id')  String? facebookInstantGameId, @JsonKey(name: 'apple_id')  String? appleId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _User() when $default != null:
+return $default(_that.id,_that.username,_that.displayName,_that.avatarUrl,_that.langTag,_that.location,_that.timezone,_that.metadata,_that.facebookId,_that.googleId,_that.gamecenterId,_that.steamId,_that.online,_that.edgeCount,_that.createTime,_that.updateTime,_that.facebookInstantGameId,_that.appleId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'display_name')  String? displayName, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'lang_tag')  String? langTag, @JsonKey(name: 'location')  String? location, @JsonKey(name: 'timezone')  String? timezone, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'facebook_id')  String? facebookId, @JsonKey(name: 'google_id')  String? googleId, @JsonKey(name: 'gamecenter_id')  String? gamecenterId, @JsonKey(name: 'steam_id')  String? steamId, @JsonKey(name: 'online')  bool online, @JsonKey(name: 'edge_count')  int edgeCount, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'facebook_instant_game_id')  String? facebookInstantGameId, @JsonKey(name: 'apple_id')  String? appleId)  $default,) {final _that = this;
+switch (_that) {
+case _User():
+return $default(_that.id,_that.username,_that.displayName,_that.avatarUrl,_that.langTag,_that.location,_that.timezone,_that.metadata,_that.facebookId,_that.googleId,_that.gamecenterId,_that.steamId,_that.online,_that.edgeCount,_that.createTime,_that.updateTime,_that.facebookInstantGameId,_that.appleId);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'display_name')  String? displayName, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'lang_tag')  String? langTag, @JsonKey(name: 'location')  String? location, @JsonKey(name: 'timezone')  String? timezone, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'facebook_id')  String? facebookId, @JsonKey(name: 'google_id')  String? googleId, @JsonKey(name: 'gamecenter_id')  String? gamecenterId, @JsonKey(name: 'steam_id')  String? steamId, @JsonKey(name: 'online')  bool online, @JsonKey(name: 'edge_count')  int edgeCount, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'facebook_instant_game_id')  String? facebookInstantGameId, @JsonKey(name: 'apple_id')  String? appleId)?  $default,) {final _that = this;
+switch (_that) {
+case _User() when $default != null:
+return $default(_that.id,_that.username,_that.displayName,_that.avatarUrl,_that.langTag,_that.location,_that.timezone,_that.metadata,_that.facebookId,_that.googleId,_that.gamecenterId,_that.steamId,_that.online,_that.edgeCount,_that.createTime,_that.updateTime,_that.facebookInstantGameId,_that.appleId);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$UserImpl extends _User {
-  const _$UserImpl(
-      {@JsonKey(name: 'id') required this.id,
-      @JsonKey(name: 'username') this.username,
-      @JsonKey(name: 'display_name') this.displayName,
-      @JsonKey(name: 'avatar_url') this.avatarUrl,
-      @JsonKey(name: 'lang_tag') this.langTag,
-      @JsonKey(name: 'location') this.location,
-      @JsonKey(name: 'timezone') this.timezone,
-      @JsonKey(name: 'metadata') this.metadata,
-      @JsonKey(name: 'facebook_id') this.facebookId,
-      @JsonKey(name: 'google_id') this.googleId,
-      @JsonKey(name: 'gamecenter_id') this.gamecenterId,
-      @JsonKey(name: 'steam_id') this.steamId,
-      @JsonKey(name: 'online') this.online = false,
-      @JsonKey(name: 'edge_count') this.edgeCount = 0,
-      @JsonKey(name: 'create_time') this.createTime,
-      @JsonKey(name: 'update_time') this.updateTime,
-      @JsonKey(name: 'facebook_instant_game_id') this.facebookInstantGameId,
-      @JsonKey(name: 'apple_id') this.appleId})
-      : super._();
 
-  factory _$UserImpl.fromJson(Map<String, dynamic> json) =>
-      _$$UserImplFromJson(json);
+class _User extends User {
+  const _User({@JsonKey(name: 'id') required this.id, @JsonKey(name: 'username') this.username, @JsonKey(name: 'display_name') this.displayName, @JsonKey(name: 'avatar_url') this.avatarUrl, @JsonKey(name: 'lang_tag') this.langTag, @JsonKey(name: 'location') this.location, @JsonKey(name: 'timezone') this.timezone, @JsonKey(name: 'metadata') this.metadata, @JsonKey(name: 'facebook_id') this.facebookId, @JsonKey(name: 'google_id') this.googleId, @JsonKey(name: 'gamecenter_id') this.gamecenterId, @JsonKey(name: 'steam_id') this.steamId, @JsonKey(name: 'online') this.online = false, @JsonKey(name: 'edge_count') this.edgeCount = 0, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'update_time') this.updateTime, @JsonKey(name: 'facebook_instant_game_id') this.facebookInstantGameId, @JsonKey(name: 'apple_id') this.appleId}): super._();
+  factory _User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
-  @override
-  @JsonKey(name: 'id')
-  final String id;
-  @override
-  @JsonKey(name: 'username')
-  final String? username;
-  @override
-  @JsonKey(name: 'display_name')
-  final String? displayName;
-  @override
-  @JsonKey(name: 'avatar_url')
-  final String? avatarUrl;
-  @override
-  @JsonKey(name: 'lang_tag')
-  final String? langTag;
-  @override
-  @JsonKey(name: 'location')
-  final String? location;
-  @override
-  @JsonKey(name: 'timezone')
-  final String? timezone;
-  @override
-  @JsonKey(name: 'metadata')
-  final String? metadata;
-  @override
-  @JsonKey(name: 'facebook_id')
-  final String? facebookId;
-  @override
-  @JsonKey(name: 'google_id')
-  final String? googleId;
-  @override
-  @JsonKey(name: 'gamecenter_id')
-  final String? gamecenterId;
-  @override
-  @JsonKey(name: 'steam_id')
-  final String? steamId;
-  @override
-  @JsonKey(name: 'online')
-  final bool online;
-  @override
-  @JsonKey(name: 'edge_count')
-  final int edgeCount;
-  @override
-  @JsonKey(name: 'create_time')
-  final DateTime? createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  final DateTime? updateTime;
-  @override
-  @JsonKey(name: 'facebook_instant_game_id')
-  final String? facebookInstantGameId;
-  @override
-  @JsonKey(name: 'apple_id')
-  final String? appleId;
+@override@JsonKey(name: 'id') final  String id;
+@override@JsonKey(name: 'username') final  String? username;
+@override@JsonKey(name: 'display_name') final  String? displayName;
+@override@JsonKey(name: 'avatar_url') final  String? avatarUrl;
+@override@JsonKey(name: 'lang_tag') final  String? langTag;
+@override@JsonKey(name: 'location') final  String? location;
+@override@JsonKey(name: 'timezone') final  String? timezone;
+@override@JsonKey(name: 'metadata') final  String? metadata;
+@override@JsonKey(name: 'facebook_id') final  String? facebookId;
+@override@JsonKey(name: 'google_id') final  String? googleId;
+@override@JsonKey(name: 'gamecenter_id') final  String? gamecenterId;
+@override@JsonKey(name: 'steam_id') final  String? steamId;
+@override@JsonKey(name: 'online') final  bool online;
+@override@JsonKey(name: 'edge_count') final  int edgeCount;
+@override@JsonKey(name: 'create_time') final  DateTime? createTime;
+@override@JsonKey(name: 'update_time') final  DateTime? updateTime;
+@override@JsonKey(name: 'facebook_instant_game_id') final  String? facebookInstantGameId;
+@override@JsonKey(name: 'apple_id') final  String? appleId;
 
-  @override
-  String toString() {
-    return 'User(id: $id, username: $username, displayName: $displayName, avatarUrl: $avatarUrl, langTag: $langTag, location: $location, timezone: $timezone, metadata: $metadata, facebookId: $facebookId, googleId: $googleId, gamecenterId: $gamecenterId, steamId: $steamId, online: $online, edgeCount: $edgeCount, createTime: $createTime, updateTime: $updateTime, facebookInstantGameId: $facebookInstantGameId, appleId: $appleId)';
-  }
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserCopyWith<_User> get copyWith => __$UserCopyWithImpl<_User>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$UserImpl &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.username, username) ||
-                other.username == username) &&
-            (identical(other.displayName, displayName) ||
-                other.displayName == displayName) &&
-            (identical(other.avatarUrl, avatarUrl) ||
-                other.avatarUrl == avatarUrl) &&
-            (identical(other.langTag, langTag) || other.langTag == langTag) &&
-            (identical(other.location, location) ||
-                other.location == location) &&
-            (identical(other.timezone, timezone) ||
-                other.timezone == timezone) &&
-            (identical(other.metadata, metadata) ||
-                other.metadata == metadata) &&
-            (identical(other.facebookId, facebookId) ||
-                other.facebookId == facebookId) &&
-            (identical(other.googleId, googleId) ||
-                other.googleId == googleId) &&
-            (identical(other.gamecenterId, gamecenterId) ||
-                other.gamecenterId == gamecenterId) &&
-            (identical(other.steamId, steamId) || other.steamId == steamId) &&
-            (identical(other.online, online) || other.online == online) &&
-            (identical(other.edgeCount, edgeCount) ||
-                other.edgeCount == edgeCount) &&
-            (identical(other.createTime, createTime) ||
-                other.createTime == createTime) &&
-            (identical(other.updateTime, updateTime) ||
-                other.updateTime == updateTime) &&
-            (identical(other.facebookInstantGameId, facebookInstantGameId) ||
-                other.facebookInstantGameId == facebookInstantGameId) &&
-            (identical(other.appleId, appleId) || other.appleId == appleId));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      username,
-      displayName,
-      avatarUrl,
-      langTag,
-      location,
-      timezone,
-      metadata,
-      facebookId,
-      googleId,
-      gamecenterId,
-      steamId,
-      online,
-      edgeCount,
-      createTime,
-      updateTime,
-      facebookInstantGameId,
-      appleId);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$UserImplCopyWith<_$UserImpl> get copyWith =>
-      __$$UserImplCopyWithImpl<_$UserImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$UserImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$UserToJson(this, );
 }
 
-abstract class _User extends User {
-  const factory _User(
-      {@JsonKey(name: 'id') required final String id,
-      @JsonKey(name: 'username') final String? username,
-      @JsonKey(name: 'display_name') final String? displayName,
-      @JsonKey(name: 'avatar_url') final String? avatarUrl,
-      @JsonKey(name: 'lang_tag') final String? langTag,
-      @JsonKey(name: 'location') final String? location,
-      @JsonKey(name: 'timezone') final String? timezone,
-      @JsonKey(name: 'metadata') final String? metadata,
-      @JsonKey(name: 'facebook_id') final String? facebookId,
-      @JsonKey(name: 'google_id') final String? googleId,
-      @JsonKey(name: 'gamecenter_id') final String? gamecenterId,
-      @JsonKey(name: 'steam_id') final String? steamId,
-      @JsonKey(name: 'online') final bool online,
-      @JsonKey(name: 'edge_count') final int edgeCount,
-      @JsonKey(name: 'create_time') final DateTime? createTime,
-      @JsonKey(name: 'update_time') final DateTime? updateTime,
-      @JsonKey(name: 'facebook_instant_game_id')
-      final String? facebookInstantGameId,
-      @JsonKey(name: 'apple_id') final String? appleId}) = _$UserImpl;
-  const _User._() : super._();
-
-  factory _User.fromJson(Map<String, dynamic> json) = _$UserImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'id')
-  String get id;
-  @override
-  @JsonKey(name: 'username')
-  String? get username;
-  @override
-  @JsonKey(name: 'display_name')
-  String? get displayName;
-  @override
-  @JsonKey(name: 'avatar_url')
-  String? get avatarUrl;
-  @override
-  @JsonKey(name: 'lang_tag')
-  String? get langTag;
-  @override
-  @JsonKey(name: 'location')
-  String? get location;
-  @override
-  @JsonKey(name: 'timezone')
-  String? get timezone;
-  @override
-  @JsonKey(name: 'metadata')
-  String? get metadata;
-  @override
-  @JsonKey(name: 'facebook_id')
-  String? get facebookId;
-  @override
-  @JsonKey(name: 'google_id')
-  String? get googleId;
-  @override
-  @JsonKey(name: 'gamecenter_id')
-  String? get gamecenterId;
-  @override
-  @JsonKey(name: 'steam_id')
-  String? get steamId;
-  @override
-  @JsonKey(name: 'online')
-  bool get online;
-  @override
-  @JsonKey(name: 'edge_count')
-  int get edgeCount;
-  @override
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  DateTime? get updateTime;
-  @override
-  @JsonKey(name: 'facebook_instant_game_id')
-  String? get facebookInstantGameId;
-  @override
-  @JsonKey(name: 'apple_id')
-  String? get appleId;
-  @override
-  @JsonKey(ignore: true)
-  _$$UserImplCopyWith<_$UserImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User&&(identical(other.id, id) || other.id == id)&&(identical(other.username, username) || other.username == username)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl)&&(identical(other.langTag, langTag) || other.langTag == langTag)&&(identical(other.location, location) || other.location == location)&&(identical(other.timezone, timezone) || other.timezone == timezone)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.facebookId, facebookId) || other.facebookId == facebookId)&&(identical(other.googleId, googleId) || other.googleId == googleId)&&(identical(other.gamecenterId, gamecenterId) || other.gamecenterId == gamecenterId)&&(identical(other.steamId, steamId) || other.steamId == steamId)&&(identical(other.online, online) || other.online == online)&&(identical(other.edgeCount, edgeCount) || other.edgeCount == edgeCount)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime)&&(identical(other.facebookInstantGameId, facebookInstantGameId) || other.facebookInstantGameId == facebookInstantGameId)&&(identical(other.appleId, appleId) || other.appleId == appleId));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,username,displayName,avatarUrl,langTag,location,timezone,metadata,facebookId,googleId,gamecenterId,steamId,online,edgeCount,createTime,updateTime,facebookInstantGameId,appleId);
+
+@override
+String toString() {
+  return 'User(id: $id, username: $username, displayName: $displayName, avatarUrl: $avatarUrl, langTag: $langTag, location: $location, timezone: $timezone, metadata: $metadata, facebookId: $facebookId, googleId: $googleId, gamecenterId: $gamecenterId, steamId: $steamId, online: $online, edgeCount: $edgeCount, createTime: $createTime, updateTime: $updateTime, facebookInstantGameId: $facebookInstantGameId, appleId: $appleId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
+  factory _$UserCopyWith(_User value, $Res Function(_User) _then) = __$UserCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'id') String id,@JsonKey(name: 'username') String? username,@JsonKey(name: 'display_name') String? displayName,@JsonKey(name: 'avatar_url') String? avatarUrl,@JsonKey(name: 'lang_tag') String? langTag,@JsonKey(name: 'location') String? location,@JsonKey(name: 'timezone') String? timezone,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'facebook_id') String? facebookId,@JsonKey(name: 'google_id') String? googleId,@JsonKey(name: 'gamecenter_id') String? gamecenterId,@JsonKey(name: 'steam_id') String? steamId,@JsonKey(name: 'online') bool online,@JsonKey(name: 'edge_count') int edgeCount,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'facebook_instant_game_id') String? facebookInstantGameId,@JsonKey(name: 'apple_id') String? appleId
+});
+
+
+
+
+}
+/// @nodoc
+class __$UserCopyWithImpl<$Res>
+    implements _$UserCopyWith<$Res> {
+  __$UserCopyWithImpl(this._self, this._then);
+
+  final _User _self;
+  final $Res Function(_User) _then;
+
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? username = freezed,Object? displayName = freezed,Object? avatarUrl = freezed,Object? langTag = freezed,Object? location = freezed,Object? timezone = freezed,Object? metadata = freezed,Object? facebookId = freezed,Object? googleId = freezed,Object? gamecenterId = freezed,Object? steamId = freezed,Object? online = null,Object? edgeCount = null,Object? createTime = freezed,Object? updateTime = freezed,Object? facebookInstantGameId = freezed,Object? appleId = freezed,}) {
+  return _then(_User(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String?,displayName: freezed == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
+as String?,avatarUrl: freezed == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String?,langTag: freezed == langTag ? _self.langTag : langTag // ignore: cast_nullable_to_non_nullable
+as String?,location: freezed == location ? _self.location : location // ignore: cast_nullable_to_non_nullable
+as String?,timezone: freezed == timezone ? _self.timezone : timezone // ignore: cast_nullable_to_non_nullable
+as String?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,facebookId: freezed == facebookId ? _self.facebookId : facebookId // ignore: cast_nullable_to_non_nullable
+as String?,googleId: freezed == googleId ? _self.googleId : googleId // ignore: cast_nullable_to_non_nullable
+as String?,gamecenterId: freezed == gamecenterId ? _self.gamecenterId : gamecenterId // ignore: cast_nullable_to_non_nullable
+as String?,steamId: freezed == steamId ? _self.steamId : steamId // ignore: cast_nullable_to_non_nullable
+as String?,online: null == online ? _self.online : online // ignore: cast_nullable_to_non_nullable
+as bool,edgeCount: null == edgeCount ? _self.edgeCount : edgeCount // ignore: cast_nullable_to_non_nullable
+as int,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,facebookInstantGameId: freezed == facebookInstantGameId ? _self.facebookInstantGameId : facebookInstantGameId // ignore: cast_nullable_to_non_nullable
+as String?,appleId: freezed == appleId ? _self.appleId : appleId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/nakama/lib/src/models/account.g.dart
+++ b/nakama/lib/src/models/account.g.dart
@@ -6,88 +6,84 @@ part of 'account.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AccountImpl _$$AccountImplFromJson(Map<String, dynamic> json) =>
-    _$AccountImpl(
-      wallet: json['wallet'] as String?,
-      email: json['email'] as String?,
-      devices: (json['devices'] as List<dynamic>?)
-          ?.map((e) => Device.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      customId: json['custom_id'] as String?,
-      verifyTime: json['verify_time'] == null
-          ? null
-          : DateTime.parse(json['verify_time'] as String),
-      disableTime: json['disable_time'] == null
-          ? null
-          : DateTime.parse(json['disable_time'] as String),
-      user: User.fromJson(json['user'] as Map<String, dynamic>),
-    );
+_Account _$AccountFromJson(Map<String, dynamic> json) => _Account(
+  wallet: json['wallet'] as String?,
+  email: json['email'] as String?,
+  devices: (json['devices'] as List<dynamic>?)
+      ?.map((e) => Device.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  customId: json['custom_id'] as String?,
+  verifyTime: json['verify_time'] == null
+      ? null
+      : DateTime.parse(json['verify_time'] as String),
+  disableTime: json['disable_time'] == null
+      ? null
+      : DateTime.parse(json['disable_time'] as String),
+  user: User.fromJson(json['user'] as Map<String, dynamic>),
+);
 
-Map<String, dynamic> _$$AccountImplToJson(_$AccountImpl instance) =>
-    <String, dynamic>{
-      'wallet': instance.wallet,
-      'email': instance.email,
-      'devices': instance.devices,
-      'custom_id': instance.customId,
-      'verify_time': instance.verifyTime?.toIso8601String(),
-      'disable_time': instance.disableTime?.toIso8601String(),
-      'user': instance.user,
-    };
+Map<String, dynamic> _$AccountToJson(_Account instance) => <String, dynamic>{
+  'wallet': instance.wallet,
+  'email': instance.email,
+  'devices': instance.devices,
+  'custom_id': instance.customId,
+  'verify_time': instance.verifyTime?.toIso8601String(),
+  'disable_time': instance.disableTime?.toIso8601String(),
+  'user': instance.user,
+};
 
-_$DeviceImpl _$$DeviceImplFromJson(Map<String, dynamic> json) => _$DeviceImpl(
-      id: json['id'] as String,
-      vars: json['vars'] as Map<String, dynamic>?,
-    );
+_Device _$DeviceFromJson(Map<String, dynamic> json) => _Device(
+  id: json['id'] as String,
+  vars: json['vars'] as Map<String, dynamic>?,
+);
 
-Map<String, dynamic> _$$DeviceImplToJson(_$DeviceImpl instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$DeviceToJson(_Device instance) => <String, dynamic>{
+  'id': instance.id,
+  'vars': instance.vars,
+};
 
-_$UserImpl _$$UserImplFromJson(Map<String, dynamic> json) => _$UserImpl(
-      id: json['id'] as String,
-      username: json['username'] as String?,
-      displayName: json['display_name'] as String?,
-      avatarUrl: json['avatar_url'] as String?,
-      langTag: json['lang_tag'] as String?,
-      location: json['location'] as String?,
-      timezone: json['timezone'] as String?,
-      metadata: json['metadata'] as String?,
-      facebookId: json['facebook_id'] as String?,
-      googleId: json['google_id'] as String?,
-      gamecenterId: json['gamecenter_id'] as String?,
-      steamId: json['steam_id'] as String?,
-      online: json['online'] as bool? ?? false,
-      edgeCount: json['edge_count'] as int? ?? 0,
-      createTime: json['create_time'] == null
-          ? null
-          : DateTime.parse(json['create_time'] as String),
-      updateTime: json['update_time'] == null
-          ? null
-          : DateTime.parse(json['update_time'] as String),
-      facebookInstantGameId: json['facebook_instant_game_id'] as String?,
-      appleId: json['apple_id'] as String?,
-    );
+_User _$UserFromJson(Map<String, dynamic> json) => _User(
+  id: json['id'] as String,
+  username: json['username'] as String?,
+  displayName: json['display_name'] as String?,
+  avatarUrl: json['avatar_url'] as String?,
+  langTag: json['lang_tag'] as String?,
+  location: json['location'] as String?,
+  timezone: json['timezone'] as String?,
+  metadata: json['metadata'] as String?,
+  facebookId: json['facebook_id'] as String?,
+  googleId: json['google_id'] as String?,
+  gamecenterId: json['gamecenter_id'] as String?,
+  steamId: json['steam_id'] as String?,
+  online: json['online'] as bool? ?? false,
+  edgeCount: (json['edge_count'] as num?)?.toInt() ?? 0,
+  createTime: json['create_time'] == null
+      ? null
+      : DateTime.parse(json['create_time'] as String),
+  updateTime: json['update_time'] == null
+      ? null
+      : DateTime.parse(json['update_time'] as String),
+  facebookInstantGameId: json['facebook_instant_game_id'] as String?,
+  appleId: json['apple_id'] as String?,
+);
 
-Map<String, dynamic> _$$UserImplToJson(_$UserImpl instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'username': instance.username,
-      'display_name': instance.displayName,
-      'avatar_url': instance.avatarUrl,
-      'lang_tag': instance.langTag,
-      'location': instance.location,
-      'timezone': instance.timezone,
-      'metadata': instance.metadata,
-      'facebook_id': instance.facebookId,
-      'google_id': instance.googleId,
-      'gamecenter_id': instance.gamecenterId,
-      'steam_id': instance.steamId,
-      'online': instance.online,
-      'edge_count': instance.edgeCount,
-      'create_time': instance.createTime?.toIso8601String(),
-      'update_time': instance.updateTime?.toIso8601String(),
-      'facebook_instant_game_id': instance.facebookInstantGameId,
-      'apple_id': instance.appleId,
-    };
+Map<String, dynamic> _$UserToJson(_User instance) => <String, dynamic>{
+  'id': instance.id,
+  'username': instance.username,
+  'display_name': instance.displayName,
+  'avatar_url': instance.avatarUrl,
+  'lang_tag': instance.langTag,
+  'location': instance.location,
+  'timezone': instance.timezone,
+  'metadata': instance.metadata,
+  'facebook_id': instance.facebookId,
+  'google_id': instance.googleId,
+  'gamecenter_id': instance.gamecenterId,
+  'steam_id': instance.steamId,
+  'online': instance.online,
+  'edge_count': instance.edgeCount,
+  'create_time': instance.createTime?.toIso8601String(),
+  'update_time': instance.updateTime?.toIso8601String(),
+  'facebook_instant_game_id': instance.facebookInstantGameId,
+  'apple_id': instance.appleId,
+};

--- a/nakama/lib/src/models/channel_message.dart
+++ b/nakama/lib/src/models/channel_message.dart
@@ -5,7 +5,7 @@ part 'channel_message.freezed.dart';
 part 'channel_message.g.dart';
 
 @freezed
-class ChannelMessage with _$ChannelMessage {
+sealed class ChannelMessage with _$ChannelMessage {
   const ChannelMessage._();
 
   const factory ChannelMessage({
@@ -44,7 +44,7 @@ class ChannelMessage with _$ChannelMessage {
 }
 
 @freezed
-class ChannelMessageList with _$ChannelMessageList {
+sealed class ChannelMessageList with _$ChannelMessageList {
   const ChannelMessageList._();
 
   const factory ChannelMessageList({

--- a/nakama/lib/src/models/channel_message.freezed.dart
+++ b/nakama/lib/src/models/channel_message.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,687 +9,573 @@ part of 'channel_message.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-ChannelMessage _$ChannelMessageFromJson(Map<String, dynamic> json) {
-  return _ChannelMessage.fromJson(json);
-}
 
 /// @nodoc
 mixin _$ChannelMessage {
-  @JsonKey(name: 'channel_id')
-  String get channelId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'message_id')
-  String get messageId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'code')
-  int get code => throw _privateConstructorUsedError;
-  @JsonKey(name: 'sender_id')
-  String get senderId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'username')
-  String get username => throw _privateConstructorUsedError;
-  @JsonKey(name: 'content')
-  String get content => throw _privateConstructorUsedError;
-  @JsonKey(name: 'create_time')
-  DateTime get createTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'update_time')
-  DateTime get updateTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'persistent')
-  bool get persistent => throw _privateConstructorUsedError;
-  @JsonKey(name: 'room_name')
-  String? get roomName => throw _privateConstructorUsedError;
-  @JsonKey(name: 'group_id')
-  String? get groupId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'user_id_one')
-  String? get userIdOne => throw _privateConstructorUsedError;
-  @JsonKey(name: 'user_id_two')
-  String? get userIdTwo => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $ChannelMessageCopyWith<ChannelMessage> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'channel_id') String get channelId;@JsonKey(name: 'message_id') String get messageId;@JsonKey(name: 'code') int get code;@JsonKey(name: 'sender_id') String get senderId;@JsonKey(name: 'username') String get username;@JsonKey(name: 'content') String get content;@JsonKey(name: 'create_time') DateTime get createTime;@JsonKey(name: 'update_time') DateTime get updateTime;@JsonKey(name: 'persistent') bool get persistent;@JsonKey(name: 'room_name') String? get roomName;@JsonKey(name: 'group_id') String? get groupId;@JsonKey(name: 'user_id_one') String? get userIdOne;@JsonKey(name: 'user_id_two') String? get userIdTwo;
+/// Create a copy of ChannelMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChannelMessageCopyWith<ChannelMessage> get copyWith => _$ChannelMessageCopyWithImpl<ChannelMessage>(this as ChannelMessage, _$identity);
+
+  /// Serializes this ChannelMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChannelMessage&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.messageId, messageId) || other.messageId == messageId)&&(identical(other.code, code) || other.code == code)&&(identical(other.senderId, senderId) || other.senderId == senderId)&&(identical(other.username, username) || other.username == username)&&(identical(other.content, content) || other.content == content)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime)&&(identical(other.persistent, persistent) || other.persistent == persistent)&&(identical(other.roomName, roomName) || other.roomName == roomName)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.userIdOne, userIdOne) || other.userIdOne == userIdOne)&&(identical(other.userIdTwo, userIdTwo) || other.userIdTwo == userIdTwo));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,channelId,messageId,code,senderId,username,content,createTime,updateTime,persistent,roomName,groupId,userIdOne,userIdTwo);
+
+@override
+String toString() {
+  return 'ChannelMessage(channelId: $channelId, messageId: $messageId, code: $code, senderId: $senderId, username: $username, content: $content, createTime: $createTime, updateTime: $updateTime, persistent: $persistent, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $ChannelMessageCopyWith<$Res> {
-  factory $ChannelMessageCopyWith(
-          ChannelMessage value, $Res Function(ChannelMessage) then) =
-      _$ChannelMessageCopyWithImpl<$Res, ChannelMessage>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'channel_id') String channelId,
-      @JsonKey(name: 'message_id') String messageId,
-      @JsonKey(name: 'code') int code,
-      @JsonKey(name: 'sender_id') String senderId,
-      @JsonKey(name: 'username') String username,
-      @JsonKey(name: 'content') String content,
-      @JsonKey(name: 'create_time') DateTime createTime,
-      @JsonKey(name: 'update_time') DateTime updateTime,
-      @JsonKey(name: 'persistent') bool persistent,
-      @JsonKey(name: 'room_name') String? roomName,
-      @JsonKey(name: 'group_id') String? groupId,
-      @JsonKey(name: 'user_id_one') String? userIdOne,
-      @JsonKey(name: 'user_id_two') String? userIdTwo});
-}
+abstract mixin class $ChannelMessageCopyWith<$Res>  {
+  factory $ChannelMessageCopyWith(ChannelMessage value, $Res Function(ChannelMessage) _then) = _$ChannelMessageCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'channel_id') String channelId,@JsonKey(name: 'message_id') String messageId,@JsonKey(name: 'code') int code,@JsonKey(name: 'sender_id') String senderId,@JsonKey(name: 'username') String username,@JsonKey(name: 'content') String content,@JsonKey(name: 'create_time') DateTime createTime,@JsonKey(name: 'update_time') DateTime updateTime,@JsonKey(name: 'persistent') bool persistent,@JsonKey(name: 'room_name') String? roomName,@JsonKey(name: 'group_id') String? groupId,@JsonKey(name: 'user_id_one') String? userIdOne,@JsonKey(name: 'user_id_two') String? userIdTwo
+});
 
+
+
+
+}
 /// @nodoc
-class _$ChannelMessageCopyWithImpl<$Res, $Val extends ChannelMessage>
+class _$ChannelMessageCopyWithImpl<$Res>
     implements $ChannelMessageCopyWith<$Res> {
-  _$ChannelMessageCopyWithImpl(this._value, this._then);
+  _$ChannelMessageCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final ChannelMessage _self;
+  final $Res Function(ChannelMessage) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? channelId = null,
-    Object? messageId = null,
-    Object? code = null,
-    Object? senderId = null,
-    Object? username = null,
-    Object? content = null,
-    Object? createTime = null,
-    Object? updateTime = null,
-    Object? persistent = null,
-    Object? roomName = freezed,
-    Object? groupId = freezed,
-    Object? userIdOne = freezed,
-    Object? userIdTwo = freezed,
-  }) {
-    return _then(_value.copyWith(
-      channelId: null == channelId
-          ? _value.channelId
-          : channelId // ignore: cast_nullable_to_non_nullable
-              as String,
-      messageId: null == messageId
-          ? _value.messageId
-          : messageId // ignore: cast_nullable_to_non_nullable
-              as String,
-      code: null == code
-          ? _value.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as int,
-      senderId: null == senderId
-          ? _value.senderId
-          : senderId // ignore: cast_nullable_to_non_nullable
-              as String,
-      username: null == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String,
-      content: null == content
-          ? _value.content
-          : content // ignore: cast_nullable_to_non_nullable
-              as String,
-      createTime: null == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updateTime: null == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      persistent: null == persistent
-          ? _value.persistent
-          : persistent // ignore: cast_nullable_to_non_nullable
-              as bool,
-      roomName: freezed == roomName
-          ? _value.roomName
-          : roomName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      groupId: freezed == groupId
-          ? _value.groupId
-          : groupId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userIdOne: freezed == userIdOne
-          ? _value.userIdOne
-          : userIdOne // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userIdTwo: freezed == userIdTwo
-          ? _value.userIdTwo
-          : userIdTwo // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of ChannelMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? channelId = null,Object? messageId = null,Object? code = null,Object? senderId = null,Object? username = null,Object? content = null,Object? createTime = null,Object? updateTime = null,Object? persistent = null,Object? roomName = freezed,Object? groupId = freezed,Object? userIdOne = freezed,Object? userIdTwo = freezed,}) {
+  return _then(_self.copyWith(
+channelId: null == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String,messageId: null == messageId ? _self.messageId : messageId // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as int,senderId: null == senderId ? _self.senderId : senderId // ignore: cast_nullable_to_non_nullable
+as String,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,content: null == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
+as String,createTime: null == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime,updateTime: null == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime,persistent: null == persistent ? _self.persistent : persistent // ignore: cast_nullable_to_non_nullable
+as bool,roomName: freezed == roomName ? _self.roomName : roomName // ignore: cast_nullable_to_non_nullable
+as String?,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String?,userIdOne: freezed == userIdOne ? _self.userIdOne : userIdOne // ignore: cast_nullable_to_non_nullable
+as String?,userIdTwo: freezed == userIdTwo ? _self.userIdTwo : userIdTwo // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$ChannelMessageImplCopyWith<$Res>
-    implements $ChannelMessageCopyWith<$Res> {
-  factory _$$ChannelMessageImplCopyWith(_$ChannelMessageImpl value,
-          $Res Function(_$ChannelMessageImpl) then) =
-      __$$ChannelMessageImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'channel_id') String channelId,
-      @JsonKey(name: 'message_id') String messageId,
-      @JsonKey(name: 'code') int code,
-      @JsonKey(name: 'sender_id') String senderId,
-      @JsonKey(name: 'username') String username,
-      @JsonKey(name: 'content') String content,
-      @JsonKey(name: 'create_time') DateTime createTime,
-      @JsonKey(name: 'update_time') DateTime updateTime,
-      @JsonKey(name: 'persistent') bool persistent,
-      @JsonKey(name: 'room_name') String? roomName,
-      @JsonKey(name: 'group_id') String? groupId,
-      @JsonKey(name: 'user_id_one') String? userIdOne,
-      @JsonKey(name: 'user_id_two') String? userIdTwo});
 }
 
-/// @nodoc
-class __$$ChannelMessageImplCopyWithImpl<$Res>
-    extends _$ChannelMessageCopyWithImpl<$Res, _$ChannelMessageImpl>
-    implements _$$ChannelMessageImplCopyWith<$Res> {
-  __$$ChannelMessageImplCopyWithImpl(
-      _$ChannelMessageImpl _value, $Res Function(_$ChannelMessageImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? channelId = null,
-    Object? messageId = null,
-    Object? code = null,
-    Object? senderId = null,
-    Object? username = null,
-    Object? content = null,
-    Object? createTime = null,
-    Object? updateTime = null,
-    Object? persistent = null,
-    Object? roomName = freezed,
-    Object? groupId = freezed,
-    Object? userIdOne = freezed,
-    Object? userIdTwo = freezed,
-  }) {
-    return _then(_$ChannelMessageImpl(
-      channelId: null == channelId
-          ? _value.channelId
-          : channelId // ignore: cast_nullable_to_non_nullable
-              as String,
-      messageId: null == messageId
-          ? _value.messageId
-          : messageId // ignore: cast_nullable_to_non_nullable
-              as String,
-      code: null == code
-          ? _value.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as int,
-      senderId: null == senderId
-          ? _value.senderId
-          : senderId // ignore: cast_nullable_to_non_nullable
-              as String,
-      username: null == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String,
-      content: null == content
-          ? _value.content
-          : content // ignore: cast_nullable_to_non_nullable
-              as String,
-      createTime: null == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updateTime: null == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      persistent: null == persistent
-          ? _value.persistent
-          : persistent // ignore: cast_nullable_to_non_nullable
-              as bool,
-      roomName: freezed == roomName
-          ? _value.roomName
-          : roomName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      groupId: freezed == groupId
-          ? _value.groupId
-          : groupId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userIdOne: freezed == userIdOne
-          ? _value.userIdOne
-          : userIdOne // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userIdTwo: freezed == userIdTwo
-          ? _value.userIdTwo
-          : userIdTwo // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [ChannelMessage].
+extension ChannelMessagePatterns on ChannelMessage {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChannelMessage value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChannelMessage() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChannelMessage value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelMessage():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChannelMessage value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelMessage() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'message_id')  String messageId, @JsonKey(name: 'code')  int code, @JsonKey(name: 'sender_id')  String senderId, @JsonKey(name: 'username')  String username, @JsonKey(name: 'content')  String content, @JsonKey(name: 'create_time')  DateTime createTime, @JsonKey(name: 'update_time')  DateTime updateTime, @JsonKey(name: 'persistent')  bool persistent, @JsonKey(name: 'room_name')  String? roomName, @JsonKey(name: 'group_id')  String? groupId, @JsonKey(name: 'user_id_one')  String? userIdOne, @JsonKey(name: 'user_id_two')  String? userIdTwo)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChannelMessage() when $default != null:
+return $default(_that.channelId,_that.messageId,_that.code,_that.senderId,_that.username,_that.content,_that.createTime,_that.updateTime,_that.persistent,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'message_id')  String messageId, @JsonKey(name: 'code')  int code, @JsonKey(name: 'sender_id')  String senderId, @JsonKey(name: 'username')  String username, @JsonKey(name: 'content')  String content, @JsonKey(name: 'create_time')  DateTime createTime, @JsonKey(name: 'update_time')  DateTime updateTime, @JsonKey(name: 'persistent')  bool persistent, @JsonKey(name: 'room_name')  String? roomName, @JsonKey(name: 'group_id')  String? groupId, @JsonKey(name: 'user_id_one')  String? userIdOne, @JsonKey(name: 'user_id_two')  String? userIdTwo)  $default,) {final _that = this;
+switch (_that) {
+case _ChannelMessage():
+return $default(_that.channelId,_that.messageId,_that.code,_that.senderId,_that.username,_that.content,_that.createTime,_that.updateTime,_that.persistent,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'message_id')  String messageId, @JsonKey(name: 'code')  int code, @JsonKey(name: 'sender_id')  String senderId, @JsonKey(name: 'username')  String username, @JsonKey(name: 'content')  String content, @JsonKey(name: 'create_time')  DateTime createTime, @JsonKey(name: 'update_time')  DateTime updateTime, @JsonKey(name: 'persistent')  bool persistent, @JsonKey(name: 'room_name')  String? roomName, @JsonKey(name: 'group_id')  String? groupId, @JsonKey(name: 'user_id_one')  String? userIdOne, @JsonKey(name: 'user_id_two')  String? userIdTwo)?  $default,) {final _that = this;
+switch (_that) {
+case _ChannelMessage() when $default != null:
+return $default(_that.channelId,_that.messageId,_that.code,_that.senderId,_that.username,_that.content,_that.createTime,_that.updateTime,_that.persistent,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$ChannelMessageImpl extends _ChannelMessage {
-  const _$ChannelMessageImpl(
-      {@JsonKey(name: 'channel_id') required this.channelId,
-      @JsonKey(name: 'message_id') required this.messageId,
-      @JsonKey(name: 'code') required this.code,
-      @JsonKey(name: 'sender_id') required this.senderId,
-      @JsonKey(name: 'username') required this.username,
-      @JsonKey(name: 'content') required this.content,
-      @JsonKey(name: 'create_time') required this.createTime,
-      @JsonKey(name: 'update_time') required this.updateTime,
-      @JsonKey(name: 'persistent') required this.persistent,
-      @JsonKey(name: 'room_name') required this.roomName,
-      @JsonKey(name: 'group_id') required this.groupId,
-      @JsonKey(name: 'user_id_one') required this.userIdOne,
-      @JsonKey(name: 'user_id_two') required this.userIdTwo})
-      : super._();
 
-  factory _$ChannelMessageImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ChannelMessageImplFromJson(json);
+class _ChannelMessage extends ChannelMessage {
+  const _ChannelMessage({@JsonKey(name: 'channel_id') required this.channelId, @JsonKey(name: 'message_id') required this.messageId, @JsonKey(name: 'code') required this.code, @JsonKey(name: 'sender_id') required this.senderId, @JsonKey(name: 'username') required this.username, @JsonKey(name: 'content') required this.content, @JsonKey(name: 'create_time') required this.createTime, @JsonKey(name: 'update_time') required this.updateTime, @JsonKey(name: 'persistent') required this.persistent, @JsonKey(name: 'room_name') required this.roomName, @JsonKey(name: 'group_id') required this.groupId, @JsonKey(name: 'user_id_one') required this.userIdOne, @JsonKey(name: 'user_id_two') required this.userIdTwo}): super._();
+  factory _ChannelMessage.fromJson(Map<String, dynamic> json) => _$ChannelMessageFromJson(json);
 
-  @override
-  @JsonKey(name: 'channel_id')
-  final String channelId;
-  @override
-  @JsonKey(name: 'message_id')
-  final String messageId;
-  @override
-  @JsonKey(name: 'code')
-  final int code;
-  @override
-  @JsonKey(name: 'sender_id')
-  final String senderId;
-  @override
-  @JsonKey(name: 'username')
-  final String username;
-  @override
-  @JsonKey(name: 'content')
-  final String content;
-  @override
-  @JsonKey(name: 'create_time')
-  final DateTime createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  final DateTime updateTime;
-  @override
-  @JsonKey(name: 'persistent')
-  final bool persistent;
-  @override
-  @JsonKey(name: 'room_name')
-  final String? roomName;
-  @override
-  @JsonKey(name: 'group_id')
-  final String? groupId;
-  @override
-  @JsonKey(name: 'user_id_one')
-  final String? userIdOne;
-  @override
-  @JsonKey(name: 'user_id_two')
-  final String? userIdTwo;
+@override@JsonKey(name: 'channel_id') final  String channelId;
+@override@JsonKey(name: 'message_id') final  String messageId;
+@override@JsonKey(name: 'code') final  int code;
+@override@JsonKey(name: 'sender_id') final  String senderId;
+@override@JsonKey(name: 'username') final  String username;
+@override@JsonKey(name: 'content') final  String content;
+@override@JsonKey(name: 'create_time') final  DateTime createTime;
+@override@JsonKey(name: 'update_time') final  DateTime updateTime;
+@override@JsonKey(name: 'persistent') final  bool persistent;
+@override@JsonKey(name: 'room_name') final  String? roomName;
+@override@JsonKey(name: 'group_id') final  String? groupId;
+@override@JsonKey(name: 'user_id_one') final  String? userIdOne;
+@override@JsonKey(name: 'user_id_two') final  String? userIdTwo;
 
-  @override
-  String toString() {
-    return 'ChannelMessage(channelId: $channelId, messageId: $messageId, code: $code, senderId: $senderId, username: $username, content: $content, createTime: $createTime, updateTime: $updateTime, persistent: $persistent, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
-  }
+/// Create a copy of ChannelMessage
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChannelMessageCopyWith<_ChannelMessage> get copyWith => __$ChannelMessageCopyWithImpl<_ChannelMessage>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ChannelMessageImpl &&
-            (identical(other.channelId, channelId) ||
-                other.channelId == channelId) &&
-            (identical(other.messageId, messageId) ||
-                other.messageId == messageId) &&
-            (identical(other.code, code) || other.code == code) &&
-            (identical(other.senderId, senderId) ||
-                other.senderId == senderId) &&
-            (identical(other.username, username) ||
-                other.username == username) &&
-            (identical(other.content, content) || other.content == content) &&
-            (identical(other.createTime, createTime) ||
-                other.createTime == createTime) &&
-            (identical(other.updateTime, updateTime) ||
-                other.updateTime == updateTime) &&
-            (identical(other.persistent, persistent) ||
-                other.persistent == persistent) &&
-            (identical(other.roomName, roomName) ||
-                other.roomName == roomName) &&
-            (identical(other.groupId, groupId) || other.groupId == groupId) &&
-            (identical(other.userIdOne, userIdOne) ||
-                other.userIdOne == userIdOne) &&
-            (identical(other.userIdTwo, userIdTwo) ||
-                other.userIdTwo == userIdTwo));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      channelId,
-      messageId,
-      code,
-      senderId,
-      username,
-      content,
-      createTime,
-      updateTime,
-      persistent,
-      roomName,
-      groupId,
-      userIdOne,
-      userIdTwo);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ChannelMessageImplCopyWith<_$ChannelMessageImpl> get copyWith =>
-      __$$ChannelMessageImplCopyWithImpl<_$ChannelMessageImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$ChannelMessageImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$ChannelMessageToJson(this, );
 }
 
-abstract class _ChannelMessage extends ChannelMessage {
-  const factory _ChannelMessage(
-          {@JsonKey(name: 'channel_id') required final String channelId,
-          @JsonKey(name: 'message_id') required final String messageId,
-          @JsonKey(name: 'code') required final int code,
-          @JsonKey(name: 'sender_id') required final String senderId,
-          @JsonKey(name: 'username') required final String username,
-          @JsonKey(name: 'content') required final String content,
-          @JsonKey(name: 'create_time') required final DateTime createTime,
-          @JsonKey(name: 'update_time') required final DateTime updateTime,
-          @JsonKey(name: 'persistent') required final bool persistent,
-          @JsonKey(name: 'room_name') required final String? roomName,
-          @JsonKey(name: 'group_id') required final String? groupId,
-          @JsonKey(name: 'user_id_one') required final String? userIdOne,
-          @JsonKey(name: 'user_id_two') required final String? userIdTwo}) =
-      _$ChannelMessageImpl;
-  const _ChannelMessage._() : super._();
-
-  factory _ChannelMessage.fromJson(Map<String, dynamic> json) =
-      _$ChannelMessageImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'channel_id')
-  String get channelId;
-  @override
-  @JsonKey(name: 'message_id')
-  String get messageId;
-  @override
-  @JsonKey(name: 'code')
-  int get code;
-  @override
-  @JsonKey(name: 'sender_id')
-  String get senderId;
-  @override
-  @JsonKey(name: 'username')
-  String get username;
-  @override
-  @JsonKey(name: 'content')
-  String get content;
-  @override
-  @JsonKey(name: 'create_time')
-  DateTime get createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  DateTime get updateTime;
-  @override
-  @JsonKey(name: 'persistent')
-  bool get persistent;
-  @override
-  @JsonKey(name: 'room_name')
-  String? get roomName;
-  @override
-  @JsonKey(name: 'group_id')
-  String? get groupId;
-  @override
-  @JsonKey(name: 'user_id_one')
-  String? get userIdOne;
-  @override
-  @JsonKey(name: 'user_id_two')
-  String? get userIdTwo;
-  @override
-  @JsonKey(ignore: true)
-  _$$ChannelMessageImplCopyWith<_$ChannelMessageImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChannelMessage&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.messageId, messageId) || other.messageId == messageId)&&(identical(other.code, code) || other.code == code)&&(identical(other.senderId, senderId) || other.senderId == senderId)&&(identical(other.username, username) || other.username == username)&&(identical(other.content, content) || other.content == content)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime)&&(identical(other.persistent, persistent) || other.persistent == persistent)&&(identical(other.roomName, roomName) || other.roomName == roomName)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.userIdOne, userIdOne) || other.userIdOne == userIdOne)&&(identical(other.userIdTwo, userIdTwo) || other.userIdTwo == userIdTwo));
 }
 
-ChannelMessageList _$ChannelMessageListFromJson(Map<String, dynamic> json) {
-  return _ChannelMessageList.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,channelId,messageId,code,senderId,username,content,createTime,updateTime,persistent,roomName,groupId,userIdOne,userIdTwo);
+
+@override
+String toString() {
+  return 'ChannelMessage(channelId: $channelId, messageId: $messageId, code: $code, senderId: $senderId, username: $username, content: $content, createTime: $createTime, updateTime: $updateTime, persistent: $persistent, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChannelMessageCopyWith<$Res> implements $ChannelMessageCopyWith<$Res> {
+  factory _$ChannelMessageCopyWith(_ChannelMessage value, $Res Function(_ChannelMessage) _then) = __$ChannelMessageCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'channel_id') String channelId,@JsonKey(name: 'message_id') String messageId,@JsonKey(name: 'code') int code,@JsonKey(name: 'sender_id') String senderId,@JsonKey(name: 'username') String username,@JsonKey(name: 'content') String content,@JsonKey(name: 'create_time') DateTime createTime,@JsonKey(name: 'update_time') DateTime updateTime,@JsonKey(name: 'persistent') bool persistent,@JsonKey(name: 'room_name') String? roomName,@JsonKey(name: 'group_id') String? groupId,@JsonKey(name: 'user_id_one') String? userIdOne,@JsonKey(name: 'user_id_two') String? userIdTwo
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChannelMessageCopyWithImpl<$Res>
+    implements _$ChannelMessageCopyWith<$Res> {
+  __$ChannelMessageCopyWithImpl(this._self, this._then);
+
+  final _ChannelMessage _self;
+  final $Res Function(_ChannelMessage) _then;
+
+/// Create a copy of ChannelMessage
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? channelId = null,Object? messageId = null,Object? code = null,Object? senderId = null,Object? username = null,Object? content = null,Object? createTime = null,Object? updateTime = null,Object? persistent = null,Object? roomName = freezed,Object? groupId = freezed,Object? userIdOne = freezed,Object? userIdTwo = freezed,}) {
+  return _then(_ChannelMessage(
+channelId: null == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String,messageId: null == messageId ? _self.messageId : messageId // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as int,senderId: null == senderId ? _self.senderId : senderId // ignore: cast_nullable_to_non_nullable
+as String,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,content: null == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
+as String,createTime: null == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime,updateTime: null == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime,persistent: null == persistent ? _self.persistent : persistent // ignore: cast_nullable_to_non_nullable
+as bool,roomName: freezed == roomName ? _self.roomName : roomName // ignore: cast_nullable_to_non_nullable
+as String?,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String?,userIdOne: freezed == userIdOne ? _self.userIdOne : userIdOne // ignore: cast_nullable_to_non_nullable
+as String?,userIdTwo: freezed == userIdTwo ? _self.userIdTwo : userIdTwo // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$ChannelMessageList {
-  @JsonKey(name: 'messages')
-  List<ChannelMessage>? get messages => throw _privateConstructorUsedError;
-  @JsonKey(name: 'next_cursor')
-  String? get nextCursor => throw _privateConstructorUsedError;
-  @JsonKey(name: 'prev_cursor')
-  String? get prevCursor => throw _privateConstructorUsedError;
-  @JsonKey(name: 'cacheable_cursor')
-  String? get cacheableCursor => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $ChannelMessageListCopyWith<ChannelMessageList> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'messages') List<ChannelMessage>? get messages;@JsonKey(name: 'next_cursor') String? get nextCursor;@JsonKey(name: 'prev_cursor') String? get prevCursor;@JsonKey(name: 'cacheable_cursor') String? get cacheableCursor;
+/// Create a copy of ChannelMessageList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChannelMessageListCopyWith<ChannelMessageList> get copyWith => _$ChannelMessageListCopyWithImpl<ChannelMessageList>(this as ChannelMessageList, _$identity);
+
+  /// Serializes this ChannelMessageList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChannelMessageList&&const DeepCollectionEquality().equals(other.messages, messages)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.prevCursor, prevCursor) || other.prevCursor == prevCursor)&&(identical(other.cacheableCursor, cacheableCursor) || other.cacheableCursor == cacheableCursor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(messages),nextCursor,prevCursor,cacheableCursor);
+
+@override
+String toString() {
+  return 'ChannelMessageList(messages: $messages, nextCursor: $nextCursor, prevCursor: $prevCursor, cacheableCursor: $cacheableCursor)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $ChannelMessageListCopyWith<$Res> {
-  factory $ChannelMessageListCopyWith(
-          ChannelMessageList value, $Res Function(ChannelMessageList) then) =
-      _$ChannelMessageListCopyWithImpl<$Res, ChannelMessageList>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'messages') List<ChannelMessage>? messages,
-      @JsonKey(name: 'next_cursor') String? nextCursor,
-      @JsonKey(name: 'prev_cursor') String? prevCursor,
-      @JsonKey(name: 'cacheable_cursor') String? cacheableCursor});
-}
+abstract mixin class $ChannelMessageListCopyWith<$Res>  {
+  factory $ChannelMessageListCopyWith(ChannelMessageList value, $Res Function(ChannelMessageList) _then) = _$ChannelMessageListCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'messages') List<ChannelMessage>? messages,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor,@JsonKey(name: 'cacheable_cursor') String? cacheableCursor
+});
 
+
+
+
+}
 /// @nodoc
-class _$ChannelMessageListCopyWithImpl<$Res, $Val extends ChannelMessageList>
+class _$ChannelMessageListCopyWithImpl<$Res>
     implements $ChannelMessageListCopyWith<$Res> {
-  _$ChannelMessageListCopyWithImpl(this._value, this._then);
+  _$ChannelMessageListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final ChannelMessageList _self;
+  final $Res Function(ChannelMessageList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? messages = freezed,
-    Object? nextCursor = freezed,
-    Object? prevCursor = freezed,
-    Object? cacheableCursor = freezed,
-  }) {
-    return _then(_value.copyWith(
-      messages: freezed == messages
-          ? _value.messages
-          : messages // ignore: cast_nullable_to_non_nullable
-              as List<ChannelMessage>?,
-      nextCursor: freezed == nextCursor
-          ? _value.nextCursor
-          : nextCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      prevCursor: freezed == prevCursor
-          ? _value.prevCursor
-          : prevCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      cacheableCursor: freezed == cacheableCursor
-          ? _value.cacheableCursor
-          : cacheableCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of ChannelMessageList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? messages = freezed,Object? nextCursor = freezed,Object? prevCursor = freezed,Object? cacheableCursor = freezed,}) {
+  return _then(_self.copyWith(
+messages: freezed == messages ? _self.messages : messages // ignore: cast_nullable_to_non_nullable
+as List<ChannelMessage>?,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,prevCursor: freezed == prevCursor ? _self.prevCursor : prevCursor // ignore: cast_nullable_to_non_nullable
+as String?,cacheableCursor: freezed == cacheableCursor ? _self.cacheableCursor : cacheableCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$ChannelMessageListImplCopyWith<$Res>
-    implements $ChannelMessageListCopyWith<$Res> {
-  factory _$$ChannelMessageListImplCopyWith(_$ChannelMessageListImpl value,
-          $Res Function(_$ChannelMessageListImpl) then) =
-      __$$ChannelMessageListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'messages') List<ChannelMessage>? messages,
-      @JsonKey(name: 'next_cursor') String? nextCursor,
-      @JsonKey(name: 'prev_cursor') String? prevCursor,
-      @JsonKey(name: 'cacheable_cursor') String? cacheableCursor});
 }
 
-/// @nodoc
-class __$$ChannelMessageListImplCopyWithImpl<$Res>
-    extends _$ChannelMessageListCopyWithImpl<$Res, _$ChannelMessageListImpl>
-    implements _$$ChannelMessageListImplCopyWith<$Res> {
-  __$$ChannelMessageListImplCopyWithImpl(_$ChannelMessageListImpl _value,
-      $Res Function(_$ChannelMessageListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? messages = freezed,
-    Object? nextCursor = freezed,
-    Object? prevCursor = freezed,
-    Object? cacheableCursor = freezed,
-  }) {
-    return _then(_$ChannelMessageListImpl(
-      messages: freezed == messages
-          ? _value._messages
-          : messages // ignore: cast_nullable_to_non_nullable
-              as List<ChannelMessage>?,
-      nextCursor: freezed == nextCursor
-          ? _value.nextCursor
-          : nextCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      prevCursor: freezed == prevCursor
-          ? _value.prevCursor
-          : prevCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      cacheableCursor: freezed == cacheableCursor
-          ? _value.cacheableCursor
-          : cacheableCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [ChannelMessageList].
+extension ChannelMessageListPatterns on ChannelMessageList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChannelMessageList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChannelMessageList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChannelMessageList value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelMessageList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChannelMessageList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelMessageList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'messages')  List<ChannelMessage>? messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChannelMessageList() when $default != null:
+return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheableCursor);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'messages')  List<ChannelMessage>? messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)  $default,) {final _that = this;
+switch (_that) {
+case _ChannelMessageList():
+return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheableCursor);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'messages')  List<ChannelMessage>? messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)?  $default,) {final _that = this;
+switch (_that) {
+case _ChannelMessageList() when $default != null:
+return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheableCursor);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$ChannelMessageListImpl extends _ChannelMessageList {
-  const _$ChannelMessageListImpl(
-      {@JsonKey(name: 'messages') required final List<ChannelMessage>? messages,
-      @JsonKey(name: 'next_cursor') required this.nextCursor,
-      @JsonKey(name: 'prev_cursor') required this.prevCursor,
-      @JsonKey(name: 'cacheable_cursor') required this.cacheableCursor})
-      : _messages = messages,
-        super._();
 
-  factory _$ChannelMessageListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ChannelMessageListImplFromJson(json);
+class _ChannelMessageList extends ChannelMessageList {
+  const _ChannelMessageList({@JsonKey(name: 'messages') required final  List<ChannelMessage>? messages, @JsonKey(name: 'next_cursor') required this.nextCursor, @JsonKey(name: 'prev_cursor') required this.prevCursor, @JsonKey(name: 'cacheable_cursor') required this.cacheableCursor}): _messages = messages,super._();
+  factory _ChannelMessageList.fromJson(Map<String, dynamic> json) => _$ChannelMessageListFromJson(json);
 
-  final List<ChannelMessage>? _messages;
-  @override
-  @JsonKey(name: 'messages')
-  List<ChannelMessage>? get messages {
-    final value = _messages;
-    if (value == null) return null;
-    if (_messages is EqualUnmodifiableListView) return _messages;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  @JsonKey(name: 'next_cursor')
-  final String? nextCursor;
-  @override
-  @JsonKey(name: 'prev_cursor')
-  final String? prevCursor;
-  @override
-  @JsonKey(name: 'cacheable_cursor')
-  final String? cacheableCursor;
-
-  @override
-  String toString() {
-    return 'ChannelMessageList(messages: $messages, nextCursor: $nextCursor, prevCursor: $prevCursor, cacheableCursor: $cacheableCursor)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ChannelMessageListImpl &&
-            const DeepCollectionEquality().equals(other._messages, _messages) &&
-            (identical(other.nextCursor, nextCursor) ||
-                other.nextCursor == nextCursor) &&
-            (identical(other.prevCursor, prevCursor) ||
-                other.prevCursor == prevCursor) &&
-            (identical(other.cacheableCursor, cacheableCursor) ||
-                other.cacheableCursor == cacheableCursor));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(_messages),
-      nextCursor,
-      prevCursor,
-      cacheableCursor);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ChannelMessageListImplCopyWith<_$ChannelMessageListImpl> get copyWith =>
-      __$$ChannelMessageListImplCopyWithImpl<_$ChannelMessageListImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$ChannelMessageListImplToJson(
-      this,
-    );
-  }
+ final  List<ChannelMessage>? _messages;
+@override@JsonKey(name: 'messages') List<ChannelMessage>? get messages {
+  final value = _messages;
+  if (value == null) return null;
+  if (_messages is EqualUnmodifiableListView) return _messages;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _ChannelMessageList extends ChannelMessageList {
-  const factory _ChannelMessageList(
-      {@JsonKey(name: 'messages') required final List<ChannelMessage>? messages,
-      @JsonKey(name: 'next_cursor') required final String? nextCursor,
-      @JsonKey(name: 'prev_cursor') required final String? prevCursor,
-      @JsonKey(name: 'cacheable_cursor')
-      required final String? cacheableCursor}) = _$ChannelMessageListImpl;
-  const _ChannelMessageList._() : super._();
+@override@JsonKey(name: 'next_cursor') final  String? nextCursor;
+@override@JsonKey(name: 'prev_cursor') final  String? prevCursor;
+@override@JsonKey(name: 'cacheable_cursor') final  String? cacheableCursor;
 
-  factory _ChannelMessageList.fromJson(Map<String, dynamic> json) =
-      _$ChannelMessageListImpl.fromJson;
+/// Create a copy of ChannelMessageList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChannelMessageListCopyWith<_ChannelMessageList> get copyWith => __$ChannelMessageListCopyWithImpl<_ChannelMessageList>(this, _$identity);
 
-  @override
-  @JsonKey(name: 'messages')
-  List<ChannelMessage>? get messages;
-  @override
-  @JsonKey(name: 'next_cursor')
-  String? get nextCursor;
-  @override
-  @JsonKey(name: 'prev_cursor')
-  String? get prevCursor;
-  @override
-  @JsonKey(name: 'cacheable_cursor')
-  String? get cacheableCursor;
-  @override
-  @JsonKey(ignore: true)
-  _$$ChannelMessageListImplCopyWith<_$ChannelMessageListImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$ChannelMessageListToJson(this, );
 }
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChannelMessageList&&const DeepCollectionEquality().equals(other._messages, _messages)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.prevCursor, prevCursor) || other.prevCursor == prevCursor)&&(identical(other.cacheableCursor, cacheableCursor) || other.cacheableCursor == cacheableCursor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_messages),nextCursor,prevCursor,cacheableCursor);
+
+@override
+String toString() {
+  return 'ChannelMessageList(messages: $messages, nextCursor: $nextCursor, prevCursor: $prevCursor, cacheableCursor: $cacheableCursor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChannelMessageListCopyWith<$Res> implements $ChannelMessageListCopyWith<$Res> {
+  factory _$ChannelMessageListCopyWith(_ChannelMessageList value, $Res Function(_ChannelMessageList) _then) = __$ChannelMessageListCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'messages') List<ChannelMessage>? messages,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor,@JsonKey(name: 'cacheable_cursor') String? cacheableCursor
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChannelMessageListCopyWithImpl<$Res>
+    implements _$ChannelMessageListCopyWith<$Res> {
+  __$ChannelMessageListCopyWithImpl(this._self, this._then);
+
+  final _ChannelMessageList _self;
+  final $Res Function(_ChannelMessageList) _then;
+
+/// Create a copy of ChannelMessageList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? messages = freezed,Object? nextCursor = freezed,Object? prevCursor = freezed,Object? cacheableCursor = freezed,}) {
+  return _then(_ChannelMessageList(
+messages: freezed == messages ? _self._messages : messages // ignore: cast_nullable_to_non_nullable
+as List<ChannelMessage>?,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,prevCursor: freezed == prevCursor ? _self.prevCursor : prevCursor // ignore: cast_nullable_to_non_nullable
+as String?,cacheableCursor: freezed == cacheableCursor ? _self.cacheableCursor : cacheableCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/nakama/lib/src/models/channel_message.g.dart
+++ b/nakama/lib/src/models/channel_message.g.dart
@@ -6,11 +6,11 @@ part of 'channel_message.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$ChannelMessageImpl _$$ChannelMessageImplFromJson(Map<String, dynamic> json) =>
-    _$ChannelMessageImpl(
+_ChannelMessage _$ChannelMessageFromJson(Map<String, dynamic> json) =>
+    _ChannelMessage(
       channelId: json['channel_id'] as String,
       messageId: json['message_id'] as String,
-      code: json['code'] as int,
+      code: (json['code'] as num).toInt(),
       senderId: json['sender_id'] as String,
       username: json['username'] as String,
       content: json['content'] as String,
@@ -23,8 +23,7 @@ _$ChannelMessageImpl _$$ChannelMessageImplFromJson(Map<String, dynamic> json) =>
       userIdTwo: json['user_id_two'] as String?,
     );
 
-Map<String, dynamic> _$$ChannelMessageImplToJson(
-        _$ChannelMessageImpl instance) =>
+Map<String, dynamic> _$ChannelMessageToJson(_ChannelMessage instance) =>
     <String, dynamic>{
       'channel_id': instance.channelId,
       'message_id': instance.messageId,
@@ -41,9 +40,8 @@ Map<String, dynamic> _$$ChannelMessageImplToJson(
       'user_id_two': instance.userIdTwo,
     };
 
-_$ChannelMessageListImpl _$$ChannelMessageListImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ChannelMessageListImpl(
+_ChannelMessageList _$ChannelMessageListFromJson(Map<String, dynamic> json) =>
+    _ChannelMessageList(
       messages: (json['messages'] as List<dynamic>?)
           ?.map((e) => ChannelMessage.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -52,8 +50,7 @@ _$ChannelMessageListImpl _$$ChannelMessageListImplFromJson(
       cacheableCursor: json['cacheable_cursor'] as String?,
     );
 
-Map<String, dynamic> _$$ChannelMessageListImplToJson(
-        _$ChannelMessageListImpl instance) =>
+Map<String, dynamic> _$ChannelMessageListToJson(_ChannelMessageList instance) =>
     <String, dynamic>{
       'messages': instance.messages,
       'next_cursor': instance.nextCursor,

--- a/nakama/lib/src/models/chat.dart
+++ b/nakama/lib/src/models/chat.dart
@@ -5,7 +5,7 @@ import 'package:nakama/src/api/rtapi.dart' as rtpb;
 part 'chat.freezed.dart';
 
 @freezed
-class Channel with _$Channel {
+sealed class Channel with _$Channel {
   const Channel._();
 
   const factory Channel({
@@ -47,7 +47,7 @@ class Channel with _$Channel {
 }
 
 @freezed
-class ChannelMessageAck with _$ChannelMessageAck {
+sealed class ChannelMessageAck with _$ChannelMessageAck {
   const ChannelMessageAck._();
 
   /// A receipt reply from a channel message send operation.

--- a/nakama/lib/src/models/chat.freezed.dart
+++ b/nakama/lib/src/models/chat.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,795 +9,625 @@ part of 'chat.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
 /// @nodoc
 mixin _$Channel {
-  /// The ID of the channel.
-  @JsonKey(name: 'id')
-  String get id => throw _privateConstructorUsedError;
 
-  /// The users currently in the channel.
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences => throw _privateConstructorUsedError;
+/// The ID of the channel.
+@JsonKey(name: 'id') String get id;/// The users currently in the channel.
+@JsonKey(name: 'presences') List<UserPresence> get presences;/// A reference to the current user's presence in the channel.
+@JsonKey(name: 'self') UserPresence get self;/// The name of the chat room, or an empty string if this message was not
+/// sent through a chat room.
+@JsonKey(name: 'room_name') String get roomName;/// The ID of the group, or an empty string if this message was not sent
+/// through a group channel.
+@JsonKey(name: 'group_id') String get groupId;/// The ID of the first DM user, or an empty string if this message was not
+/// sent through a DM chat.
+@JsonKey(name: 'user_id_one') String get userIdOne;/// The ID of the second DM user, or an empty string if this message was not
+/// sent through a DM chat.
+@JsonKey(name: 'user_id_two') String get userIdTwo;
+/// Create a copy of Channel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChannelCopyWith<Channel> get copyWith => _$ChannelCopyWithImpl<Channel>(this as Channel, _$identity);
 
-  /// A reference to the current user's presence in the channel.
-  @JsonKey(name: 'self')
-  UserPresence get self => throw _privateConstructorUsedError;
 
-  /// The name of the chat room, or an empty string if this message was not
-  /// sent through a chat room.
-  @JsonKey(name: 'room_name')
-  String get roomName => throw _privateConstructorUsedError;
 
-  /// The ID of the group, or an empty string if this message was not sent
-  /// through a group channel.
-  @JsonKey(name: 'group_id')
-  String get groupId => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Channel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.presences, presences)&&(identical(other.self, self) || other.self == self)&&(identical(other.roomName, roomName) || other.roomName == roomName)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.userIdOne, userIdOne) || other.userIdOne == userIdOne)&&(identical(other.userIdTwo, userIdTwo) || other.userIdTwo == userIdTwo));
+}
 
-  /// The ID of the first DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @JsonKey(name: 'user_id_one')
-  String get userIdOne => throw _privateConstructorUsedError;
 
-  /// The ID of the second DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @JsonKey(name: 'user_id_two')
-  String get userIdTwo => throw _privateConstructorUsedError;
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(presences),self,roomName,groupId,userIdOne,userIdTwo);
 
-  @JsonKey(ignore: true)
-  $ChannelCopyWith<Channel> get copyWith => throw _privateConstructorUsedError;
+@override
+String toString() {
+  return 'Channel(id: $id, presences: $presences, self: $self, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $ChannelCopyWith<$Res> {
-  factory $ChannelCopyWith(Channel value, $Res Function(Channel) then) =
-      _$ChannelCopyWithImpl<$Res, Channel>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'id') String id,
-      @JsonKey(name: 'presences') List<UserPresence> presences,
-      @JsonKey(name: 'self') UserPresence self,
-      @JsonKey(name: 'room_name') String roomName,
-      @JsonKey(name: 'group_id') String groupId,
-      @JsonKey(name: 'user_id_one') String userIdOne,
-      @JsonKey(name: 'user_id_two') String userIdTwo});
+abstract mixin class $ChannelCopyWith<$Res>  {
+  factory $ChannelCopyWith(Channel value, $Res Function(Channel) _then) = _$ChannelCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'id') String id,@JsonKey(name: 'presences') List<UserPresence> presences,@JsonKey(name: 'self') UserPresence self,@JsonKey(name: 'room_name') String roomName,@JsonKey(name: 'group_id') String groupId,@JsonKey(name: 'user_id_one') String userIdOne,@JsonKey(name: 'user_id_two') String userIdTwo
+});
 
-  $UserPresenceCopyWith<$Res> get self;
+
+$UserPresenceCopyWith<$Res> get self;
+
 }
-
 /// @nodoc
-class _$ChannelCopyWithImpl<$Res, $Val extends Channel>
+class _$ChannelCopyWithImpl<$Res>
     implements $ChannelCopyWith<$Res> {
-  _$ChannelCopyWithImpl(this._value, this._then);
+  _$ChannelCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Channel _self;
+  final $Res Function(Channel) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? presences = null,
-    Object? self = null,
-    Object? roomName = null,
-    Object? groupId = null,
-    Object? userIdOne = null,
-    Object? userIdTwo = null,
-  }) {
-    return _then(_value.copyWith(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      presences: null == presences
-          ? _value.presences
-          : presences // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-      self: null == self
-          ? _value.self
-          : self // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      roomName: null == roomName
-          ? _value.roomName
-          : roomName // ignore: cast_nullable_to_non_nullable
-              as String,
-      groupId: null == groupId
-          ? _value.groupId
-          : groupId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userIdOne: null == userIdOne
-          ? _value.userIdOne
-          : userIdOne // ignore: cast_nullable_to_non_nullable
-              as String,
-      userIdTwo: null == userIdTwo
-          ? _value.userIdTwo
-          : userIdTwo // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
+/// Create a copy of Channel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? presences = null,Object? self = null,Object? roomName = null,Object? groupId = null,Object? userIdOne = null,Object? userIdTwo = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,presences: null == presences ? _self.presences : presences // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,self: null == self ? _self.self : self // ignore: cast_nullable_to_non_nullable
+as UserPresence,roomName: null == roomName ? _self.roomName : roomName // ignore: cast_nullable_to_non_nullable
+as String,groupId: null == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String,userIdOne: null == userIdOne ? _self.userIdOne : userIdOne // ignore: cast_nullable_to_non_nullable
+as String,userIdTwo: null == userIdTwo ? _self.userIdTwo : userIdTwo // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+/// Create a copy of Channel
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get self {
+  
+  return $UserPresenceCopyWith<$Res>(_self.self, (value) {
+    return _then(_self.copyWith(self: value));
+  });
+}
+}
 
-  @override
-  @pragma('vm:prefer-inline')
-  $UserPresenceCopyWith<$Res> get self {
-    return $UserPresenceCopyWith<$Res>(_value.self, (value) {
-      return _then(_value.copyWith(self: value) as $Val);
-    });
-  }
+
+/// Adds pattern-matching-related methods to [Channel].
+extension ChannelPatterns on Channel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Channel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Channel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Channel value)  $default,){
+final _that = this;
+switch (_that) {
+case _Channel():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Channel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Channel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'presences')  List<UserPresence> presences, @JsonKey(name: 'self')  UserPresence self, @JsonKey(name: 'room_name')  String roomName, @JsonKey(name: 'group_id')  String groupId, @JsonKey(name: 'user_id_one')  String userIdOne, @JsonKey(name: 'user_id_two')  String userIdTwo)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Channel() when $default != null:
+return $default(_that.id,_that.presences,_that.self,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'presences')  List<UserPresence> presences, @JsonKey(name: 'self')  UserPresence self, @JsonKey(name: 'room_name')  String roomName, @JsonKey(name: 'group_id')  String groupId, @JsonKey(name: 'user_id_one')  String userIdOne, @JsonKey(name: 'user_id_two')  String userIdTwo)  $default,) {final _that = this;
+switch (_that) {
+case _Channel():
+return $default(_that.id,_that.presences,_that.self,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'presences')  List<UserPresence> presences, @JsonKey(name: 'self')  UserPresence self, @JsonKey(name: 'room_name')  String roomName, @JsonKey(name: 'group_id')  String groupId, @JsonKey(name: 'user_id_one')  String userIdOne, @JsonKey(name: 'user_id_two')  String userIdTwo)?  $default,) {final _that = this;
+switch (_that) {
+case _Channel() when $default != null:
+return $default(_that.id,_that.presences,_that.self,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$ChannelImplCopyWith<$Res> implements $ChannelCopyWith<$Res> {
-  factory _$$ChannelImplCopyWith(
-          _$ChannelImpl value, $Res Function(_$ChannelImpl) then) =
-      __$$ChannelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'id') String id,
-      @JsonKey(name: 'presences') List<UserPresence> presences,
-      @JsonKey(name: 'self') UserPresence self,
-      @JsonKey(name: 'room_name') String roomName,
-      @JsonKey(name: 'group_id') String groupId,
-      @JsonKey(name: 'user_id_one') String userIdOne,
-      @JsonKey(name: 'user_id_two') String userIdTwo});
 
-  @override
-  $UserPresenceCopyWith<$Res> get self;
+
+class _Channel extends Channel {
+  const _Channel({@JsonKey(name: 'id') required this.id, @JsonKey(name: 'presences') required final  List<UserPresence> presences, @JsonKey(name: 'self') required this.self, @JsonKey(name: 'room_name') required this.roomName, @JsonKey(name: 'group_id') required this.groupId, @JsonKey(name: 'user_id_one') required this.userIdOne, @JsonKey(name: 'user_id_two') required this.userIdTwo}): _presences = presences,super._();
+  
+
+/// The ID of the channel.
+@override@JsonKey(name: 'id') final  String id;
+/// The users currently in the channel.
+ final  List<UserPresence> _presences;
+/// The users currently in the channel.
+@override@JsonKey(name: 'presences') List<UserPresence> get presences {
+  if (_presences is EqualUnmodifiableListView) return _presences;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_presences);
+}
+
+/// A reference to the current user's presence in the channel.
+@override@JsonKey(name: 'self') final  UserPresence self;
+/// The name of the chat room, or an empty string if this message was not
+/// sent through a chat room.
+@override@JsonKey(name: 'room_name') final  String roomName;
+/// The ID of the group, or an empty string if this message was not sent
+/// through a group channel.
+@override@JsonKey(name: 'group_id') final  String groupId;
+/// The ID of the first DM user, or an empty string if this message was not
+/// sent through a DM chat.
+@override@JsonKey(name: 'user_id_one') final  String userIdOne;
+/// The ID of the second DM user, or an empty string if this message was not
+/// sent through a DM chat.
+@override@JsonKey(name: 'user_id_two') final  String userIdTwo;
+
+/// Create a copy of Channel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChannelCopyWith<_Channel> get copyWith => __$ChannelCopyWithImpl<_Channel>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Channel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._presences, _presences)&&(identical(other.self, self) || other.self == self)&&(identical(other.roomName, roomName) || other.roomName == roomName)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.userIdOne, userIdOne) || other.userIdOne == userIdOne)&&(identical(other.userIdTwo, userIdTwo) || other.userIdTwo == userIdTwo));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_presences),self,roomName,groupId,userIdOne,userIdTwo);
+
+@override
+String toString() {
+  return 'Channel(id: $id, presences: $presences, self: $self, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
+}
+
+
 }
 
 /// @nodoc
-class __$$ChannelImplCopyWithImpl<$Res>
-    extends _$ChannelCopyWithImpl<$Res, _$ChannelImpl>
-    implements _$$ChannelImplCopyWith<$Res> {
-  __$$ChannelImplCopyWithImpl(
-      _$ChannelImpl _value, $Res Function(_$ChannelImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$ChannelCopyWith<$Res> implements $ChannelCopyWith<$Res> {
+  factory _$ChannelCopyWith(_Channel value, $Res Function(_Channel) _then) = __$ChannelCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'id') String id,@JsonKey(name: 'presences') List<UserPresence> presences,@JsonKey(name: 'self') UserPresence self,@JsonKey(name: 'room_name') String roomName,@JsonKey(name: 'group_id') String groupId,@JsonKey(name: 'user_id_one') String userIdOne,@JsonKey(name: 'user_id_two') String userIdTwo
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? presences = null,
-    Object? self = null,
-    Object? roomName = null,
-    Object? groupId = null,
-    Object? userIdOne = null,
-    Object? userIdTwo = null,
-  }) {
-    return _then(_$ChannelImpl(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      presences: null == presences
-          ? _value._presences
-          : presences // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-      self: null == self
-          ? _value.self
-          : self // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      roomName: null == roomName
-          ? _value.roomName
-          : roomName // ignore: cast_nullable_to_non_nullable
-              as String,
-      groupId: null == groupId
-          ? _value.groupId
-          : groupId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userIdOne: null == userIdOne
-          ? _value.userIdOne
-          : userIdOne // ignore: cast_nullable_to_non_nullable
-              as String,
-      userIdTwo: null == userIdTwo
-          ? _value.userIdTwo
-          : userIdTwo // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+
+@override $UserPresenceCopyWith<$Res> get self;
+
 }
-
 /// @nodoc
+class __$ChannelCopyWithImpl<$Res>
+    implements _$ChannelCopyWith<$Res> {
+  __$ChannelCopyWithImpl(this._self, this._then);
 
-class _$ChannelImpl extends _Channel {
-  const _$ChannelImpl(
-      {@JsonKey(name: 'id') required this.id,
-      @JsonKey(name: 'presences') required final List<UserPresence> presences,
-      @JsonKey(name: 'self') required this.self,
-      @JsonKey(name: 'room_name') required this.roomName,
-      @JsonKey(name: 'group_id') required this.groupId,
-      @JsonKey(name: 'user_id_one') required this.userIdOne,
-      @JsonKey(name: 'user_id_two') required this.userIdTwo})
-      : _presences = presences,
-        super._();
+  final _Channel _self;
+  final $Res Function(_Channel) _then;
 
-  /// The ID of the channel.
-  @override
-  @JsonKey(name: 'id')
-  final String id;
-
-  /// The users currently in the channel.
-  final List<UserPresence> _presences;
-
-  /// The users currently in the channel.
-  @override
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences {
-    if (_presences is EqualUnmodifiableListView) return _presences;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_presences);
-  }
-
-  /// A reference to the current user's presence in the channel.
-  @override
-  @JsonKey(name: 'self')
-  final UserPresence self;
-
-  /// The name of the chat room, or an empty string if this message was not
-  /// sent through a chat room.
-  @override
-  @JsonKey(name: 'room_name')
-  final String roomName;
-
-  /// The ID of the group, or an empty string if this message was not sent
-  /// through a group channel.
-  @override
-  @JsonKey(name: 'group_id')
-  final String groupId;
-
-  /// The ID of the first DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @override
-  @JsonKey(name: 'user_id_one')
-  final String userIdOne;
-
-  /// The ID of the second DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @override
-  @JsonKey(name: 'user_id_two')
-  final String userIdTwo;
-
-  @override
-  String toString() {
-    return 'Channel(id: $id, presences: $presences, self: $self, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ChannelImpl &&
-            (identical(other.id, id) || other.id == id) &&
-            const DeepCollectionEquality()
-                .equals(other._presences, _presences) &&
-            (identical(other.self, self) || other.self == self) &&
-            (identical(other.roomName, roomName) ||
-                other.roomName == roomName) &&
-            (identical(other.groupId, groupId) || other.groupId == groupId) &&
-            (identical(other.userIdOne, userIdOne) ||
-                other.userIdOne == userIdOne) &&
-            (identical(other.userIdTwo, userIdTwo) ||
-                other.userIdTwo == userIdTwo));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      const DeepCollectionEquality().hash(_presences),
-      self,
-      roomName,
-      groupId,
-      userIdOne,
-      userIdTwo);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ChannelImplCopyWith<_$ChannelImpl> get copyWith =>
-      __$$ChannelImplCopyWithImpl<_$ChannelImpl>(this, _$identity);
+/// Create a copy of Channel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? presences = null,Object? self = null,Object? roomName = null,Object? groupId = null,Object? userIdOne = null,Object? userIdTwo = null,}) {
+  return _then(_Channel(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,presences: null == presences ? _self._presences : presences // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,self: null == self ? _self.self : self // ignore: cast_nullable_to_non_nullable
+as UserPresence,roomName: null == roomName ? _self.roomName : roomName // ignore: cast_nullable_to_non_nullable
+as String,groupId: null == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String,userIdOne: null == userIdOne ? _self.userIdOne : userIdOne // ignore: cast_nullable_to_non_nullable
+as String,userIdTwo: null == userIdTwo ? _self.userIdTwo : userIdTwo // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
 
-abstract class _Channel extends Channel {
-  const factory _Channel(
-      {@JsonKey(name: 'id') required final String id,
-      @JsonKey(name: 'presences') required final List<UserPresence> presences,
-      @JsonKey(name: 'self') required final UserPresence self,
-      @JsonKey(name: 'room_name') required final String roomName,
-      @JsonKey(name: 'group_id') required final String groupId,
-      @JsonKey(name: 'user_id_one') required final String userIdOne,
-      @JsonKey(name: 'user_id_two')
-      required final String userIdTwo}) = _$ChannelImpl;
-  const _Channel._() : super._();
-
-  @override
-
-  /// The ID of the channel.
-  @JsonKey(name: 'id')
-  String get id;
-  @override
-
-  /// The users currently in the channel.
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences;
-  @override
-
-  /// A reference to the current user's presence in the channel.
-  @JsonKey(name: 'self')
-  UserPresence get self;
-  @override
-
-  /// The name of the chat room, or an empty string if this message was not
-  /// sent through a chat room.
-  @JsonKey(name: 'room_name')
-  String get roomName;
-  @override
-
-  /// The ID of the group, or an empty string if this message was not sent
-  /// through a group channel.
-  @JsonKey(name: 'group_id')
-  String get groupId;
-  @override
-
-  /// The ID of the first DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @JsonKey(name: 'user_id_one')
-  String get userIdOne;
-  @override
-
-  /// The ID of the second DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @JsonKey(name: 'user_id_two')
-  String get userIdTwo;
-  @override
-  @JsonKey(ignore: true)
-  _$$ChannelImplCopyWith<_$ChannelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+/// Create a copy of Channel
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get self {
+  
+  return $UserPresenceCopyWith<$Res>(_self.self, (value) {
+    return _then(_self.copyWith(self: value));
+  });
+}
 }
 
 /// @nodoc
 mixin _$ChannelMessageAck {
-  /// The channel the message was sent to.
-  @JsonKey(name: 'channel_id')
-  String get channelId => throw _privateConstructorUsedError;
 
-  /// The unique ID assigned to the message.
-  @JsonKey(name: 'message_id')
-  String get messageId => throw _privateConstructorUsedError;
+/// The channel the message was sent to.
+@JsonKey(name: 'channel_id') String get channelId;/// The unique ID assigned to the message.
+@JsonKey(name: 'message_id') String get messageId;/// The code representing a message type or category.
+@JsonKey(name: 'code') int get code;/// Username of the message sender.
+@JsonKey(name: 'username') String get username;/// The UNIX time when the message was created.
+@JsonKey(name: 'created') DateTime get created;/// The UNIX time when the message was last updated.
+@JsonKey(name: 'updated') DateTime get updated;/// True if the message was persisted to the channel's history, false otherwise.
+@JsonKey(name: 'persistent') bool get persistent;/// The name of the chat room, or an empty string if this message was not sent through a chat room.
+@JsonKey(name: 'room_name') String get roomName;/// The ID of the group, or an empty string if this message was not sent through a group channel.
+@JsonKey(name: 'group_id') String get groupId;/// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
+@JsonKey(name: 'user_id_one') String get userIdOne;/// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
+@JsonKey(name: 'user_id_two') String get userIdTwo;
+/// Create a copy of ChannelMessageAck
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChannelMessageAckCopyWith<ChannelMessageAck> get copyWith => _$ChannelMessageAckCopyWithImpl<ChannelMessageAck>(this as ChannelMessageAck, _$identity);
 
-  /// The code representing a message type or category.
-  @JsonKey(name: 'code')
-  int get code => throw _privateConstructorUsedError;
 
-  /// Username of the message sender.
-  @JsonKey(name: 'username')
-  String get username => throw _privateConstructorUsedError;
 
-  /// The UNIX time when the message was created.
-  @JsonKey(name: 'created')
-  DateTime get created => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChannelMessageAck&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.messageId, messageId) || other.messageId == messageId)&&(identical(other.code, code) || other.code == code)&&(identical(other.username, username) || other.username == username)&&(identical(other.created, created) || other.created == created)&&(identical(other.updated, updated) || other.updated == updated)&&(identical(other.persistent, persistent) || other.persistent == persistent)&&(identical(other.roomName, roomName) || other.roomName == roomName)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.userIdOne, userIdOne) || other.userIdOne == userIdOne)&&(identical(other.userIdTwo, userIdTwo) || other.userIdTwo == userIdTwo));
+}
 
-  /// The UNIX time when the message was last updated.
-  @JsonKey(name: 'updated')
-  DateTime get updated => throw _privateConstructorUsedError;
 
-  /// True if the message was persisted to the channel's history, false otherwise.
-  @JsonKey(name: 'persistent')
-  bool get persistent => throw _privateConstructorUsedError;
+@override
+int get hashCode => Object.hash(runtimeType,channelId,messageId,code,username,created,updated,persistent,roomName,groupId,userIdOne,userIdTwo);
 
-  /// The name of the chat room, or an empty string if this message was not sent through a chat room.
-  @JsonKey(name: 'room_name')
-  String get roomName => throw _privateConstructorUsedError;
+@override
+String toString() {
+  return 'ChannelMessageAck(channelId: $channelId, messageId: $messageId, code: $code, username: $username, created: $created, updated: $updated, persistent: $persistent, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
+}
 
-  /// The ID of the group, or an empty string if this message was not sent through a group channel.
-  @JsonKey(name: 'group_id')
-  String get groupId => throw _privateConstructorUsedError;
 
-  /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
-  @JsonKey(name: 'user_id_one')
-  String get userIdOne => throw _privateConstructorUsedError;
-
-  /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
-  @JsonKey(name: 'user_id_two')
-  String get userIdTwo => throw _privateConstructorUsedError;
-
-  @JsonKey(ignore: true)
-  $ChannelMessageAckCopyWith<ChannelMessageAck> get copyWith =>
-      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $ChannelMessageAckCopyWith<$Res> {
-  factory $ChannelMessageAckCopyWith(
-          ChannelMessageAck value, $Res Function(ChannelMessageAck) then) =
-      _$ChannelMessageAckCopyWithImpl<$Res, ChannelMessageAck>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'channel_id') String channelId,
-      @JsonKey(name: 'message_id') String messageId,
-      @JsonKey(name: 'code') int code,
-      @JsonKey(name: 'username') String username,
-      @JsonKey(name: 'created') DateTime created,
-      @JsonKey(name: 'updated') DateTime updated,
-      @JsonKey(name: 'persistent') bool persistent,
-      @JsonKey(name: 'room_name') String roomName,
-      @JsonKey(name: 'group_id') String groupId,
-      @JsonKey(name: 'user_id_one') String userIdOne,
-      @JsonKey(name: 'user_id_two') String userIdTwo});
-}
+abstract mixin class $ChannelMessageAckCopyWith<$Res>  {
+  factory $ChannelMessageAckCopyWith(ChannelMessageAck value, $Res Function(ChannelMessageAck) _then) = _$ChannelMessageAckCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'channel_id') String channelId,@JsonKey(name: 'message_id') String messageId,@JsonKey(name: 'code') int code,@JsonKey(name: 'username') String username,@JsonKey(name: 'created') DateTime created,@JsonKey(name: 'updated') DateTime updated,@JsonKey(name: 'persistent') bool persistent,@JsonKey(name: 'room_name') String roomName,@JsonKey(name: 'group_id') String groupId,@JsonKey(name: 'user_id_one') String userIdOne,@JsonKey(name: 'user_id_two') String userIdTwo
+});
 
+
+
+
+}
 /// @nodoc
-class _$ChannelMessageAckCopyWithImpl<$Res, $Val extends ChannelMessageAck>
+class _$ChannelMessageAckCopyWithImpl<$Res>
     implements $ChannelMessageAckCopyWith<$Res> {
-  _$ChannelMessageAckCopyWithImpl(this._value, this._then);
+  _$ChannelMessageAckCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final ChannelMessageAck _self;
+  final $Res Function(ChannelMessageAck) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? channelId = null,
-    Object? messageId = null,
-    Object? code = null,
-    Object? username = null,
-    Object? created = null,
-    Object? updated = null,
-    Object? persistent = null,
-    Object? roomName = null,
-    Object? groupId = null,
-    Object? userIdOne = null,
-    Object? userIdTwo = null,
-  }) {
-    return _then(_value.copyWith(
-      channelId: null == channelId
-          ? _value.channelId
-          : channelId // ignore: cast_nullable_to_non_nullable
-              as String,
-      messageId: null == messageId
-          ? _value.messageId
-          : messageId // ignore: cast_nullable_to_non_nullable
-              as String,
-      code: null == code
-          ? _value.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as int,
-      username: null == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String,
-      created: null == created
-          ? _value.created
-          : created // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updated: null == updated
-          ? _value.updated
-          : updated // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      persistent: null == persistent
-          ? _value.persistent
-          : persistent // ignore: cast_nullable_to_non_nullable
-              as bool,
-      roomName: null == roomName
-          ? _value.roomName
-          : roomName // ignore: cast_nullable_to_non_nullable
-              as String,
-      groupId: null == groupId
-          ? _value.groupId
-          : groupId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userIdOne: null == userIdOne
-          ? _value.userIdOne
-          : userIdOne // ignore: cast_nullable_to_non_nullable
-              as String,
-      userIdTwo: null == userIdTwo
-          ? _value.userIdTwo
-          : userIdTwo // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
+/// Create a copy of ChannelMessageAck
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? channelId = null,Object? messageId = null,Object? code = null,Object? username = null,Object? created = null,Object? updated = null,Object? persistent = null,Object? roomName = null,Object? groupId = null,Object? userIdOne = null,Object? userIdTwo = null,}) {
+  return _then(_self.copyWith(
+channelId: null == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String,messageId: null == messageId ? _self.messageId : messageId // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as int,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,created: null == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
+as DateTime,updated: null == updated ? _self.updated : updated // ignore: cast_nullable_to_non_nullable
+as DateTime,persistent: null == persistent ? _self.persistent : persistent // ignore: cast_nullable_to_non_nullable
+as bool,roomName: null == roomName ? _self.roomName : roomName // ignore: cast_nullable_to_non_nullable
+as String,groupId: null == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String,userIdOne: null == userIdOne ? _self.userIdOne : userIdOne // ignore: cast_nullable_to_non_nullable
+as String,userIdTwo: null == userIdTwo ? _self.userIdTwo : userIdTwo // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
 
-/// @nodoc
-abstract class _$$ChannelMessageAckImplCopyWith<$Res>
-    implements $ChannelMessageAckCopyWith<$Res> {
-  factory _$$ChannelMessageAckImplCopyWith(_$ChannelMessageAckImpl value,
-          $Res Function(_$ChannelMessageAckImpl) then) =
-      __$$ChannelMessageAckImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'channel_id') String channelId,
-      @JsonKey(name: 'message_id') String messageId,
-      @JsonKey(name: 'code') int code,
-      @JsonKey(name: 'username') String username,
-      @JsonKey(name: 'created') DateTime created,
-      @JsonKey(name: 'updated') DateTime updated,
-      @JsonKey(name: 'persistent') bool persistent,
-      @JsonKey(name: 'room_name') String roomName,
-      @JsonKey(name: 'group_id') String groupId,
-      @JsonKey(name: 'user_id_one') String userIdOne,
-      @JsonKey(name: 'user_id_two') String userIdTwo});
 }
 
-/// @nodoc
-class __$$ChannelMessageAckImplCopyWithImpl<$Res>
-    extends _$ChannelMessageAckCopyWithImpl<$Res, _$ChannelMessageAckImpl>
-    implements _$$ChannelMessageAckImplCopyWith<$Res> {
-  __$$ChannelMessageAckImplCopyWithImpl(_$ChannelMessageAckImpl _value,
-      $Res Function(_$ChannelMessageAckImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? channelId = null,
-    Object? messageId = null,
-    Object? code = null,
-    Object? username = null,
-    Object? created = null,
-    Object? updated = null,
-    Object? persistent = null,
-    Object? roomName = null,
-    Object? groupId = null,
-    Object? userIdOne = null,
-    Object? userIdTwo = null,
-  }) {
-    return _then(_$ChannelMessageAckImpl(
-      channelId: null == channelId
-          ? _value.channelId
-          : channelId // ignore: cast_nullable_to_non_nullable
-              as String,
-      messageId: null == messageId
-          ? _value.messageId
-          : messageId // ignore: cast_nullable_to_non_nullable
-              as String,
-      code: null == code
-          ? _value.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as int,
-      username: null == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String,
-      created: null == created
-          ? _value.created
-          : created // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updated: null == updated
-          ? _value.updated
-          : updated // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      persistent: null == persistent
-          ? _value.persistent
-          : persistent // ignore: cast_nullable_to_non_nullable
-              as bool,
-      roomName: null == roomName
-          ? _value.roomName
-          : roomName // ignore: cast_nullable_to_non_nullable
-              as String,
-      groupId: null == groupId
-          ? _value.groupId
-          : groupId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userIdOne: null == userIdOne
-          ? _value.userIdOne
-          : userIdOne // ignore: cast_nullable_to_non_nullable
-              as String,
-      userIdTwo: null == userIdTwo
-          ? _value.userIdTwo
-          : userIdTwo // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Adds pattern-matching-related methods to [ChannelMessageAck].
+extension ChannelMessageAckPatterns on ChannelMessageAck {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChannelMessageAck value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChannelMessageAck() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChannelMessageAck value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelMessageAck():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChannelMessageAck value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelMessageAck() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'message_id')  String messageId, @JsonKey(name: 'code')  int code, @JsonKey(name: 'username')  String username, @JsonKey(name: 'created')  DateTime created, @JsonKey(name: 'updated')  DateTime updated, @JsonKey(name: 'persistent')  bool persistent, @JsonKey(name: 'room_name')  String roomName, @JsonKey(name: 'group_id')  String groupId, @JsonKey(name: 'user_id_one')  String userIdOne, @JsonKey(name: 'user_id_two')  String userIdTwo)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChannelMessageAck() when $default != null:
+return $default(_that.channelId,_that.messageId,_that.code,_that.username,_that.created,_that.updated,_that.persistent,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'message_id')  String messageId, @JsonKey(name: 'code')  int code, @JsonKey(name: 'username')  String username, @JsonKey(name: 'created')  DateTime created, @JsonKey(name: 'updated')  DateTime updated, @JsonKey(name: 'persistent')  bool persistent, @JsonKey(name: 'room_name')  String roomName, @JsonKey(name: 'group_id')  String groupId, @JsonKey(name: 'user_id_one')  String userIdOne, @JsonKey(name: 'user_id_two')  String userIdTwo)  $default,) {final _that = this;
+switch (_that) {
+case _ChannelMessageAck():
+return $default(_that.channelId,_that.messageId,_that.code,_that.username,_that.created,_that.updated,_that.persistent,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'message_id')  String messageId, @JsonKey(name: 'code')  int code, @JsonKey(name: 'username')  String username, @JsonKey(name: 'created')  DateTime created, @JsonKey(name: 'updated')  DateTime updated, @JsonKey(name: 'persistent')  bool persistent, @JsonKey(name: 'room_name')  String roomName, @JsonKey(name: 'group_id')  String groupId, @JsonKey(name: 'user_id_one')  String userIdOne, @JsonKey(name: 'user_id_two')  String userIdTwo)?  $default,) {final _that = this;
+switch (_that) {
+case _ChannelMessageAck() when $default != null:
+return $default(_that.channelId,_that.messageId,_that.code,_that.username,_that.created,_that.updated,_that.persistent,_that.roomName,_that.groupId,_that.userIdOne,_that.userIdTwo);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 
-class _$ChannelMessageAckImpl extends _ChannelMessageAck {
-  const _$ChannelMessageAckImpl(
-      {@JsonKey(name: 'channel_id') required this.channelId,
-      @JsonKey(name: 'message_id') required this.messageId,
-      @JsonKey(name: 'code') required this.code,
-      @JsonKey(name: 'username') required this.username,
-      @JsonKey(name: 'created') required this.created,
-      @JsonKey(name: 'updated') required this.updated,
-      @JsonKey(name: 'persistent') required this.persistent,
-      @JsonKey(name: 'room_name') required this.roomName,
-      @JsonKey(name: 'group_id') required this.groupId,
-      @JsonKey(name: 'user_id_one') required this.userIdOne,
-      @JsonKey(name: 'user_id_two') required this.userIdTwo})
-      : super._();
 
-  /// The channel the message was sent to.
-  @override
-  @JsonKey(name: 'channel_id')
-  final String channelId;
+class _ChannelMessageAck extends ChannelMessageAck {
+  const _ChannelMessageAck({@JsonKey(name: 'channel_id') required this.channelId, @JsonKey(name: 'message_id') required this.messageId, @JsonKey(name: 'code') required this.code, @JsonKey(name: 'username') required this.username, @JsonKey(name: 'created') required this.created, @JsonKey(name: 'updated') required this.updated, @JsonKey(name: 'persistent') required this.persistent, @JsonKey(name: 'room_name') required this.roomName, @JsonKey(name: 'group_id') required this.groupId, @JsonKey(name: 'user_id_one') required this.userIdOne, @JsonKey(name: 'user_id_two') required this.userIdTwo}): super._();
+  
 
-  /// The unique ID assigned to the message.
-  @override
-  @JsonKey(name: 'message_id')
-  final String messageId;
+/// The channel the message was sent to.
+@override@JsonKey(name: 'channel_id') final  String channelId;
+/// The unique ID assigned to the message.
+@override@JsonKey(name: 'message_id') final  String messageId;
+/// The code representing a message type or category.
+@override@JsonKey(name: 'code') final  int code;
+/// Username of the message sender.
+@override@JsonKey(name: 'username') final  String username;
+/// The UNIX time when the message was created.
+@override@JsonKey(name: 'created') final  DateTime created;
+/// The UNIX time when the message was last updated.
+@override@JsonKey(name: 'updated') final  DateTime updated;
+/// True if the message was persisted to the channel's history, false otherwise.
+@override@JsonKey(name: 'persistent') final  bool persistent;
+/// The name of the chat room, or an empty string if this message was not sent through a chat room.
+@override@JsonKey(name: 'room_name') final  String roomName;
+/// The ID of the group, or an empty string if this message was not sent through a group channel.
+@override@JsonKey(name: 'group_id') final  String groupId;
+/// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
+@override@JsonKey(name: 'user_id_one') final  String userIdOne;
+/// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
+@override@JsonKey(name: 'user_id_two') final  String userIdTwo;
 
-  /// The code representing a message type or category.
-  @override
-  @JsonKey(name: 'code')
-  final int code;
+/// Create a copy of ChannelMessageAck
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChannelMessageAckCopyWith<_ChannelMessageAck> get copyWith => __$ChannelMessageAckCopyWithImpl<_ChannelMessageAck>(this, _$identity);
 
-  /// Username of the message sender.
-  @override
-  @JsonKey(name: 'username')
-  final String username;
 
-  /// The UNIX time when the message was created.
-  @override
-  @JsonKey(name: 'created')
-  final DateTime created;
 
-  /// The UNIX time when the message was last updated.
-  @override
-  @JsonKey(name: 'updated')
-  final DateTime updated;
-
-  /// True if the message was persisted to the channel's history, false otherwise.
-  @override
-  @JsonKey(name: 'persistent')
-  final bool persistent;
-
-  /// The name of the chat room, or an empty string if this message was not sent through a chat room.
-  @override
-  @JsonKey(name: 'room_name')
-  final String roomName;
-
-  /// The ID of the group, or an empty string if this message was not sent through a group channel.
-  @override
-  @JsonKey(name: 'group_id')
-  final String groupId;
-
-  /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
-  @override
-  @JsonKey(name: 'user_id_one')
-  final String userIdOne;
-
-  /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
-  @override
-  @JsonKey(name: 'user_id_two')
-  final String userIdTwo;
-
-  @override
-  String toString() {
-    return 'ChannelMessageAck(channelId: $channelId, messageId: $messageId, code: $code, username: $username, created: $created, updated: $updated, persistent: $persistent, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ChannelMessageAckImpl &&
-            (identical(other.channelId, channelId) ||
-                other.channelId == channelId) &&
-            (identical(other.messageId, messageId) ||
-                other.messageId == messageId) &&
-            (identical(other.code, code) || other.code == code) &&
-            (identical(other.username, username) ||
-                other.username == username) &&
-            (identical(other.created, created) || other.created == created) &&
-            (identical(other.updated, updated) || other.updated == updated) &&
-            (identical(other.persistent, persistent) ||
-                other.persistent == persistent) &&
-            (identical(other.roomName, roomName) ||
-                other.roomName == roomName) &&
-            (identical(other.groupId, groupId) || other.groupId == groupId) &&
-            (identical(other.userIdOne, userIdOne) ||
-                other.userIdOne == userIdOne) &&
-            (identical(other.userIdTwo, userIdTwo) ||
-                other.userIdTwo == userIdTwo));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      channelId,
-      messageId,
-      code,
-      username,
-      created,
-      updated,
-      persistent,
-      roomName,
-      groupId,
-      userIdOne,
-      userIdTwo);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ChannelMessageAckImplCopyWith<_$ChannelMessageAckImpl> get copyWith =>
-      __$$ChannelMessageAckImplCopyWithImpl<_$ChannelMessageAckImpl>(
-          this, _$identity);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChannelMessageAck&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.messageId, messageId) || other.messageId == messageId)&&(identical(other.code, code) || other.code == code)&&(identical(other.username, username) || other.username == username)&&(identical(other.created, created) || other.created == created)&&(identical(other.updated, updated) || other.updated == updated)&&(identical(other.persistent, persistent) || other.persistent == persistent)&&(identical(other.roomName, roomName) || other.roomName == roomName)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.userIdOne, userIdOne) || other.userIdOne == userIdOne)&&(identical(other.userIdTwo, userIdTwo) || other.userIdTwo == userIdTwo));
 }
 
-abstract class _ChannelMessageAck extends ChannelMessageAck {
-  const factory _ChannelMessageAck(
-          {@JsonKey(name: 'channel_id') required final String channelId,
-          @JsonKey(name: 'message_id') required final String messageId,
-          @JsonKey(name: 'code') required final int code,
-          @JsonKey(name: 'username') required final String username,
-          @JsonKey(name: 'created') required final DateTime created,
-          @JsonKey(name: 'updated') required final DateTime updated,
-          @JsonKey(name: 'persistent') required final bool persistent,
-          @JsonKey(name: 'room_name') required final String roomName,
-          @JsonKey(name: 'group_id') required final String groupId,
-          @JsonKey(name: 'user_id_one') required final String userIdOne,
-          @JsonKey(name: 'user_id_two') required final String userIdTwo}) =
-      _$ChannelMessageAckImpl;
-  const _ChannelMessageAck._() : super._();
 
-  @override
+@override
+int get hashCode => Object.hash(runtimeType,channelId,messageId,code,username,created,updated,persistent,roomName,groupId,userIdOne,userIdTwo);
 
-  /// The channel the message was sent to.
-  @JsonKey(name: 'channel_id')
-  String get channelId;
-  @override
-
-  /// The unique ID assigned to the message.
-  @JsonKey(name: 'message_id')
-  String get messageId;
-  @override
-
-  /// The code representing a message type or category.
-  @JsonKey(name: 'code')
-  int get code;
-  @override
-
-  /// Username of the message sender.
-  @JsonKey(name: 'username')
-  String get username;
-  @override
-
-  /// The UNIX time when the message was created.
-  @JsonKey(name: 'created')
-  DateTime get created;
-  @override
-
-  /// The UNIX time when the message was last updated.
-  @JsonKey(name: 'updated')
-  DateTime get updated;
-  @override
-
-  /// True if the message was persisted to the channel's history, false otherwise.
-  @JsonKey(name: 'persistent')
-  bool get persistent;
-  @override
-
-  /// The name of the chat room, or an empty string if this message was not sent through a chat room.
-  @JsonKey(name: 'room_name')
-  String get roomName;
-  @override
-
-  /// The ID of the group, or an empty string if this message was not sent through a group channel.
-  @JsonKey(name: 'group_id')
-  String get groupId;
-  @override
-
-  /// The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
-  @JsonKey(name: 'user_id_one')
-  String get userIdOne;
-  @override
-
-  /// The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
-  @JsonKey(name: 'user_id_two')
-  String get userIdTwo;
-  @override
-  @JsonKey(ignore: true)
-  _$$ChannelMessageAckImplCopyWith<_$ChannelMessageAckImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+String toString() {
+  return 'ChannelMessageAck(channelId: $channelId, messageId: $messageId, code: $code, username: $username, created: $created, updated: $updated, persistent: $persistent, roomName: $roomName, groupId: $groupId, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChannelMessageAckCopyWith<$Res> implements $ChannelMessageAckCopyWith<$Res> {
+  factory _$ChannelMessageAckCopyWith(_ChannelMessageAck value, $Res Function(_ChannelMessageAck) _then) = __$ChannelMessageAckCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'channel_id') String channelId,@JsonKey(name: 'message_id') String messageId,@JsonKey(name: 'code') int code,@JsonKey(name: 'username') String username,@JsonKey(name: 'created') DateTime created,@JsonKey(name: 'updated') DateTime updated,@JsonKey(name: 'persistent') bool persistent,@JsonKey(name: 'room_name') String roomName,@JsonKey(name: 'group_id') String groupId,@JsonKey(name: 'user_id_one') String userIdOne,@JsonKey(name: 'user_id_two') String userIdTwo
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChannelMessageAckCopyWithImpl<$Res>
+    implements _$ChannelMessageAckCopyWith<$Res> {
+  __$ChannelMessageAckCopyWithImpl(this._self, this._then);
+
+  final _ChannelMessageAck _self;
+  final $Res Function(_ChannelMessageAck) _then;
+
+/// Create a copy of ChannelMessageAck
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? channelId = null,Object? messageId = null,Object? code = null,Object? username = null,Object? created = null,Object? updated = null,Object? persistent = null,Object? roomName = null,Object? groupId = null,Object? userIdOne = null,Object? userIdTwo = null,}) {
+  return _then(_ChannelMessageAck(
+channelId: null == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String,messageId: null == messageId ? _self.messageId : messageId // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as int,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,created: null == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
+as DateTime,updated: null == updated ? _self.updated : updated // ignore: cast_nullable_to_non_nullable
+as DateTime,persistent: null == persistent ? _self.persistent : persistent // ignore: cast_nullable_to_non_nullable
+as bool,roomName: null == roomName ? _self.roomName : roomName // ignore: cast_nullable_to_non_nullable
+as String,groupId: null == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String,userIdOne: null == userIdOne ? _self.userIdOne : userIdOne // ignore: cast_nullable_to_non_nullable
+as String,userIdTwo: null == userIdTwo ? _self.userIdTwo : userIdTwo // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/nakama/lib/src/models/friends.dart
+++ b/nakama/lib/src/models/friends.dart
@@ -7,7 +7,7 @@ part 'friends.freezed.dart';
 part 'friends.g.dart';
 
 @freezed
-class FriendsList with _$FriendsList {
+sealed class FriendsList with _$FriendsList {
   const FriendsList._();
 
   const factory FriendsList({
@@ -30,7 +30,7 @@ class FriendsList with _$FriendsList {
 }
 
 @freezed
-class Friend with _$Friend {
+sealed class Friend with _$Friend {
   const Friend._();
 
   const factory Friend({

--- a/nakama/lib/src/models/friends.freezed.dart
+++ b/nakama/lib/src/models/friends.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,367 +9,555 @@ part of 'friends.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-FriendsList _$FriendsListFromJson(Map<String, dynamic> json) {
-  return _FriendsList.fromJson(json);
-}
 
 /// @nodoc
 mixin _$FriendsList {
-  String? get cursor => throw _privateConstructorUsedError;
-  List<Friend>? get friends => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $FriendsListCopyWith<FriendsList> get copyWith =>
-      throw _privateConstructorUsedError;
+ String? get cursor; List<Friend>? get friends;
+/// Create a copy of FriendsList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FriendsListCopyWith<FriendsList> get copyWith => _$FriendsListCopyWithImpl<FriendsList>(this as FriendsList, _$identity);
+
+  /// Serializes this FriendsList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FriendsList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.friends, friends));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(friends));
+
+@override
+String toString() {
+  return 'FriendsList(cursor: $cursor, friends: $friends)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $FriendsListCopyWith<$Res> {
-  factory $FriendsListCopyWith(
-          FriendsList value, $Res Function(FriendsList) then) =
-      _$FriendsListCopyWithImpl<$Res, FriendsList>;
-  @useResult
-  $Res call({String? cursor, List<Friend>? friends});
-}
+abstract mixin class $FriendsListCopyWith<$Res>  {
+  factory $FriendsListCopyWith(FriendsList value, $Res Function(FriendsList) _then) = _$FriendsListCopyWithImpl;
+@useResult
+$Res call({
+ String? cursor, List<Friend>? friends
+});
 
+
+
+
+}
 /// @nodoc
-class _$FriendsListCopyWithImpl<$Res, $Val extends FriendsList>
+class _$FriendsListCopyWithImpl<$Res>
     implements $FriendsListCopyWith<$Res> {
-  _$FriendsListCopyWithImpl(this._value, this._then);
+  _$FriendsListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final FriendsList _self;
+  final $Res Function(FriendsList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? friends = freezed,
-  }) {
-    return _then(_value.copyWith(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      friends: freezed == friends
-          ? _value.friends
-          : friends // ignore: cast_nullable_to_non_nullable
-              as List<Friend>?,
-    ) as $Val);
-  }
+/// Create a copy of FriendsList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? friends = freezed,}) {
+  return _then(_self.copyWith(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,friends: freezed == friends ? _self.friends : friends // ignore: cast_nullable_to_non_nullable
+as List<Friend>?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$FriendsListImplCopyWith<$Res>
-    implements $FriendsListCopyWith<$Res> {
-  factory _$$FriendsListImplCopyWith(
-          _$FriendsListImpl value, $Res Function(_$FriendsListImpl) then) =
-      __$$FriendsListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? cursor, List<Friend>? friends});
 }
 
-/// @nodoc
-class __$$FriendsListImplCopyWithImpl<$Res>
-    extends _$FriendsListCopyWithImpl<$Res, _$FriendsListImpl>
-    implements _$$FriendsListImplCopyWith<$Res> {
-  __$$FriendsListImplCopyWithImpl(
-      _$FriendsListImpl _value, $Res Function(_$FriendsListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? friends = freezed,
-  }) {
-    return _then(_$FriendsListImpl(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      friends: freezed == friends
-          ? _value._friends
-          : friends // ignore: cast_nullable_to_non_nullable
-              as List<Friend>?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [FriendsList].
+extension FriendsListPatterns on FriendsList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _FriendsList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _FriendsList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _FriendsList value)  $default,){
+final _that = this;
+switch (_that) {
+case _FriendsList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _FriendsList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _FriendsList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor,  List<Friend>? friends)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _FriendsList() when $default != null:
+return $default(_that.cursor,_that.friends);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor,  List<Friend>? friends)  $default,) {final _that = this;
+switch (_that) {
+case _FriendsList():
+return $default(_that.cursor,_that.friends);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor,  List<Friend>? friends)?  $default,) {final _that = this;
+switch (_that) {
+case _FriendsList() when $default != null:
+return $default(_that.cursor,_that.friends);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$FriendsListImpl extends _FriendsList {
-  const _$FriendsListImpl({this.cursor, required final List<Friend>? friends})
-      : _friends = friends,
-        super._();
 
-  factory _$FriendsListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FriendsListImplFromJson(json);
+class _FriendsList extends FriendsList {
+  const _FriendsList({this.cursor, required final  List<Friend>? friends}): _friends = friends,super._();
+  factory _FriendsList.fromJson(Map<String, dynamic> json) => _$FriendsListFromJson(json);
 
-  @override
-  final String? cursor;
-  final List<Friend>? _friends;
-  @override
-  List<Friend>? get friends {
-    final value = _friends;
-    if (value == null) return null;
-    if (_friends is EqualUnmodifiableListView) return _friends;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'FriendsList(cursor: $cursor, friends: $friends)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$FriendsListImpl &&
-            (identical(other.cursor, cursor) || other.cursor == cursor) &&
-            const DeepCollectionEquality().equals(other._friends, _friends));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, cursor, const DeepCollectionEquality().hash(_friends));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$FriendsListImplCopyWith<_$FriendsListImpl> get copyWith =>
-      __$$FriendsListImplCopyWithImpl<_$FriendsListImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$FriendsListImplToJson(
-      this,
-    );
-  }
+@override final  String? cursor;
+ final  List<Friend>? _friends;
+@override List<Friend>? get friends {
+  final value = _friends;
+  if (value == null) return null;
+  if (_friends is EqualUnmodifiableListView) return _friends;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _FriendsList extends FriendsList {
-  const factory _FriendsList(
-      {final String? cursor,
-      required final List<Friend>? friends}) = _$FriendsListImpl;
-  const _FriendsList._() : super._();
 
-  factory _FriendsList.fromJson(Map<String, dynamic> json) =
-      _$FriendsListImpl.fromJson;
+/// Create a copy of FriendsList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FriendsListCopyWith<_FriendsList> get copyWith => __$FriendsListCopyWithImpl<_FriendsList>(this, _$identity);
 
-  @override
-  String? get cursor;
-  @override
-  List<Friend>? get friends;
-  @override
-  @JsonKey(ignore: true)
-  _$$FriendsListImplCopyWith<_$FriendsListImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$FriendsListToJson(this, );
 }
 
-Friend _$FriendFromJson(Map<String, dynamic> json) {
-  return _Friend.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FriendsList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._friends, _friends));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(_friends));
+
+@override
+String toString() {
+  return 'FriendsList(cursor: $cursor, friends: $friends)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$FriendsListCopyWith<$Res> implements $FriendsListCopyWith<$Res> {
+  factory _$FriendsListCopyWith(_FriendsList value, $Res Function(_FriendsList) _then) = __$FriendsListCopyWithImpl;
+@override @useResult
+$Res call({
+ String? cursor, List<Friend>? friends
+});
+
+
+
+
+}
+/// @nodoc
+class __$FriendsListCopyWithImpl<$Res>
+    implements _$FriendsListCopyWith<$Res> {
+  __$FriendsListCopyWithImpl(this._self, this._then);
+
+  final _FriendsList _self;
+  final $Res Function(_FriendsList) _then;
+
+/// Create a copy of FriendsList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? friends = freezed,}) {
+  return _then(_FriendsList(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,friends: freezed == friends ? _self._friends : friends // ignore: cast_nullable_to_non_nullable
+as List<Friend>?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$Friend {
-  FriendshipState get state => throw _privateConstructorUsedError;
-  @JsonKey(name: 'update_time')
-  DateTime get updateTime => throw _privateConstructorUsedError;
-  User get user => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $FriendCopyWith<Friend> get copyWith => throw _privateConstructorUsedError;
+ FriendshipState get state;@JsonKey(name: 'update_time') DateTime get updateTime; User get user;
+/// Create a copy of Friend
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FriendCopyWith<Friend> get copyWith => _$FriendCopyWithImpl<Friend>(this as Friend, _$identity);
+
+  /// Serializes this Friend to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Friend&&(identical(other.state, state) || other.state == state)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,updateTime,user);
+
+@override
+String toString() {
+  return 'Friend(state: $state, updateTime: $updateTime, user: $user)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $FriendCopyWith<$Res> {
-  factory $FriendCopyWith(Friend value, $Res Function(Friend) then) =
-      _$FriendCopyWithImpl<$Res, Friend>;
-  @useResult
-  $Res call(
-      {FriendshipState state,
-      @JsonKey(name: 'update_time') DateTime updateTime,
-      User user});
+abstract mixin class $FriendCopyWith<$Res>  {
+  factory $FriendCopyWith(Friend value, $Res Function(Friend) _then) = _$FriendCopyWithImpl;
+@useResult
+$Res call({
+ FriendshipState state,@JsonKey(name: 'update_time') DateTime updateTime, User user
+});
 
-  $UserCopyWith<$Res> get user;
+
+$UserCopyWith<$Res> get user;
+
 }
-
 /// @nodoc
-class _$FriendCopyWithImpl<$Res, $Val extends Friend>
+class _$FriendCopyWithImpl<$Res>
     implements $FriendCopyWith<$Res> {
-  _$FriendCopyWithImpl(this._value, this._then);
+  _$FriendCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Friend _self;
+  final $Res Function(Friend) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? state = null,
-    Object? updateTime = null,
-    Object? user = null,
-  }) {
-    return _then(_value.copyWith(
-      state: null == state
-          ? _value.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as FriendshipState,
-      updateTime: null == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      user: null == user
-          ? _value.user
-          : user // ignore: cast_nullable_to_non_nullable
-              as User,
-    ) as $Val);
-  }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $UserCopyWith<$Res> get user {
-    return $UserCopyWith<$Res>(_value.user, (value) {
-      return _then(_value.copyWith(user: value) as $Val);
-    });
-  }
+/// Create a copy of Friend
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? state = null,Object? updateTime = null,Object? user = null,}) {
+  return _then(_self.copyWith(
+state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as FriendshipState,updateTime: null == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+/// Create a copy of Friend
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$FriendImplCopyWith<$Res> implements $FriendCopyWith<$Res> {
-  factory _$$FriendImplCopyWith(
-          _$FriendImpl value, $Res Function(_$FriendImpl) then) =
-      __$$FriendImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {FriendshipState state,
-      @JsonKey(name: 'update_time') DateTime updateTime,
-      User user});
 
-  @override
-  $UserCopyWith<$Res> get user;
+/// Adds pattern-matching-related methods to [Friend].
+extension FriendPatterns on Friend {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Friend value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Friend() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Friend value)  $default,){
+final _that = this;
+switch (_that) {
+case _Friend():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Friend value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Friend() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( FriendshipState state, @JsonKey(name: 'update_time')  DateTime updateTime,  User user)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Friend() when $default != null:
+return $default(_that.state,_that.updateTime,_that.user);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( FriendshipState state, @JsonKey(name: 'update_time')  DateTime updateTime,  User user)  $default,) {final _that = this;
+switch (_that) {
+case _Friend():
+return $default(_that.state,_that.updateTime,_that.user);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( FriendshipState state, @JsonKey(name: 'update_time')  DateTime updateTime,  User user)?  $default,) {final _that = this;
+switch (_that) {
+case _Friend() when $default != null:
+return $default(_that.state,_that.updateTime,_that.user);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$FriendImplCopyWithImpl<$Res>
-    extends _$FriendCopyWithImpl<$Res, _$FriendImpl>
-    implements _$$FriendImplCopyWith<$Res> {
-  __$$FriendImplCopyWithImpl(
-      _$FriendImpl _value, $Res Function(_$FriendImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? state = null,
-    Object? updateTime = null,
-    Object? user = null,
-  }) {
-    return _then(_$FriendImpl(
-      state: null == state
-          ? _value.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as FriendshipState,
-      updateTime: null == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      user: null == user
-          ? _value.user
-          : user // ignore: cast_nullable_to_non_nullable
-              as User,
-    ));
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$FriendImpl extends _Friend {
-  const _$FriendImpl(
-      {required this.state,
-      @JsonKey(name: 'update_time') required this.updateTime,
-      required this.user})
-      : super._();
 
-  factory _$FriendImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FriendImplFromJson(json);
+class _Friend extends Friend {
+  const _Friend({required this.state, @JsonKey(name: 'update_time') required this.updateTime, required this.user}): super._();
+  factory _Friend.fromJson(Map<String, dynamic> json) => _$FriendFromJson(json);
 
-  @override
-  final FriendshipState state;
-  @override
-  @JsonKey(name: 'update_time')
-  final DateTime updateTime;
-  @override
-  final User user;
+@override final  FriendshipState state;
+@override@JsonKey(name: 'update_time') final  DateTime updateTime;
+@override final  User user;
 
-  @override
-  String toString() {
-    return 'Friend(state: $state, updateTime: $updateTime, user: $user)';
-  }
+/// Create a copy of Friend
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FriendCopyWith<_Friend> get copyWith => __$FriendCopyWithImpl<_Friend>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$FriendImpl &&
-            (identical(other.state, state) || other.state == state) &&
-            (identical(other.updateTime, updateTime) ||
-                other.updateTime == updateTime) &&
-            (identical(other.user, user) || other.user == user));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, state, updateTime, user);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$FriendImplCopyWith<_$FriendImpl> get copyWith =>
-      __$$FriendImplCopyWithImpl<_$FriendImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$FriendImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$FriendToJson(this, );
 }
 
-abstract class _Friend extends Friend {
-  const factory _Friend(
-      {required final FriendshipState state,
-      @JsonKey(name: 'update_time') required final DateTime updateTime,
-      required final User user}) = _$FriendImpl;
-  const _Friend._() : super._();
-
-  factory _Friend.fromJson(Map<String, dynamic> json) = _$FriendImpl.fromJson;
-
-  @override
-  FriendshipState get state;
-  @override
-  @JsonKey(name: 'update_time')
-  DateTime get updateTime;
-  @override
-  User get user;
-  @override
-  @JsonKey(ignore: true)
-  _$$FriendImplCopyWith<_$FriendImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Friend&&(identical(other.state, state) || other.state == state)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime)&&(identical(other.user, user) || other.user == user));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,updateTime,user);
+
+@override
+String toString() {
+  return 'Friend(state: $state, updateTime: $updateTime, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$FriendCopyWith<$Res> implements $FriendCopyWith<$Res> {
+  factory _$FriendCopyWith(_Friend value, $Res Function(_Friend) _then) = __$FriendCopyWithImpl;
+@override @useResult
+$Res call({
+ FriendshipState state,@JsonKey(name: 'update_time') DateTime updateTime, User user
+});
+
+
+@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$FriendCopyWithImpl<$Res>
+    implements _$FriendCopyWith<$Res> {
+  __$FriendCopyWithImpl(this._self, this._then);
+
+  final _Friend _self;
+  final $Res Function(_Friend) _then;
+
+/// Create a copy of Friend
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? state = null,Object? updateTime = null,Object? user = null,}) {
+  return _then(_Friend(
+state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as FriendshipState,updateTime: null == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+
+/// Create a copy of Friend
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/nakama/lib/src/models/friends.g.dart
+++ b/nakama/lib/src/models/friends.g.dart
@@ -6,32 +6,27 @@ part of 'friends.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$FriendsListImpl _$$FriendsListImplFromJson(Map<String, dynamic> json) =>
-    _$FriendsListImpl(
-      cursor: json['cursor'] as String?,
-      friends: (json['friends'] as List<dynamic>?)
-          ?.map((e) => Friend.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+_FriendsList _$FriendsListFromJson(Map<String, dynamic> json) => _FriendsList(
+  cursor: json['cursor'] as String?,
+  friends: (json['friends'] as List<dynamic>?)
+      ?.map((e) => Friend.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$$FriendsListImplToJson(_$FriendsListImpl instance) =>
-    <String, dynamic>{
-      'cursor': instance.cursor,
-      'friends': instance.friends,
-    };
+Map<String, dynamic> _$FriendsListToJson(_FriendsList instance) =>
+    <String, dynamic>{'cursor': instance.cursor, 'friends': instance.friends};
 
-_$FriendImpl _$$FriendImplFromJson(Map<String, dynamic> json) => _$FriendImpl(
-      state: $enumDecode(_$FriendshipStateEnumMap, json['state']),
-      updateTime: DateTime.parse(json['update_time'] as String),
-      user: User.fromJson(json['user'] as Map<String, dynamic>),
-    );
+_Friend _$FriendFromJson(Map<String, dynamic> json) => _Friend(
+  state: $enumDecode(_$FriendshipStateEnumMap, json['state']),
+  updateTime: DateTime.parse(json['update_time'] as String),
+  user: User.fromJson(json['user'] as Map<String, dynamic>),
+);
 
-Map<String, dynamic> _$$FriendImplToJson(_$FriendImpl instance) =>
-    <String, dynamic>{
-      'state': _$FriendshipStateEnumMap[instance.state]!,
-      'update_time': instance.updateTime.toIso8601String(),
-      'user': instance.user,
-    };
+Map<String, dynamic> _$FriendToJson(_Friend instance) => <String, dynamic>{
+  'state': _$FriendshipStateEnumMap[instance.state]!,
+  'update_time': instance.updateTime.toIso8601String(),
+  'user': instance.user,
+};
 
 const _$FriendshipStateEnumMap = {
   FriendshipState.mutual: 0,

--- a/nakama/lib/src/models/group.dart
+++ b/nakama/lib/src/models/group.dart
@@ -7,7 +7,7 @@ part 'group.freezed.dart';
 part 'group.g.dart';
 
 @freezed
-class Group with _$Group {
+sealed class Group with _$Group {
   const Group._();
 
   const factory Group({
@@ -44,7 +44,7 @@ class Group with _$Group {
 }
 
 @freezed
-class GroupList with _$GroupList {
+sealed class GroupList with _$GroupList {
   const GroupList._();
 
   const factory GroupList({
@@ -61,7 +61,7 @@ class GroupList with _$GroupList {
 }
 
 @freezed
-class UserGroupList with _$UserGroupList {
+sealed class UserGroupList with _$UserGroupList {
   const UserGroupList._();
 
   const factory UserGroupList({
@@ -78,7 +78,7 @@ class UserGroupList with _$UserGroupList {
 }
 
 @freezed
-class UserGroup with _$UserGroup {
+sealed class UserGroup with _$UserGroup {
   const UserGroup._();
 
   const factory UserGroup({
@@ -95,7 +95,7 @@ class UserGroup with _$UserGroup {
 }
 
 @freezed
-class GroupUserList with _$GroupUserList {
+sealed class GroupUserList with _$GroupUserList {
   const GroupUserList._();
 
   const factory GroupUserList({
@@ -112,7 +112,7 @@ class GroupUserList with _$GroupUserList {
 }
 
 @freezed
-class GroupUser with _$GroupUser {
+sealed class GroupUser with _$GroupUser {
   const GroupUser._();
 
   const factory GroupUser({

--- a/nakama/lib/src/models/group.freezed.dart
+++ b/nakama/lib/src/models/group.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,1267 +9,1654 @@ part of 'group.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-Group _$GroupFromJson(Map<String, dynamic> json) {
-  return _Group.fromJson(json);
-}
 
 /// @nodoc
 mixin _$Group {
-  String get id => throw _privateConstructorUsedError;
-  @JsonKey(name: 'creator_id')
-  String? get creatorId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'name')
-  String? get name => throw _privateConstructorUsedError;
-  @JsonKey(name: 'description')
-  String? get description => throw _privateConstructorUsedError;
-  @JsonKey(name: 'lang_tag')
-  String? get langTag => throw _privateConstructorUsedError;
-  @JsonKey(name: 'metadata')
-  String? get metadata => throw _privateConstructorUsedError;
-  @JsonKey(name: 'avatar_url')
-  String? get avatarUrl => throw _privateConstructorUsedError;
-  @JsonKey(name: 'open')
-  bool? get open => throw _privateConstructorUsedError;
-  @JsonKey(name: 'edge_count')
-  int? get edgeCount => throw _privateConstructorUsedError;
-  @JsonKey(name: 'max_count')
-  int? get maxCount => throw _privateConstructorUsedError;
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'update_time')
-  DateTime? get updateTime => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $GroupCopyWith<Group> get copyWith => throw _privateConstructorUsedError;
+ String get id;@JsonKey(name: 'creator_id') String? get creatorId;@JsonKey(name: 'name') String? get name;@JsonKey(name: 'description') String? get description;@JsonKey(name: 'lang_tag') String? get langTag;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'avatar_url') String? get avatarUrl;@JsonKey(name: 'open') bool? get open;@JsonKey(name: 'edge_count') int? get edgeCount;@JsonKey(name: 'max_count') int? get maxCount;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;
+/// Create a copy of Group
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GroupCopyWith<Group> get copyWith => _$GroupCopyWithImpl<Group>(this as Group, _$identity);
+
+  /// Serializes this Group to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Group&&(identical(other.id, id) || other.id == id)&&(identical(other.creatorId, creatorId) || other.creatorId == creatorId)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.langTag, langTag) || other.langTag == langTag)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl)&&(identical(other.open, open) || other.open == open)&&(identical(other.edgeCount, edgeCount) || other.edgeCount == edgeCount)&&(identical(other.maxCount, maxCount) || other.maxCount == maxCount)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,creatorId,name,description,langTag,metadata,avatarUrl,open,edgeCount,maxCount,createTime,updateTime);
+
+@override
+String toString() {
+  return 'Group(id: $id, creatorId: $creatorId, name: $name, description: $description, langTag: $langTag, metadata: $metadata, avatarUrl: $avatarUrl, open: $open, edgeCount: $edgeCount, maxCount: $maxCount, createTime: $createTime, updateTime: $updateTime)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $GroupCopyWith<$Res> {
-  factory $GroupCopyWith(Group value, $Res Function(Group) then) =
-      _$GroupCopyWithImpl<$Res, Group>;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'creator_id') String? creatorId,
-      @JsonKey(name: 'name') String? name,
-      @JsonKey(name: 'description') String? description,
-      @JsonKey(name: 'lang_tag') String? langTag,
-      @JsonKey(name: 'metadata') String? metadata,
-      @JsonKey(name: 'avatar_url') String? avatarUrl,
-      @JsonKey(name: 'open') bool? open,
-      @JsonKey(name: 'edge_count') int? edgeCount,
-      @JsonKey(name: 'max_count') int? maxCount,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'update_time') DateTime? updateTime});
-}
+abstract mixin class $GroupCopyWith<$Res>  {
+  factory $GroupCopyWith(Group value, $Res Function(Group) _then) = _$GroupCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'creator_id') String? creatorId,@JsonKey(name: 'name') String? name,@JsonKey(name: 'description') String? description,@JsonKey(name: 'lang_tag') String? langTag,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'avatar_url') String? avatarUrl,@JsonKey(name: 'open') bool? open,@JsonKey(name: 'edge_count') int? edgeCount,@JsonKey(name: 'max_count') int? maxCount,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime
+});
 
+
+
+
+}
 /// @nodoc
-class _$GroupCopyWithImpl<$Res, $Val extends Group>
+class _$GroupCopyWithImpl<$Res>
     implements $GroupCopyWith<$Res> {
-  _$GroupCopyWithImpl(this._value, this._then);
+  _$GroupCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Group _self;
+  final $Res Function(Group) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? creatorId = freezed,
-    Object? name = freezed,
-    Object? description = freezed,
-    Object? langTag = freezed,
-    Object? metadata = freezed,
-    Object? avatarUrl = freezed,
-    Object? open = freezed,
-    Object? edgeCount = freezed,
-    Object? maxCount = freezed,
-    Object? createTime = freezed,
-    Object? updateTime = freezed,
-  }) {
-    return _then(_value.copyWith(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      creatorId: freezed == creatorId
-          ? _value.creatorId
-          : creatorId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _value.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      langTag: freezed == langTag
-          ? _value.langTag
-          : langTag // ignore: cast_nullable_to_non_nullable
-              as String?,
-      metadata: freezed == metadata
-          ? _value.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as String?,
-      avatarUrl: freezed == avatarUrl
-          ? _value.avatarUrl
-          : avatarUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      open: freezed == open
-          ? _value.open
-          : open // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      edgeCount: freezed == edgeCount
-          ? _value.edgeCount
-          : edgeCount // ignore: cast_nullable_to_non_nullable
-              as int?,
-      maxCount: freezed == maxCount
-          ? _value.maxCount
-          : maxCount // ignore: cast_nullable_to_non_nullable
-              as int?,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updateTime: freezed == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ) as $Val);
-  }
+/// Create a copy of Group
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? creatorId = freezed,Object? name = freezed,Object? description = freezed,Object? langTag = freezed,Object? metadata = freezed,Object? avatarUrl = freezed,Object? open = freezed,Object? edgeCount = freezed,Object? maxCount = freezed,Object? createTime = freezed,Object? updateTime = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,creatorId: freezed == creatorId ? _self.creatorId : creatorId // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,langTag: freezed == langTag ? _self.langTag : langTag // ignore: cast_nullable_to_non_nullable
+as String?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,avatarUrl: freezed == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String?,open: freezed == open ? _self.open : open // ignore: cast_nullable_to_non_nullable
+as bool?,edgeCount: freezed == edgeCount ? _self.edgeCount : edgeCount // ignore: cast_nullable_to_non_nullable
+as int?,maxCount: freezed == maxCount ? _self.maxCount : maxCount // ignore: cast_nullable_to_non_nullable
+as int?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$GroupImplCopyWith<$Res> implements $GroupCopyWith<$Res> {
-  factory _$$GroupImplCopyWith(
-          _$GroupImpl value, $Res Function(_$GroupImpl) then) =
-      __$$GroupImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'creator_id') String? creatorId,
-      @JsonKey(name: 'name') String? name,
-      @JsonKey(name: 'description') String? description,
-      @JsonKey(name: 'lang_tag') String? langTag,
-      @JsonKey(name: 'metadata') String? metadata,
-      @JsonKey(name: 'avatar_url') String? avatarUrl,
-      @JsonKey(name: 'open') bool? open,
-      @JsonKey(name: 'edge_count') int? edgeCount,
-      @JsonKey(name: 'max_count') int? maxCount,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'update_time') DateTime? updateTime});
 }
 
-/// @nodoc
-class __$$GroupImplCopyWithImpl<$Res>
-    extends _$GroupCopyWithImpl<$Res, _$GroupImpl>
-    implements _$$GroupImplCopyWith<$Res> {
-  __$$GroupImplCopyWithImpl(
-      _$GroupImpl _value, $Res Function(_$GroupImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? creatorId = freezed,
-    Object? name = freezed,
-    Object? description = freezed,
-    Object? langTag = freezed,
-    Object? metadata = freezed,
-    Object? avatarUrl = freezed,
-    Object? open = freezed,
-    Object? edgeCount = freezed,
-    Object? maxCount = freezed,
-    Object? createTime = freezed,
-    Object? updateTime = freezed,
-  }) {
-    return _then(_$GroupImpl(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      creatorId: freezed == creatorId
-          ? _value.creatorId
-          : creatorId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _value.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      langTag: freezed == langTag
-          ? _value.langTag
-          : langTag // ignore: cast_nullable_to_non_nullable
-              as String?,
-      metadata: freezed == metadata
-          ? _value.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as String?,
-      avatarUrl: freezed == avatarUrl
-          ? _value.avatarUrl
-          : avatarUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      open: freezed == open
-          ? _value.open
-          : open // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      edgeCount: freezed == edgeCount
-          ? _value.edgeCount
-          : edgeCount // ignore: cast_nullable_to_non_nullable
-              as int?,
-      maxCount: freezed == maxCount
-          ? _value.maxCount
-          : maxCount // ignore: cast_nullable_to_non_nullable
-              as int?,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updateTime: freezed == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Group].
+extension GroupPatterns on Group {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Group value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Group() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Group value)  $default,){
+final _that = this;
+switch (_that) {
+case _Group():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Group value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Group() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'creator_id')  String? creatorId, @JsonKey(name: 'name')  String? name, @JsonKey(name: 'description')  String? description, @JsonKey(name: 'lang_tag')  String? langTag, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'open')  bool? open, @JsonKey(name: 'edge_count')  int? edgeCount, @JsonKey(name: 'max_count')  int? maxCount, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Group() when $default != null:
+return $default(_that.id,_that.creatorId,_that.name,_that.description,_that.langTag,_that.metadata,_that.avatarUrl,_that.open,_that.edgeCount,_that.maxCount,_that.createTime,_that.updateTime);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'creator_id')  String? creatorId, @JsonKey(name: 'name')  String? name, @JsonKey(name: 'description')  String? description, @JsonKey(name: 'lang_tag')  String? langTag, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'open')  bool? open, @JsonKey(name: 'edge_count')  int? edgeCount, @JsonKey(name: 'max_count')  int? maxCount, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime)  $default,) {final _that = this;
+switch (_that) {
+case _Group():
+return $default(_that.id,_that.creatorId,_that.name,_that.description,_that.langTag,_that.metadata,_that.avatarUrl,_that.open,_that.edgeCount,_that.maxCount,_that.createTime,_that.updateTime);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'creator_id')  String? creatorId, @JsonKey(name: 'name')  String? name, @JsonKey(name: 'description')  String? description, @JsonKey(name: 'lang_tag')  String? langTag, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'open')  bool? open, @JsonKey(name: 'edge_count')  int? edgeCount, @JsonKey(name: 'max_count')  int? maxCount, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime)?  $default,) {final _that = this;
+switch (_that) {
+case _Group() when $default != null:
+return $default(_that.id,_that.creatorId,_that.name,_that.description,_that.langTag,_that.metadata,_that.avatarUrl,_that.open,_that.edgeCount,_that.maxCount,_that.createTime,_that.updateTime);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$GroupImpl extends _Group {
-  const _$GroupImpl(
-      {required this.id,
-      @JsonKey(name: 'creator_id') this.creatorId,
-      @JsonKey(name: 'name') this.name,
-      @JsonKey(name: 'description') this.description,
-      @JsonKey(name: 'lang_tag') this.langTag,
-      @JsonKey(name: 'metadata') this.metadata,
-      @JsonKey(name: 'avatar_url') this.avatarUrl,
-      @JsonKey(name: 'open') this.open,
-      @JsonKey(name: 'edge_count') this.edgeCount,
-      @JsonKey(name: 'max_count') this.maxCount,
-      @JsonKey(name: 'create_time') this.createTime,
-      @JsonKey(name: 'update_time') this.updateTime})
-      : super._();
 
-  factory _$GroupImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GroupImplFromJson(json);
+class _Group extends Group {
+  const _Group({required this.id, @JsonKey(name: 'creator_id') this.creatorId, @JsonKey(name: 'name') this.name, @JsonKey(name: 'description') this.description, @JsonKey(name: 'lang_tag') this.langTag, @JsonKey(name: 'metadata') this.metadata, @JsonKey(name: 'avatar_url') this.avatarUrl, @JsonKey(name: 'open') this.open, @JsonKey(name: 'edge_count') this.edgeCount, @JsonKey(name: 'max_count') this.maxCount, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'update_time') this.updateTime}): super._();
+  factory _Group.fromJson(Map<String, dynamic> json) => _$GroupFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'creator_id')
-  final String? creatorId;
-  @override
-  @JsonKey(name: 'name')
-  final String? name;
-  @override
-  @JsonKey(name: 'description')
-  final String? description;
-  @override
-  @JsonKey(name: 'lang_tag')
-  final String? langTag;
-  @override
-  @JsonKey(name: 'metadata')
-  final String? metadata;
-  @override
-  @JsonKey(name: 'avatar_url')
-  final String? avatarUrl;
-  @override
-  @JsonKey(name: 'open')
-  final bool? open;
-  @override
-  @JsonKey(name: 'edge_count')
-  final int? edgeCount;
-  @override
-  @JsonKey(name: 'max_count')
-  final int? maxCount;
-  @override
-  @JsonKey(name: 'create_time')
-  final DateTime? createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  final DateTime? updateTime;
+@override final  String id;
+@override@JsonKey(name: 'creator_id') final  String? creatorId;
+@override@JsonKey(name: 'name') final  String? name;
+@override@JsonKey(name: 'description') final  String? description;
+@override@JsonKey(name: 'lang_tag') final  String? langTag;
+@override@JsonKey(name: 'metadata') final  String? metadata;
+@override@JsonKey(name: 'avatar_url') final  String? avatarUrl;
+@override@JsonKey(name: 'open') final  bool? open;
+@override@JsonKey(name: 'edge_count') final  int? edgeCount;
+@override@JsonKey(name: 'max_count') final  int? maxCount;
+@override@JsonKey(name: 'create_time') final  DateTime? createTime;
+@override@JsonKey(name: 'update_time') final  DateTime? updateTime;
 
-  @override
-  String toString() {
-    return 'Group(id: $id, creatorId: $creatorId, name: $name, description: $description, langTag: $langTag, metadata: $metadata, avatarUrl: $avatarUrl, open: $open, edgeCount: $edgeCount, maxCount: $maxCount, createTime: $createTime, updateTime: $updateTime)';
-  }
+/// Create a copy of Group
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GroupCopyWith<_Group> get copyWith => __$GroupCopyWithImpl<_Group>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$GroupImpl &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.creatorId, creatorId) ||
-                other.creatorId == creatorId) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            (identical(other.langTag, langTag) || other.langTag == langTag) &&
-            (identical(other.metadata, metadata) ||
-                other.metadata == metadata) &&
-            (identical(other.avatarUrl, avatarUrl) ||
-                other.avatarUrl == avatarUrl) &&
-            (identical(other.open, open) || other.open == open) &&
-            (identical(other.edgeCount, edgeCount) ||
-                other.edgeCount == edgeCount) &&
-            (identical(other.maxCount, maxCount) ||
-                other.maxCount == maxCount) &&
-            (identical(other.createTime, createTime) ||
-                other.createTime == createTime) &&
-            (identical(other.updateTime, updateTime) ||
-                other.updateTime == updateTime));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      creatorId,
-      name,
-      description,
-      langTag,
-      metadata,
-      avatarUrl,
-      open,
-      edgeCount,
-      maxCount,
-      createTime,
-      updateTime);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
-      __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$GroupImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$GroupToJson(this, );
 }
 
-abstract class _Group extends Group {
-  const factory _Group(
-      {required final String id,
-      @JsonKey(name: 'creator_id') final String? creatorId,
-      @JsonKey(name: 'name') final String? name,
-      @JsonKey(name: 'description') final String? description,
-      @JsonKey(name: 'lang_tag') final String? langTag,
-      @JsonKey(name: 'metadata') final String? metadata,
-      @JsonKey(name: 'avatar_url') final String? avatarUrl,
-      @JsonKey(name: 'open') final bool? open,
-      @JsonKey(name: 'edge_count') final int? edgeCount,
-      @JsonKey(name: 'max_count') final int? maxCount,
-      @JsonKey(name: 'create_time') final DateTime? createTime,
-      @JsonKey(name: 'update_time') final DateTime? updateTime}) = _$GroupImpl;
-  const _Group._() : super._();
-
-  factory _Group.fromJson(Map<String, dynamic> json) = _$GroupImpl.fromJson;
-
-  @override
-  String get id;
-  @override
-  @JsonKey(name: 'creator_id')
-  String? get creatorId;
-  @override
-  @JsonKey(name: 'name')
-  String? get name;
-  @override
-  @JsonKey(name: 'description')
-  String? get description;
-  @override
-  @JsonKey(name: 'lang_tag')
-  String? get langTag;
-  @override
-  @JsonKey(name: 'metadata')
-  String? get metadata;
-  @override
-  @JsonKey(name: 'avatar_url')
-  String? get avatarUrl;
-  @override
-  @JsonKey(name: 'open')
-  bool? get open;
-  @override
-  @JsonKey(name: 'edge_count')
-  int? get edgeCount;
-  @override
-  @JsonKey(name: 'max_count')
-  int? get maxCount;
-  @override
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  DateTime? get updateTime;
-  @override
-  @JsonKey(ignore: true)
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Group&&(identical(other.id, id) || other.id == id)&&(identical(other.creatorId, creatorId) || other.creatorId == creatorId)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.langTag, langTag) || other.langTag == langTag)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl)&&(identical(other.open, open) || other.open == open)&&(identical(other.edgeCount, edgeCount) || other.edgeCount == edgeCount)&&(identical(other.maxCount, maxCount) || other.maxCount == maxCount)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime));
 }
 
-GroupList _$GroupListFromJson(Map<String, dynamic> json) {
-  return _GroupList.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,creatorId,name,description,langTag,metadata,avatarUrl,open,edgeCount,maxCount,createTime,updateTime);
+
+@override
+String toString() {
+  return 'Group(id: $id, creatorId: $creatorId, name: $name, description: $description, langTag: $langTag, metadata: $metadata, avatarUrl: $avatarUrl, open: $open, edgeCount: $edgeCount, maxCount: $maxCount, createTime: $createTime, updateTime: $updateTime)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GroupCopyWith<$Res> implements $GroupCopyWith<$Res> {
+  factory _$GroupCopyWith(_Group value, $Res Function(_Group) _then) = __$GroupCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'creator_id') String? creatorId,@JsonKey(name: 'name') String? name,@JsonKey(name: 'description') String? description,@JsonKey(name: 'lang_tag') String? langTag,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'avatar_url') String? avatarUrl,@JsonKey(name: 'open') bool? open,@JsonKey(name: 'edge_count') int? edgeCount,@JsonKey(name: 'max_count') int? maxCount,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime
+});
+
+
+
+
+}
+/// @nodoc
+class __$GroupCopyWithImpl<$Res>
+    implements _$GroupCopyWith<$Res> {
+  __$GroupCopyWithImpl(this._self, this._then);
+
+  final _Group _self;
+  final $Res Function(_Group) _then;
+
+/// Create a copy of Group
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? creatorId = freezed,Object? name = freezed,Object? description = freezed,Object? langTag = freezed,Object? metadata = freezed,Object? avatarUrl = freezed,Object? open = freezed,Object? edgeCount = freezed,Object? maxCount = freezed,Object? createTime = freezed,Object? updateTime = freezed,}) {
+  return _then(_Group(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,creatorId: freezed == creatorId ? _self.creatorId : creatorId // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,langTag: freezed == langTag ? _self.langTag : langTag // ignore: cast_nullable_to_non_nullable
+as String?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,avatarUrl: freezed == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String?,open: freezed == open ? _self.open : open // ignore: cast_nullable_to_non_nullable
+as bool?,edgeCount: freezed == edgeCount ? _self.edgeCount : edgeCount // ignore: cast_nullable_to_non_nullable
+as int?,maxCount: freezed == maxCount ? _self.maxCount : maxCount // ignore: cast_nullable_to_non_nullable
+as int?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$GroupList {
-  String? get cursor => throw _privateConstructorUsedError;
-  List<Group>? get groups => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $GroupListCopyWith<GroupList> get copyWith =>
-      throw _privateConstructorUsedError;
+ String? get cursor; List<Group>? get groups;
+/// Create a copy of GroupList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GroupListCopyWith<GroupList> get copyWith => _$GroupListCopyWithImpl<GroupList>(this as GroupList, _$identity);
+
+  /// Serializes this GroupList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.groups, groups));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(groups));
+
+@override
+String toString() {
+  return 'GroupList(cursor: $cursor, groups: $groups)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $GroupListCopyWith<$Res> {
-  factory $GroupListCopyWith(GroupList value, $Res Function(GroupList) then) =
-      _$GroupListCopyWithImpl<$Res, GroupList>;
-  @useResult
-  $Res call({String? cursor, List<Group>? groups});
-}
+abstract mixin class $GroupListCopyWith<$Res>  {
+  factory $GroupListCopyWith(GroupList value, $Res Function(GroupList) _then) = _$GroupListCopyWithImpl;
+@useResult
+$Res call({
+ String? cursor, List<Group>? groups
+});
 
+
+
+
+}
 /// @nodoc
-class _$GroupListCopyWithImpl<$Res, $Val extends GroupList>
+class _$GroupListCopyWithImpl<$Res>
     implements $GroupListCopyWith<$Res> {
-  _$GroupListCopyWithImpl(this._value, this._then);
+  _$GroupListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final GroupList _self;
+  final $Res Function(GroupList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? groups = freezed,
-  }) {
-    return _then(_value.copyWith(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      groups: freezed == groups
-          ? _value.groups
-          : groups // ignore: cast_nullable_to_non_nullable
-              as List<Group>?,
-    ) as $Val);
-  }
+/// Create a copy of GroupList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? groups = freezed,}) {
+  return _then(_self.copyWith(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,groups: freezed == groups ? _self.groups : groups // ignore: cast_nullable_to_non_nullable
+as List<Group>?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$GroupListImplCopyWith<$Res>
-    implements $GroupListCopyWith<$Res> {
-  factory _$$GroupListImplCopyWith(
-          _$GroupListImpl value, $Res Function(_$GroupListImpl) then) =
-      __$$GroupListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? cursor, List<Group>? groups});
 }
 
-/// @nodoc
-class __$$GroupListImplCopyWithImpl<$Res>
-    extends _$GroupListCopyWithImpl<$Res, _$GroupListImpl>
-    implements _$$GroupListImplCopyWith<$Res> {
-  __$$GroupListImplCopyWithImpl(
-      _$GroupListImpl _value, $Res Function(_$GroupListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? groups = freezed,
-  }) {
-    return _then(_$GroupListImpl(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      groups: freezed == groups
-          ? _value._groups
-          : groups // ignore: cast_nullable_to_non_nullable
-              as List<Group>?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [GroupList].
+extension GroupListPatterns on GroupList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GroupList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GroupList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GroupList value)  $default,){
+final _that = this;
+switch (_that) {
+case _GroupList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GroupList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GroupList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor,  List<Group>? groups)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GroupList() when $default != null:
+return $default(_that.cursor,_that.groups);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor,  List<Group>? groups)  $default,) {final _that = this;
+switch (_that) {
+case _GroupList():
+return $default(_that.cursor,_that.groups);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor,  List<Group>? groups)?  $default,) {final _that = this;
+switch (_that) {
+case _GroupList() when $default != null:
+return $default(_that.cursor,_that.groups);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$GroupListImpl extends _GroupList {
-  const _$GroupListImpl({this.cursor, required final List<Group>? groups})
-      : _groups = groups,
-        super._();
 
-  factory _$GroupListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GroupListImplFromJson(json);
+class _GroupList extends GroupList {
+  const _GroupList({this.cursor, required final  List<Group>? groups}): _groups = groups,super._();
+  factory _GroupList.fromJson(Map<String, dynamic> json) => _$GroupListFromJson(json);
 
-  @override
-  final String? cursor;
-  final List<Group>? _groups;
-  @override
-  List<Group>? get groups {
-    final value = _groups;
-    if (value == null) return null;
-    if (_groups is EqualUnmodifiableListView) return _groups;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'GroupList(cursor: $cursor, groups: $groups)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$GroupListImpl &&
-            (identical(other.cursor, cursor) || other.cursor == cursor) &&
-            const DeepCollectionEquality().equals(other._groups, _groups));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, cursor, const DeepCollectionEquality().hash(_groups));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$GroupListImplCopyWith<_$GroupListImpl> get copyWith =>
-      __$$GroupListImplCopyWithImpl<_$GroupListImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$GroupListImplToJson(
-      this,
-    );
-  }
+@override final  String? cursor;
+ final  List<Group>? _groups;
+@override List<Group>? get groups {
+  final value = _groups;
+  if (value == null) return null;
+  if (_groups is EqualUnmodifiableListView) return _groups;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _GroupList extends GroupList {
-  const factory _GroupList(
-      {final String? cursor,
-      required final List<Group>? groups}) = _$GroupListImpl;
-  const _GroupList._() : super._();
 
-  factory _GroupList.fromJson(Map<String, dynamic> json) =
-      _$GroupListImpl.fromJson;
+/// Create a copy of GroupList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GroupListCopyWith<_GroupList> get copyWith => __$GroupListCopyWithImpl<_GroupList>(this, _$identity);
 
-  @override
-  String? get cursor;
-  @override
-  List<Group>? get groups;
-  @override
-  @JsonKey(ignore: true)
-  _$$GroupListImplCopyWith<_$GroupListImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$GroupListToJson(this, );
 }
 
-UserGroupList _$UserGroupListFromJson(Map<String, dynamic> json) {
-  return _UserGroupList.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._groups, _groups));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(_groups));
+
+@override
+String toString() {
+  return 'GroupList(cursor: $cursor, groups: $groups)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GroupListCopyWith<$Res> implements $GroupListCopyWith<$Res> {
+  factory _$GroupListCopyWith(_GroupList value, $Res Function(_GroupList) _then) = __$GroupListCopyWithImpl;
+@override @useResult
+$Res call({
+ String? cursor, List<Group>? groups
+});
+
+
+
+
+}
+/// @nodoc
+class __$GroupListCopyWithImpl<$Res>
+    implements _$GroupListCopyWith<$Res> {
+  __$GroupListCopyWithImpl(this._self, this._then);
+
+  final _GroupList _self;
+  final $Res Function(_GroupList) _then;
+
+/// Create a copy of GroupList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? groups = freezed,}) {
+  return _then(_GroupList(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,groups: freezed == groups ? _self._groups : groups // ignore: cast_nullable_to_non_nullable
+as List<Group>?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$UserGroupList {
-  String? get cursor => throw _privateConstructorUsedError;
-  @JsonKey(name: 'user_groups')
-  List<UserGroup>? get userGroups => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $UserGroupListCopyWith<UserGroupList> get copyWith =>
-      throw _privateConstructorUsedError;
+ String? get cursor;@JsonKey(name: 'user_groups') List<UserGroup>? get userGroups;
+/// Create a copy of UserGroupList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserGroupListCopyWith<UserGroupList> get copyWith => _$UserGroupListCopyWithImpl<UserGroupList>(this as UserGroupList, _$identity);
+
+  /// Serializes this UserGroupList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserGroupList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.userGroups, userGroups));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(userGroups));
+
+@override
+String toString() {
+  return 'UserGroupList(cursor: $cursor, userGroups: $userGroups)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $UserGroupListCopyWith<$Res> {
-  factory $UserGroupListCopyWith(
-          UserGroupList value, $Res Function(UserGroupList) then) =
-      _$UserGroupListCopyWithImpl<$Res, UserGroupList>;
-  @useResult
-  $Res call(
-      {String? cursor,
-      @JsonKey(name: 'user_groups') List<UserGroup>? userGroups});
-}
+abstract mixin class $UserGroupListCopyWith<$Res>  {
+  factory $UserGroupListCopyWith(UserGroupList value, $Res Function(UserGroupList) _then) = _$UserGroupListCopyWithImpl;
+@useResult
+$Res call({
+ String? cursor,@JsonKey(name: 'user_groups') List<UserGroup>? userGroups
+});
 
+
+
+
+}
 /// @nodoc
-class _$UserGroupListCopyWithImpl<$Res, $Val extends UserGroupList>
+class _$UserGroupListCopyWithImpl<$Res>
     implements $UserGroupListCopyWith<$Res> {
-  _$UserGroupListCopyWithImpl(this._value, this._then);
+  _$UserGroupListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final UserGroupList _self;
+  final $Res Function(UserGroupList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? userGroups = freezed,
-  }) {
-    return _then(_value.copyWith(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userGroups: freezed == userGroups
-          ? _value.userGroups
-          : userGroups // ignore: cast_nullable_to_non_nullable
-              as List<UserGroup>?,
-    ) as $Val);
-  }
+/// Create a copy of UserGroupList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? userGroups = freezed,}) {
+  return _then(_self.copyWith(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,userGroups: freezed == userGroups ? _self.userGroups : userGroups // ignore: cast_nullable_to_non_nullable
+as List<UserGroup>?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$UserGroupListImplCopyWith<$Res>
-    implements $UserGroupListCopyWith<$Res> {
-  factory _$$UserGroupListImplCopyWith(
-          _$UserGroupListImpl value, $Res Function(_$UserGroupListImpl) then) =
-      __$$UserGroupListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String? cursor,
-      @JsonKey(name: 'user_groups') List<UserGroup>? userGroups});
 }
 
-/// @nodoc
-class __$$UserGroupListImplCopyWithImpl<$Res>
-    extends _$UserGroupListCopyWithImpl<$Res, _$UserGroupListImpl>
-    implements _$$UserGroupListImplCopyWith<$Res> {
-  __$$UserGroupListImplCopyWithImpl(
-      _$UserGroupListImpl _value, $Res Function(_$UserGroupListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? userGroups = freezed,
-  }) {
-    return _then(_$UserGroupListImpl(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userGroups: freezed == userGroups
-          ? _value._userGroups
-          : userGroups // ignore: cast_nullable_to_non_nullable
-              as List<UserGroup>?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [UserGroupList].
+extension UserGroupListPatterns on UserGroupList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserGroupList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserGroupList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserGroupList value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserGroupList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserGroupList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserGroupList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup>? userGroups)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserGroupList() when $default != null:
+return $default(_that.cursor,_that.userGroups);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup>? userGroups)  $default,) {final _that = this;
+switch (_that) {
+case _UserGroupList():
+return $default(_that.cursor,_that.userGroups);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup>? userGroups)?  $default,) {final _that = this;
+switch (_that) {
+case _UserGroupList() when $default != null:
+return $default(_that.cursor,_that.userGroups);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$UserGroupListImpl extends _UserGroupList {
-  const _$UserGroupListImpl(
-      {this.cursor,
-      @JsonKey(name: 'user_groups') required final List<UserGroup>? userGroups})
-      : _userGroups = userGroups,
-        super._();
 
-  factory _$UserGroupListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$UserGroupListImplFromJson(json);
+class _UserGroupList extends UserGroupList {
+  const _UserGroupList({this.cursor, @JsonKey(name: 'user_groups') required final  List<UserGroup>? userGroups}): _userGroups = userGroups,super._();
+  factory _UserGroupList.fromJson(Map<String, dynamic> json) => _$UserGroupListFromJson(json);
 
-  @override
-  final String? cursor;
-  final List<UserGroup>? _userGroups;
-  @override
-  @JsonKey(name: 'user_groups')
-  List<UserGroup>? get userGroups {
-    final value = _userGroups;
-    if (value == null) return null;
-    if (_userGroups is EqualUnmodifiableListView) return _userGroups;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'UserGroupList(cursor: $cursor, userGroups: $userGroups)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$UserGroupListImpl &&
-            (identical(other.cursor, cursor) || other.cursor == cursor) &&
-            const DeepCollectionEquality()
-                .equals(other._userGroups, _userGroups));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, cursor, const DeepCollectionEquality().hash(_userGroups));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$UserGroupListImplCopyWith<_$UserGroupListImpl> get copyWith =>
-      __$$UserGroupListImplCopyWithImpl<_$UserGroupListImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$UserGroupListImplToJson(
-      this,
-    );
-  }
+@override final  String? cursor;
+ final  List<UserGroup>? _userGroups;
+@override@JsonKey(name: 'user_groups') List<UserGroup>? get userGroups {
+  final value = _userGroups;
+  if (value == null) return null;
+  if (_userGroups is EqualUnmodifiableListView) return _userGroups;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _UserGroupList extends UserGroupList {
-  const factory _UserGroupList(
-      {final String? cursor,
-      @JsonKey(name: 'user_groups')
-      required final List<UserGroup>? userGroups}) = _$UserGroupListImpl;
-  const _UserGroupList._() : super._();
 
-  factory _UserGroupList.fromJson(Map<String, dynamic> json) =
-      _$UserGroupListImpl.fromJson;
+/// Create a copy of UserGroupList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserGroupListCopyWith<_UserGroupList> get copyWith => __$UserGroupListCopyWithImpl<_UserGroupList>(this, _$identity);
 
-  @override
-  String? get cursor;
-  @override
-  @JsonKey(name: 'user_groups')
-  List<UserGroup>? get userGroups;
-  @override
-  @JsonKey(ignore: true)
-  _$$UserGroupListImplCopyWith<_$UserGroupListImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$UserGroupListToJson(this, );
 }
 
-UserGroup _$UserGroupFromJson(Map<String, dynamic> json) {
-  return _UserGroup.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserGroupList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._userGroups, _userGroups));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(_userGroups));
+
+@override
+String toString() {
+  return 'UserGroupList(cursor: $cursor, userGroups: $userGroups)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UserGroupListCopyWith<$Res> implements $UserGroupListCopyWith<$Res> {
+  factory _$UserGroupListCopyWith(_UserGroupList value, $Res Function(_UserGroupList) _then) = __$UserGroupListCopyWithImpl;
+@override @useResult
+$Res call({
+ String? cursor,@JsonKey(name: 'user_groups') List<UserGroup>? userGroups
+});
+
+
+
+
+}
+/// @nodoc
+class __$UserGroupListCopyWithImpl<$Res>
+    implements _$UserGroupListCopyWith<$Res> {
+  __$UserGroupListCopyWithImpl(this._self, this._then);
+
+  final _UserGroupList _self;
+  final $Res Function(_UserGroupList) _then;
+
+/// Create a copy of UserGroupList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? userGroups = freezed,}) {
+  return _then(_UserGroupList(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,userGroups: freezed == userGroups ? _self._userGroups : userGroups // ignore: cast_nullable_to_non_nullable
+as List<UserGroup>?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$UserGroup {
-  GroupMembershipState get state => throw _privateConstructorUsedError;
-  Group get group => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $UserGroupCopyWith<UserGroup> get copyWith =>
-      throw _privateConstructorUsedError;
+ GroupMembershipState get state; Group get group;
+/// Create a copy of UserGroup
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserGroupCopyWith<UserGroup> get copyWith => _$UserGroupCopyWithImpl<UserGroup>(this as UserGroup, _$identity);
+
+  /// Serializes this UserGroup to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserGroup&&(identical(other.state, state) || other.state == state)&&(identical(other.group, group) || other.group == group));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,group);
+
+@override
+String toString() {
+  return 'UserGroup(state: $state, group: $group)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $UserGroupCopyWith<$Res> {
-  factory $UserGroupCopyWith(UserGroup value, $Res Function(UserGroup) then) =
-      _$UserGroupCopyWithImpl<$Res, UserGroup>;
-  @useResult
-  $Res call({GroupMembershipState state, Group group});
+abstract mixin class $UserGroupCopyWith<$Res>  {
+  factory $UserGroupCopyWith(UserGroup value, $Res Function(UserGroup) _then) = _$UserGroupCopyWithImpl;
+@useResult
+$Res call({
+ GroupMembershipState state, Group group
+});
 
-  $GroupCopyWith<$Res> get group;
+
+$GroupCopyWith<$Res> get group;
+
 }
-
 /// @nodoc
-class _$UserGroupCopyWithImpl<$Res, $Val extends UserGroup>
+class _$UserGroupCopyWithImpl<$Res>
     implements $UserGroupCopyWith<$Res> {
-  _$UserGroupCopyWithImpl(this._value, this._then);
+  _$UserGroupCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final UserGroup _self;
+  final $Res Function(UserGroup) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? state = null,
-    Object? group = null,
-  }) {
-    return _then(_value.copyWith(
-      state: null == state
-          ? _value.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as GroupMembershipState,
-      group: null == group
-          ? _value.group
-          : group // ignore: cast_nullable_to_non_nullable
-              as Group,
-    ) as $Val);
-  }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $GroupCopyWith<$Res> get group {
-    return $GroupCopyWith<$Res>(_value.group, (value) {
-      return _then(_value.copyWith(group: value) as $Val);
-    });
-  }
+/// Create a copy of UserGroup
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? state = null,Object? group = null,}) {
+  return _then(_self.copyWith(
+state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as GroupMembershipState,group: null == group ? _self.group : group // ignore: cast_nullable_to_non_nullable
+as Group,
+  ));
+}
+/// Create a copy of UserGroup
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GroupCopyWith<$Res> get group {
+  
+  return $GroupCopyWith<$Res>(_self.group, (value) {
+    return _then(_self.copyWith(group: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$UserGroupImplCopyWith<$Res>
-    implements $UserGroupCopyWith<$Res> {
-  factory _$$UserGroupImplCopyWith(
-          _$UserGroupImpl value, $Res Function(_$UserGroupImpl) then) =
-      __$$UserGroupImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({GroupMembershipState state, Group group});
 
-  @override
-  $GroupCopyWith<$Res> get group;
+/// Adds pattern-matching-related methods to [UserGroup].
+extension UserGroupPatterns on UserGroup {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserGroup value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserGroup() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserGroup value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserGroup():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserGroup value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserGroup() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( GroupMembershipState state,  Group group)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserGroup() when $default != null:
+return $default(_that.state,_that.group);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( GroupMembershipState state,  Group group)  $default,) {final _that = this;
+switch (_that) {
+case _UserGroup():
+return $default(_that.state,_that.group);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( GroupMembershipState state,  Group group)?  $default,) {final _that = this;
+switch (_that) {
+case _UserGroup() when $default != null:
+return $default(_that.state,_that.group);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$UserGroupImplCopyWithImpl<$Res>
-    extends _$UserGroupCopyWithImpl<$Res, _$UserGroupImpl>
-    implements _$$UserGroupImplCopyWith<$Res> {
-  __$$UserGroupImplCopyWithImpl(
-      _$UserGroupImpl _value, $Res Function(_$UserGroupImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? state = null,
-    Object? group = null,
-  }) {
-    return _then(_$UserGroupImpl(
-      state: null == state
-          ? _value.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as GroupMembershipState,
-      group: null == group
-          ? _value.group
-          : group // ignore: cast_nullable_to_non_nullable
-              as Group,
-    ));
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$UserGroupImpl extends _UserGroup {
-  const _$UserGroupImpl({required this.state, required this.group}) : super._();
 
-  factory _$UserGroupImpl.fromJson(Map<String, dynamic> json) =>
-      _$$UserGroupImplFromJson(json);
+class _UserGroup extends UserGroup {
+  const _UserGroup({required this.state, required this.group}): super._();
+  factory _UserGroup.fromJson(Map<String, dynamic> json) => _$UserGroupFromJson(json);
 
-  @override
-  final GroupMembershipState state;
-  @override
-  final Group group;
+@override final  GroupMembershipState state;
+@override final  Group group;
 
-  @override
-  String toString() {
-    return 'UserGroup(state: $state, group: $group)';
-  }
+/// Create a copy of UserGroup
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserGroupCopyWith<_UserGroup> get copyWith => __$UserGroupCopyWithImpl<_UserGroup>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$UserGroupImpl &&
-            (identical(other.state, state) || other.state == state) &&
-            (identical(other.group, group) || other.group == group));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, state, group);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$UserGroupImplCopyWith<_$UserGroupImpl> get copyWith =>
-      __$$UserGroupImplCopyWithImpl<_$UserGroupImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$UserGroupImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$UserGroupToJson(this, );
 }
 
-abstract class _UserGroup extends UserGroup {
-  const factory _UserGroup(
-      {required final GroupMembershipState state,
-      required final Group group}) = _$UserGroupImpl;
-  const _UserGroup._() : super._();
-
-  factory _UserGroup.fromJson(Map<String, dynamic> json) =
-      _$UserGroupImpl.fromJson;
-
-  @override
-  GroupMembershipState get state;
-  @override
-  Group get group;
-  @override
-  @JsonKey(ignore: true)
-  _$$UserGroupImplCopyWith<_$UserGroupImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserGroup&&(identical(other.state, state) || other.state == state)&&(identical(other.group, group) || other.group == group));
 }
 
-GroupUserList _$GroupUserListFromJson(Map<String, dynamic> json) {
-  return _GroupUserList.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,group);
+
+@override
+String toString() {
+  return 'UserGroup(state: $state, group: $group)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UserGroupCopyWith<$Res> implements $UserGroupCopyWith<$Res> {
+  factory _$UserGroupCopyWith(_UserGroup value, $Res Function(_UserGroup) _then) = __$UserGroupCopyWithImpl;
+@override @useResult
+$Res call({
+ GroupMembershipState state, Group group
+});
+
+
+@override $GroupCopyWith<$Res> get group;
+
+}
+/// @nodoc
+class __$UserGroupCopyWithImpl<$Res>
+    implements _$UserGroupCopyWith<$Res> {
+  __$UserGroupCopyWithImpl(this._self, this._then);
+
+  final _UserGroup _self;
+  final $Res Function(_UserGroup) _then;
+
+/// Create a copy of UserGroup
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? state = null,Object? group = null,}) {
+  return _then(_UserGroup(
+state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as GroupMembershipState,group: null == group ? _self.group : group // ignore: cast_nullable_to_non_nullable
+as Group,
+  ));
+}
+
+/// Create a copy of UserGroup
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GroupCopyWith<$Res> get group {
+  
+  return $GroupCopyWith<$Res>(_self.group, (value) {
+    return _then(_self.copyWith(group: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$GroupUserList {
-  String? get cursor => throw _privateConstructorUsedError;
-  @JsonKey(name: 'group_users')
-  List<GroupUser> get groupUsers => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $GroupUserListCopyWith<GroupUserList> get copyWith =>
-      throw _privateConstructorUsedError;
+ String? get cursor;@JsonKey(name: 'group_users') List<GroupUser> get groupUsers;
+/// Create a copy of GroupUserList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GroupUserListCopyWith<GroupUserList> get copyWith => _$GroupUserListCopyWithImpl<GroupUserList>(this as GroupUserList, _$identity);
+
+  /// Serializes this GroupUserList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupUserList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.groupUsers, groupUsers));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(groupUsers));
+
+@override
+String toString() {
+  return 'GroupUserList(cursor: $cursor, groupUsers: $groupUsers)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $GroupUserListCopyWith<$Res> {
-  factory $GroupUserListCopyWith(
-          GroupUserList value, $Res Function(GroupUserList) then) =
-      _$GroupUserListCopyWithImpl<$Res, GroupUserList>;
-  @useResult
-  $Res call(
-      {String? cursor,
-      @JsonKey(name: 'group_users') List<GroupUser> groupUsers});
-}
+abstract mixin class $GroupUserListCopyWith<$Res>  {
+  factory $GroupUserListCopyWith(GroupUserList value, $Res Function(GroupUserList) _then) = _$GroupUserListCopyWithImpl;
+@useResult
+$Res call({
+ String? cursor,@JsonKey(name: 'group_users') List<GroupUser> groupUsers
+});
 
+
+
+
+}
 /// @nodoc
-class _$GroupUserListCopyWithImpl<$Res, $Val extends GroupUserList>
+class _$GroupUserListCopyWithImpl<$Res>
     implements $GroupUserListCopyWith<$Res> {
-  _$GroupUserListCopyWithImpl(this._value, this._then);
+  _$GroupUserListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final GroupUserList _self;
+  final $Res Function(GroupUserList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? groupUsers = null,
-  }) {
-    return _then(_value.copyWith(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      groupUsers: null == groupUsers
-          ? _value.groupUsers
-          : groupUsers // ignore: cast_nullable_to_non_nullable
-              as List<GroupUser>,
-    ) as $Val);
-  }
+/// Create a copy of GroupUserList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? groupUsers = null,}) {
+  return _then(_self.copyWith(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,groupUsers: null == groupUsers ? _self.groupUsers : groupUsers // ignore: cast_nullable_to_non_nullable
+as List<GroupUser>,
+  ));
 }
 
-/// @nodoc
-abstract class _$$GroupUserListImplCopyWith<$Res>
-    implements $GroupUserListCopyWith<$Res> {
-  factory _$$GroupUserListImplCopyWith(
-          _$GroupUserListImpl value, $Res Function(_$GroupUserListImpl) then) =
-      __$$GroupUserListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String? cursor,
-      @JsonKey(name: 'group_users') List<GroupUser> groupUsers});
 }
 
-/// @nodoc
-class __$$GroupUserListImplCopyWithImpl<$Res>
-    extends _$GroupUserListCopyWithImpl<$Res, _$GroupUserListImpl>
-    implements _$$GroupUserListImplCopyWith<$Res> {
-  __$$GroupUserListImplCopyWithImpl(
-      _$GroupUserListImpl _value, $Res Function(_$GroupUserListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? groupUsers = null,
-  }) {
-    return _then(_$GroupUserListImpl(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      groupUsers: null == groupUsers
-          ? _value._groupUsers
-          : groupUsers // ignore: cast_nullable_to_non_nullable
-              as List<GroupUser>,
-    ));
-  }
+/// Adds pattern-matching-related methods to [GroupUserList].
+extension GroupUserListPatterns on GroupUserList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GroupUserList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GroupUserList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GroupUserList value)  $default,){
+final _that = this;
+switch (_that) {
+case _GroupUserList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GroupUserList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GroupUserList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor, @JsonKey(name: 'group_users')  List<GroupUser> groupUsers)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GroupUserList() when $default != null:
+return $default(_that.cursor,_that.groupUsers);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor, @JsonKey(name: 'group_users')  List<GroupUser> groupUsers)  $default,) {final _that = this;
+switch (_that) {
+case _GroupUserList():
+return $default(_that.cursor,_that.groupUsers);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor, @JsonKey(name: 'group_users')  List<GroupUser> groupUsers)?  $default,) {final _that = this;
+switch (_that) {
+case _GroupUserList() when $default != null:
+return $default(_that.cursor,_that.groupUsers);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$GroupUserListImpl extends _GroupUserList {
-  const _$GroupUserListImpl(
-      {this.cursor,
-      @JsonKey(name: 'group_users') required final List<GroupUser> groupUsers})
-      : _groupUsers = groupUsers,
-        super._();
 
-  factory _$GroupUserListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GroupUserListImplFromJson(json);
+class _GroupUserList extends GroupUserList {
+  const _GroupUserList({this.cursor, @JsonKey(name: 'group_users') required final  List<GroupUser> groupUsers}): _groupUsers = groupUsers,super._();
+  factory _GroupUserList.fromJson(Map<String, dynamic> json) => _$GroupUserListFromJson(json);
 
-  @override
-  final String? cursor;
-  final List<GroupUser> _groupUsers;
-  @override
-  @JsonKey(name: 'group_users')
-  List<GroupUser> get groupUsers {
-    if (_groupUsers is EqualUnmodifiableListView) return _groupUsers;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_groupUsers);
-  }
-
-  @override
-  String toString() {
-    return 'GroupUserList(cursor: $cursor, groupUsers: $groupUsers)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$GroupUserListImpl &&
-            (identical(other.cursor, cursor) || other.cursor == cursor) &&
-            const DeepCollectionEquality()
-                .equals(other._groupUsers, _groupUsers));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, cursor, const DeepCollectionEquality().hash(_groupUsers));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$GroupUserListImplCopyWith<_$GroupUserListImpl> get copyWith =>
-      __$$GroupUserListImplCopyWithImpl<_$GroupUserListImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$GroupUserListImplToJson(
-      this,
-    );
-  }
+@override final  String? cursor;
+ final  List<GroupUser> _groupUsers;
+@override@JsonKey(name: 'group_users') List<GroupUser> get groupUsers {
+  if (_groupUsers is EqualUnmodifiableListView) return _groupUsers;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_groupUsers);
 }
 
-abstract class _GroupUserList extends GroupUserList {
-  const factory _GroupUserList(
-      {final String? cursor,
-      @JsonKey(name: 'group_users')
-      required final List<GroupUser> groupUsers}) = _$GroupUserListImpl;
-  const _GroupUserList._() : super._();
 
-  factory _GroupUserList.fromJson(Map<String, dynamic> json) =
-      _$GroupUserListImpl.fromJson;
+/// Create a copy of GroupUserList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GroupUserListCopyWith<_GroupUserList> get copyWith => __$GroupUserListCopyWithImpl<_GroupUserList>(this, _$identity);
 
-  @override
-  String? get cursor;
-  @override
-  @JsonKey(name: 'group_users')
-  List<GroupUser> get groupUsers;
-  @override
-  @JsonKey(ignore: true)
-  _$$GroupUserListImplCopyWith<_$GroupUserListImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$GroupUserListToJson(this, );
 }
 
-GroupUser _$GroupUserFromJson(Map<String, dynamic> json) {
-  return _GroupUser.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupUserList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._groupUsers, _groupUsers));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(_groupUsers));
+
+@override
+String toString() {
+  return 'GroupUserList(cursor: $cursor, groupUsers: $groupUsers)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GroupUserListCopyWith<$Res> implements $GroupUserListCopyWith<$Res> {
+  factory _$GroupUserListCopyWith(_GroupUserList value, $Res Function(_GroupUserList) _then) = __$GroupUserListCopyWithImpl;
+@override @useResult
+$Res call({
+ String? cursor,@JsonKey(name: 'group_users') List<GroupUser> groupUsers
+});
+
+
+
+
+}
+/// @nodoc
+class __$GroupUserListCopyWithImpl<$Res>
+    implements _$GroupUserListCopyWith<$Res> {
+  __$GroupUserListCopyWithImpl(this._self, this._then);
+
+  final _GroupUserList _self;
+  final $Res Function(_GroupUserList) _then;
+
+/// Create a copy of GroupUserList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? groupUsers = null,}) {
+  return _then(_GroupUserList(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,groupUsers: null == groupUsers ? _self._groupUsers : groupUsers // ignore: cast_nullable_to_non_nullable
+as List<GroupUser>,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$GroupUser {
-  GroupMembershipState get state => throw _privateConstructorUsedError;
-  User get user => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $GroupUserCopyWith<GroupUser> get copyWith =>
-      throw _privateConstructorUsedError;
+ GroupMembershipState get state; User get user;
+/// Create a copy of GroupUser
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GroupUserCopyWith<GroupUser> get copyWith => _$GroupUserCopyWithImpl<GroupUser>(this as GroupUser, _$identity);
+
+  /// Serializes this GroupUser to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupUser&&(identical(other.state, state) || other.state == state)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,user);
+
+@override
+String toString() {
+  return 'GroupUser(state: $state, user: $user)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $GroupUserCopyWith<$Res> {
-  factory $GroupUserCopyWith(GroupUser value, $Res Function(GroupUser) then) =
-      _$GroupUserCopyWithImpl<$Res, GroupUser>;
-  @useResult
-  $Res call({GroupMembershipState state, User user});
+abstract mixin class $GroupUserCopyWith<$Res>  {
+  factory $GroupUserCopyWith(GroupUser value, $Res Function(GroupUser) _then) = _$GroupUserCopyWithImpl;
+@useResult
+$Res call({
+ GroupMembershipState state, User user
+});
 
-  $UserCopyWith<$Res> get user;
+
+$UserCopyWith<$Res> get user;
+
 }
-
 /// @nodoc
-class _$GroupUserCopyWithImpl<$Res, $Val extends GroupUser>
+class _$GroupUserCopyWithImpl<$Res>
     implements $GroupUserCopyWith<$Res> {
-  _$GroupUserCopyWithImpl(this._value, this._then);
+  _$GroupUserCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final GroupUser _self;
+  final $Res Function(GroupUser) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? state = null,
-    Object? user = null,
-  }) {
-    return _then(_value.copyWith(
-      state: null == state
-          ? _value.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as GroupMembershipState,
-      user: null == user
-          ? _value.user
-          : user // ignore: cast_nullable_to_non_nullable
-              as User,
-    ) as $Val);
-  }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $UserCopyWith<$Res> get user {
-    return $UserCopyWith<$Res>(_value.user, (value) {
-      return _then(_value.copyWith(user: value) as $Val);
-    });
-  }
+/// Create a copy of GroupUser
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? state = null,Object? user = null,}) {
+  return _then(_self.copyWith(
+state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as GroupMembershipState,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+/// Create a copy of GroupUser
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$GroupUserImplCopyWith<$Res>
-    implements $GroupUserCopyWith<$Res> {
-  factory _$$GroupUserImplCopyWith(
-          _$GroupUserImpl value, $Res Function(_$GroupUserImpl) then) =
-      __$$GroupUserImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({GroupMembershipState state, User user});
 
-  @override
-  $UserCopyWith<$Res> get user;
+/// Adds pattern-matching-related methods to [GroupUser].
+extension GroupUserPatterns on GroupUser {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GroupUser value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GroupUser() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GroupUser value)  $default,){
+final _that = this;
+switch (_that) {
+case _GroupUser():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GroupUser value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GroupUser() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( GroupMembershipState state,  User user)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GroupUser() when $default != null:
+return $default(_that.state,_that.user);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( GroupMembershipState state,  User user)  $default,) {final _that = this;
+switch (_that) {
+case _GroupUser():
+return $default(_that.state,_that.user);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( GroupMembershipState state,  User user)?  $default,) {final _that = this;
+switch (_that) {
+case _GroupUser() when $default != null:
+return $default(_that.state,_that.user);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$GroupUserImplCopyWithImpl<$Res>
-    extends _$GroupUserCopyWithImpl<$Res, _$GroupUserImpl>
-    implements _$$GroupUserImplCopyWith<$Res> {
-  __$$GroupUserImplCopyWithImpl(
-      _$GroupUserImpl _value, $Res Function(_$GroupUserImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? state = null,
-    Object? user = null,
-  }) {
-    return _then(_$GroupUserImpl(
-      state: null == state
-          ? _value.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as GroupMembershipState,
-      user: null == user
-          ? _value.user
-          : user // ignore: cast_nullable_to_non_nullable
-              as User,
-    ));
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$GroupUserImpl extends _GroupUser {
-  const _$GroupUserImpl({required this.state, required this.user}) : super._();
 
-  factory _$GroupUserImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GroupUserImplFromJson(json);
+class _GroupUser extends GroupUser {
+  const _GroupUser({required this.state, required this.user}): super._();
+  factory _GroupUser.fromJson(Map<String, dynamic> json) => _$GroupUserFromJson(json);
 
-  @override
-  final GroupMembershipState state;
-  @override
-  final User user;
+@override final  GroupMembershipState state;
+@override final  User user;
 
-  @override
-  String toString() {
-    return 'GroupUser(state: $state, user: $user)';
-  }
+/// Create a copy of GroupUser
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GroupUserCopyWith<_GroupUser> get copyWith => __$GroupUserCopyWithImpl<_GroupUser>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$GroupUserImpl &&
-            (identical(other.state, state) || other.state == state) &&
-            (identical(other.user, user) || other.user == user));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, state, user);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$GroupUserImplCopyWith<_$GroupUserImpl> get copyWith =>
-      __$$GroupUserImplCopyWithImpl<_$GroupUserImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$GroupUserImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$GroupUserToJson(this, );
 }
 
-abstract class _GroupUser extends GroupUser {
-  const factory _GroupUser(
-      {required final GroupMembershipState state,
-      required final User user}) = _$GroupUserImpl;
-  const _GroupUser._() : super._();
-
-  factory _GroupUser.fromJson(Map<String, dynamic> json) =
-      _$GroupUserImpl.fromJson;
-
-  @override
-  GroupMembershipState get state;
-  @override
-  User get user;
-  @override
-  @JsonKey(ignore: true)
-  _$$GroupUserImplCopyWith<_$GroupUserImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupUser&&(identical(other.state, state) || other.state == state)&&(identical(other.user, user) || other.user == user));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,user);
+
+@override
+String toString() {
+  return 'GroupUser(state: $state, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GroupUserCopyWith<$Res> implements $GroupUserCopyWith<$Res> {
+  factory _$GroupUserCopyWith(_GroupUser value, $Res Function(_GroupUser) _then) = __$GroupUserCopyWithImpl;
+@override @useResult
+$Res call({
+ GroupMembershipState state, User user
+});
+
+
+@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$GroupUserCopyWithImpl<$Res>
+    implements _$GroupUserCopyWith<$Res> {
+  __$GroupUserCopyWithImpl(this._self, this._then);
+
+  final _GroupUser _self;
+  final $Res Function(_GroupUser) _then;
+
+/// Create a copy of GroupUser
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? state = null,Object? user = null,}) {
+  return _then(_GroupUser(
+state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as GroupMembershipState,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+
+/// Create a copy of GroupUser
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/nakama/lib/src/models/group.g.dart
+++ b/nakama/lib/src/models/group.g.dart
@@ -6,76 +6,70 @@ part of 'group.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) => _$GroupImpl(
-      id: json['id'] as String,
-      creatorId: json['creator_id'] as String?,
-      name: json['name'] as String?,
-      description: json['description'] as String?,
-      langTag: json['lang_tag'] as String?,
-      metadata: json['metadata'] as String?,
-      avatarUrl: json['avatar_url'] as String?,
-      open: json['open'] as bool?,
-      edgeCount: json['edge_count'] as int?,
-      maxCount: json['max_count'] as int?,
-      createTime: json['create_time'] == null
-          ? null
-          : DateTime.parse(json['create_time'] as String),
-      updateTime: json['update_time'] == null
-          ? null
-          : DateTime.parse(json['update_time'] as String),
-    );
+_Group _$GroupFromJson(Map<String, dynamic> json) => _Group(
+  id: json['id'] as String,
+  creatorId: json['creator_id'] as String?,
+  name: json['name'] as String?,
+  description: json['description'] as String?,
+  langTag: json['lang_tag'] as String?,
+  metadata: json['metadata'] as String?,
+  avatarUrl: json['avatar_url'] as String?,
+  open: json['open'] as bool?,
+  edgeCount: (json['edge_count'] as num?)?.toInt(),
+  maxCount: (json['max_count'] as num?)?.toInt(),
+  createTime: json['create_time'] == null
+      ? null
+      : DateTime.parse(json['create_time'] as String),
+  updateTime: json['update_time'] == null
+      ? null
+      : DateTime.parse(json['update_time'] as String),
+);
 
-Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'creator_id': instance.creatorId,
-      'name': instance.name,
-      'description': instance.description,
-      'lang_tag': instance.langTag,
-      'metadata': instance.metadata,
-      'avatar_url': instance.avatarUrl,
-      'open': instance.open,
-      'edge_count': instance.edgeCount,
-      'max_count': instance.maxCount,
-      'create_time': instance.createTime?.toIso8601String(),
-      'update_time': instance.updateTime?.toIso8601String(),
-    };
+Map<String, dynamic> _$GroupToJson(_Group instance) => <String, dynamic>{
+  'id': instance.id,
+  'creator_id': instance.creatorId,
+  'name': instance.name,
+  'description': instance.description,
+  'lang_tag': instance.langTag,
+  'metadata': instance.metadata,
+  'avatar_url': instance.avatarUrl,
+  'open': instance.open,
+  'edge_count': instance.edgeCount,
+  'max_count': instance.maxCount,
+  'create_time': instance.createTime?.toIso8601String(),
+  'update_time': instance.updateTime?.toIso8601String(),
+};
 
-_$GroupListImpl _$$GroupListImplFromJson(Map<String, dynamic> json) =>
-    _$GroupListImpl(
-      cursor: json['cursor'] as String?,
-      groups: (json['groups'] as List<dynamic>?)
-          ?.map((e) => Group.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+_GroupList _$GroupListFromJson(Map<String, dynamic> json) => _GroupList(
+  cursor: json['cursor'] as String?,
+  groups: (json['groups'] as List<dynamic>?)
+      ?.map((e) => Group.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$$GroupListImplToJson(_$GroupListImpl instance) =>
-    <String, dynamic>{
-      'cursor': instance.cursor,
-      'groups': instance.groups,
-    };
+Map<String, dynamic> _$GroupListToJson(_GroupList instance) =>
+    <String, dynamic>{'cursor': instance.cursor, 'groups': instance.groups};
 
-_$UserGroupListImpl _$$UserGroupListImplFromJson(Map<String, dynamic> json) =>
-    _$UserGroupListImpl(
+_UserGroupList _$UserGroupListFromJson(Map<String, dynamic> json) =>
+    _UserGroupList(
       cursor: json['cursor'] as String?,
       userGroups: (json['user_groups'] as List<dynamic>?)
           ?.map((e) => UserGroup.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$UserGroupListImplToJson(_$UserGroupListImpl instance) =>
+Map<String, dynamic> _$UserGroupListToJson(_UserGroupList instance) =>
     <String, dynamic>{
       'cursor': instance.cursor,
       'user_groups': instance.userGroups,
     };
 
-_$UserGroupImpl _$$UserGroupImplFromJson(Map<String, dynamic> json) =>
-    _$UserGroupImpl(
-      state: $enumDecode(_$GroupMembershipStateEnumMap, json['state']),
-      group: Group.fromJson(json['group'] as Map<String, dynamic>),
-    );
+_UserGroup _$UserGroupFromJson(Map<String, dynamic> json) => _UserGroup(
+  state: $enumDecode(_$GroupMembershipStateEnumMap, json['state']),
+  group: Group.fromJson(json['group'] as Map<String, dynamic>),
+);
 
-Map<String, dynamic> _$$UserGroupImplToJson(_$UserGroupImpl instance) =>
+Map<String, dynamic> _$UserGroupToJson(_UserGroup instance) =>
     <String, dynamic>{
       'state': _$GroupMembershipStateEnumMap[instance.state]!,
       'group': instance.group,
@@ -88,27 +82,26 @@ const _$GroupMembershipStateEnumMap = {
   GroupMembershipState.joinRequest: 3,
 };
 
-_$GroupUserListImpl _$$GroupUserListImplFromJson(Map<String, dynamic> json) =>
-    _$GroupUserListImpl(
+_GroupUserList _$GroupUserListFromJson(Map<String, dynamic> json) =>
+    _GroupUserList(
       cursor: json['cursor'] as String?,
       groupUsers: (json['group_users'] as List<dynamic>)
           .map((e) => GroupUser.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$GroupUserListImplToJson(_$GroupUserListImpl instance) =>
+Map<String, dynamic> _$GroupUserListToJson(_GroupUserList instance) =>
     <String, dynamic>{
       'cursor': instance.cursor,
       'group_users': instance.groupUsers,
     };
 
-_$GroupUserImpl _$$GroupUserImplFromJson(Map<String, dynamic> json) =>
-    _$GroupUserImpl(
-      state: $enumDecode(_$GroupMembershipStateEnumMap, json['state']),
-      user: User.fromJson(json['user'] as Map<String, dynamic>),
-    );
+_GroupUser _$GroupUserFromJson(Map<String, dynamic> json) => _GroupUser(
+  state: $enumDecode(_$GroupMembershipStateEnumMap, json['state']),
+  user: User.fromJson(json['user'] as Map<String, dynamic>),
+);
 
-Map<String, dynamic> _$$GroupUserImplToJson(_$GroupUserImpl instance) =>
+Map<String, dynamic> _$GroupUserToJson(_GroupUser instance) =>
     <String, dynamic>{
       'state': _$GroupMembershipStateEnumMap[instance.state]!,
       'user': instance.user,

--- a/nakama/lib/src/models/leaderboard.dart
+++ b/nakama/lib/src/models/leaderboard.dart
@@ -22,7 +22,7 @@ enum LeaderboardOperator {
 }
 
 @freezed
-class LeaderboardRecordList with _$LeaderboardRecordList {
+sealed class LeaderboardRecordList with _$LeaderboardRecordList {
   const LeaderboardRecordList._();
 
   const factory LeaderboardRecordList({
@@ -43,7 +43,7 @@ class LeaderboardRecordList with _$LeaderboardRecordList {
 }
 
 @freezed
-class LeaderboardRecord with _$LeaderboardRecord {
+sealed class LeaderboardRecord with _$LeaderboardRecord {
   const LeaderboardRecord._();
 
   const factory LeaderboardRecord({

--- a/nakama/lib/src/models/leaderboard.freezed.dart
+++ b/nakama/lib/src/models/leaderboard.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,680 +9,578 @@ part of 'leaderboard.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-LeaderboardRecordList _$LeaderboardRecordListFromJson(
-    Map<String, dynamic> json) {
-  return _LeaderboardRecordList.fromJson(json);
-}
 
 /// @nodoc
 mixin _$LeaderboardRecordList {
-  @JsonKey(name: 'records')
-  List<LeaderboardRecord>? get records => throw _privateConstructorUsedError;
-  @JsonKey(name: 'owner_records')
-  List<LeaderboardRecord>? get ownerRecords =>
-      throw _privateConstructorUsedError;
-  @JsonKey(name: 'next_cursor')
-  String? get nextCursor => throw _privateConstructorUsedError;
-  @JsonKey(name: 'prev_cursor')
-  String? get prevCursor => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $LeaderboardRecordListCopyWith<LeaderboardRecordList> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'records') List<LeaderboardRecord>? get records;@JsonKey(name: 'owner_records') List<LeaderboardRecord>? get ownerRecords;@JsonKey(name: 'next_cursor') String? get nextCursor;@JsonKey(name: 'prev_cursor') String? get prevCursor;
+/// Create a copy of LeaderboardRecordList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LeaderboardRecordListCopyWith<LeaderboardRecordList> get copyWith => _$LeaderboardRecordListCopyWithImpl<LeaderboardRecordList>(this as LeaderboardRecordList, _$identity);
+
+  /// Serializes this LeaderboardRecordList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LeaderboardRecordList&&const DeepCollectionEquality().equals(other.records, records)&&const DeepCollectionEquality().equals(other.ownerRecords, ownerRecords)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.prevCursor, prevCursor) || other.prevCursor == prevCursor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(records),const DeepCollectionEquality().hash(ownerRecords),nextCursor,prevCursor);
+
+@override
+String toString() {
+  return 'LeaderboardRecordList(records: $records, ownerRecords: $ownerRecords, nextCursor: $nextCursor, prevCursor: $prevCursor)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $LeaderboardRecordListCopyWith<$Res> {
-  factory $LeaderboardRecordListCopyWith(LeaderboardRecordList value,
-          $Res Function(LeaderboardRecordList) then) =
-      _$LeaderboardRecordListCopyWithImpl<$Res, LeaderboardRecordList>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'records') List<LeaderboardRecord>? records,
-      @JsonKey(name: 'owner_records') List<LeaderboardRecord>? ownerRecords,
-      @JsonKey(name: 'next_cursor') String? nextCursor,
-      @JsonKey(name: 'prev_cursor') String? prevCursor});
-}
+abstract mixin class $LeaderboardRecordListCopyWith<$Res>  {
+  factory $LeaderboardRecordListCopyWith(LeaderboardRecordList value, $Res Function(LeaderboardRecordList) _then) = _$LeaderboardRecordListCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'records') List<LeaderboardRecord>? records,@JsonKey(name: 'owner_records') List<LeaderboardRecord>? ownerRecords,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor
+});
 
+
+
+
+}
 /// @nodoc
-class _$LeaderboardRecordListCopyWithImpl<$Res,
-        $Val extends LeaderboardRecordList>
+class _$LeaderboardRecordListCopyWithImpl<$Res>
     implements $LeaderboardRecordListCopyWith<$Res> {
-  _$LeaderboardRecordListCopyWithImpl(this._value, this._then);
+  _$LeaderboardRecordListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final LeaderboardRecordList _self;
+  final $Res Function(LeaderboardRecordList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? records = freezed,
-    Object? ownerRecords = freezed,
-    Object? nextCursor = freezed,
-    Object? prevCursor = freezed,
-  }) {
-    return _then(_value.copyWith(
-      records: freezed == records
-          ? _value.records
-          : records // ignore: cast_nullable_to_non_nullable
-              as List<LeaderboardRecord>?,
-      ownerRecords: freezed == ownerRecords
-          ? _value.ownerRecords
-          : ownerRecords // ignore: cast_nullable_to_non_nullable
-              as List<LeaderboardRecord>?,
-      nextCursor: freezed == nextCursor
-          ? _value.nextCursor
-          : nextCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      prevCursor: freezed == prevCursor
-          ? _value.prevCursor
-          : prevCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of LeaderboardRecordList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? records = freezed,Object? ownerRecords = freezed,Object? nextCursor = freezed,Object? prevCursor = freezed,}) {
+  return _then(_self.copyWith(
+records: freezed == records ? _self.records : records // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>?,ownerRecords: freezed == ownerRecords ? _self.ownerRecords : ownerRecords // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>?,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,prevCursor: freezed == prevCursor ? _self.prevCursor : prevCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$LeaderboardRecordListImplCopyWith<$Res>
-    implements $LeaderboardRecordListCopyWith<$Res> {
-  factory _$$LeaderboardRecordListImplCopyWith(
-          _$LeaderboardRecordListImpl value,
-          $Res Function(_$LeaderboardRecordListImpl) then) =
-      __$$LeaderboardRecordListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'records') List<LeaderboardRecord>? records,
-      @JsonKey(name: 'owner_records') List<LeaderboardRecord>? ownerRecords,
-      @JsonKey(name: 'next_cursor') String? nextCursor,
-      @JsonKey(name: 'prev_cursor') String? prevCursor});
 }
 
-/// @nodoc
-class __$$LeaderboardRecordListImplCopyWithImpl<$Res>
-    extends _$LeaderboardRecordListCopyWithImpl<$Res,
-        _$LeaderboardRecordListImpl>
-    implements _$$LeaderboardRecordListImplCopyWith<$Res> {
-  __$$LeaderboardRecordListImplCopyWithImpl(_$LeaderboardRecordListImpl _value,
-      $Res Function(_$LeaderboardRecordListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? records = freezed,
-    Object? ownerRecords = freezed,
-    Object? nextCursor = freezed,
-    Object? prevCursor = freezed,
-  }) {
-    return _then(_$LeaderboardRecordListImpl(
-      records: freezed == records
-          ? _value._records
-          : records // ignore: cast_nullable_to_non_nullable
-              as List<LeaderboardRecord>?,
-      ownerRecords: freezed == ownerRecords
-          ? _value._ownerRecords
-          : ownerRecords // ignore: cast_nullable_to_non_nullable
-              as List<LeaderboardRecord>?,
-      nextCursor: freezed == nextCursor
-          ? _value.nextCursor
-          : nextCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      prevCursor: freezed == prevCursor
-          ? _value.prevCursor
-          : prevCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [LeaderboardRecordList].
+extension LeaderboardRecordListPatterns on LeaderboardRecordList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _LeaderboardRecordList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _LeaderboardRecordList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _LeaderboardRecordList value)  $default,){
+final _that = this;
+switch (_that) {
+case _LeaderboardRecordList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _LeaderboardRecordList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _LeaderboardRecordList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'records')  List<LeaderboardRecord>? records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord>? ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _LeaderboardRecordList() when $default != null:
+return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCursor);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'records')  List<LeaderboardRecord>? records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord>? ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)  $default,) {final _that = this;
+switch (_that) {
+case _LeaderboardRecordList():
+return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCursor);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'records')  List<LeaderboardRecord>? records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord>? ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)?  $default,) {final _that = this;
+switch (_that) {
+case _LeaderboardRecordList() when $default != null:
+return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCursor);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$LeaderboardRecordListImpl extends _LeaderboardRecordList {
-  const _$LeaderboardRecordListImpl(
-      {@JsonKey(name: 'records')
-      required final List<LeaderboardRecord>? records,
-      @JsonKey(name: 'owner_records')
-      required final List<LeaderboardRecord>? ownerRecords,
-      @JsonKey(name: 'next_cursor') this.nextCursor,
-      @JsonKey(name: 'prev_cursor') this.prevCursor})
-      : _records = records,
-        _ownerRecords = ownerRecords,
-        super._();
 
-  factory _$LeaderboardRecordListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LeaderboardRecordListImplFromJson(json);
+class _LeaderboardRecordList extends LeaderboardRecordList {
+  const _LeaderboardRecordList({@JsonKey(name: 'records') required final  List<LeaderboardRecord>? records, @JsonKey(name: 'owner_records') required final  List<LeaderboardRecord>? ownerRecords, @JsonKey(name: 'next_cursor') this.nextCursor, @JsonKey(name: 'prev_cursor') this.prevCursor}): _records = records,_ownerRecords = ownerRecords,super._();
+  factory _LeaderboardRecordList.fromJson(Map<String, dynamic> json) => _$LeaderboardRecordListFromJson(json);
 
-  final List<LeaderboardRecord>? _records;
-  @override
-  @JsonKey(name: 'records')
-  List<LeaderboardRecord>? get records {
-    final value = _records;
-    if (value == null) return null;
-    if (_records is EqualUnmodifiableListView) return _records;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  final List<LeaderboardRecord>? _ownerRecords;
-  @override
-  @JsonKey(name: 'owner_records')
-  List<LeaderboardRecord>? get ownerRecords {
-    final value = _ownerRecords;
-    if (value == null) return null;
-    if (_ownerRecords is EqualUnmodifiableListView) return _ownerRecords;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  @JsonKey(name: 'next_cursor')
-  final String? nextCursor;
-  @override
-  @JsonKey(name: 'prev_cursor')
-  final String? prevCursor;
-
-  @override
-  String toString() {
-    return 'LeaderboardRecordList(records: $records, ownerRecords: $ownerRecords, nextCursor: $nextCursor, prevCursor: $prevCursor)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$LeaderboardRecordListImpl &&
-            const DeepCollectionEquality().equals(other._records, _records) &&
-            const DeepCollectionEquality()
-                .equals(other._ownerRecords, _ownerRecords) &&
-            (identical(other.nextCursor, nextCursor) ||
-                other.nextCursor == nextCursor) &&
-            (identical(other.prevCursor, prevCursor) ||
-                other.prevCursor == prevCursor));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(_records),
-      const DeepCollectionEquality().hash(_ownerRecords),
-      nextCursor,
-      prevCursor);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$LeaderboardRecordListImplCopyWith<_$LeaderboardRecordListImpl>
-      get copyWith => __$$LeaderboardRecordListImplCopyWithImpl<
-          _$LeaderboardRecordListImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$LeaderboardRecordListImplToJson(
-      this,
-    );
-  }
+ final  List<LeaderboardRecord>? _records;
+@override@JsonKey(name: 'records') List<LeaderboardRecord>? get records {
+  final value = _records;
+  if (value == null) return null;
+  if (_records is EqualUnmodifiableListView) return _records;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _LeaderboardRecordList extends LeaderboardRecordList {
-  const factory _LeaderboardRecordList(
-          {@JsonKey(name: 'records')
-          required final List<LeaderboardRecord>? records,
-          @JsonKey(name: 'owner_records')
-          required final List<LeaderboardRecord>? ownerRecords,
-          @JsonKey(name: 'next_cursor') final String? nextCursor,
-          @JsonKey(name: 'prev_cursor') final String? prevCursor}) =
-      _$LeaderboardRecordListImpl;
-  const _LeaderboardRecordList._() : super._();
-
-  factory _LeaderboardRecordList.fromJson(Map<String, dynamic> json) =
-      _$LeaderboardRecordListImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'records')
-  List<LeaderboardRecord>? get records;
-  @override
-  @JsonKey(name: 'owner_records')
-  List<LeaderboardRecord>? get ownerRecords;
-  @override
-  @JsonKey(name: 'next_cursor')
-  String? get nextCursor;
-  @override
-  @JsonKey(name: 'prev_cursor')
-  String? get prevCursor;
-  @override
-  @JsonKey(ignore: true)
-  _$$LeaderboardRecordListImplCopyWith<_$LeaderboardRecordListImpl>
-      get copyWith => throw _privateConstructorUsedError;
+ final  List<LeaderboardRecord>? _ownerRecords;
+@override@JsonKey(name: 'owner_records') List<LeaderboardRecord>? get ownerRecords {
+  final value = _ownerRecords;
+  if (value == null) return null;
+  if (_ownerRecords is EqualUnmodifiableListView) return _ownerRecords;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-LeaderboardRecord _$LeaderboardRecordFromJson(Map<String, dynamic> json) {
-  return _LeaderboardRecord.fromJson(json);
+@override@JsonKey(name: 'next_cursor') final  String? nextCursor;
+@override@JsonKey(name: 'prev_cursor') final  String? prevCursor;
+
+/// Create a copy of LeaderboardRecordList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LeaderboardRecordListCopyWith<_LeaderboardRecordList> get copyWith => __$LeaderboardRecordListCopyWithImpl<_LeaderboardRecordList>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$LeaderboardRecordListToJson(this, );
 }
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LeaderboardRecordList&&const DeepCollectionEquality().equals(other._records, _records)&&const DeepCollectionEquality().equals(other._ownerRecords, _ownerRecords)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.prevCursor, prevCursor) || other.prevCursor == prevCursor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_records),const DeepCollectionEquality().hash(_ownerRecords),nextCursor,prevCursor);
+
+@override
+String toString() {
+  return 'LeaderboardRecordList(records: $records, ownerRecords: $ownerRecords, nextCursor: $nextCursor, prevCursor: $prevCursor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LeaderboardRecordListCopyWith<$Res> implements $LeaderboardRecordListCopyWith<$Res> {
+  factory _$LeaderboardRecordListCopyWith(_LeaderboardRecordList value, $Res Function(_LeaderboardRecordList) _then) = __$LeaderboardRecordListCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'records') List<LeaderboardRecord>? records,@JsonKey(name: 'owner_records') List<LeaderboardRecord>? ownerRecords,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor
+});
+
+
+
+
+}
+/// @nodoc
+class __$LeaderboardRecordListCopyWithImpl<$Res>
+    implements _$LeaderboardRecordListCopyWith<$Res> {
+  __$LeaderboardRecordListCopyWithImpl(this._self, this._then);
+
+  final _LeaderboardRecordList _self;
+  final $Res Function(_LeaderboardRecordList) _then;
+
+/// Create a copy of LeaderboardRecordList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? records = freezed,Object? ownerRecords = freezed,Object? nextCursor = freezed,Object? prevCursor = freezed,}) {
+  return _then(_LeaderboardRecordList(
+records: freezed == records ? _self._records : records // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>?,ownerRecords: freezed == ownerRecords ? _self._ownerRecords : ownerRecords // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>?,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,prevCursor: freezed == prevCursor ? _self.prevCursor : prevCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$LeaderboardRecord {
-  @JsonKey(name: 'leaderboard_id')
-  String? get leaderboardId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'owner_id')
-  String? get ownerId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'username')
-  String? get username => throw _privateConstructorUsedError;
-  @JsonKey(name: 'score')
-  String? get score => throw _privateConstructorUsedError;
-  @JsonKey(name: 'subscore')
-  int? get subscore => throw _privateConstructorUsedError;
-  @JsonKey(name: 'num_score')
-  int? get numScore => throw _privateConstructorUsedError;
-  @JsonKey(name: 'metadata')
-  String? get metadata => throw _privateConstructorUsedError;
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'update_time')
-  DateTime? get updateTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'expiry_time')
-  DateTime? get expiryTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'rank')
-  String? get rank => throw _privateConstructorUsedError;
-  @JsonKey(name: 'max_num_score')
-  int? get maxNumScore => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $LeaderboardRecordCopyWith<LeaderboardRecord> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'leaderboard_id') String? get leaderboardId;@JsonKey(name: 'owner_id') String? get ownerId;@JsonKey(name: 'username') String? get username;@JsonKey(name: 'score') String? get score;@JsonKey(name: 'subscore') int? get subscore;@JsonKey(name: 'num_score') int? get numScore;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;@JsonKey(name: 'expiry_time') DateTime? get expiryTime;@JsonKey(name: 'rank') String? get rank;@JsonKey(name: 'max_num_score') int? get maxNumScore;
+/// Create a copy of LeaderboardRecord
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LeaderboardRecordCopyWith<LeaderboardRecord> get copyWith => _$LeaderboardRecordCopyWithImpl<LeaderboardRecord>(this as LeaderboardRecord, _$identity);
+
+  /// Serializes this LeaderboardRecord to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LeaderboardRecord&&(identical(other.leaderboardId, leaderboardId) || other.leaderboardId == leaderboardId)&&(identical(other.ownerId, ownerId) || other.ownerId == ownerId)&&(identical(other.username, username) || other.username == username)&&(identical(other.score, score) || other.score == score)&&(identical(other.subscore, subscore) || other.subscore == subscore)&&(identical(other.numScore, numScore) || other.numScore == numScore)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime)&&(identical(other.expiryTime, expiryTime) || other.expiryTime == expiryTime)&&(identical(other.rank, rank) || other.rank == rank)&&(identical(other.maxNumScore, maxNumScore) || other.maxNumScore == maxNumScore));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,leaderboardId,ownerId,username,score,subscore,numScore,metadata,createTime,updateTime,expiryTime,rank,maxNumScore);
+
+@override
+String toString() {
+  return 'LeaderboardRecord(leaderboardId: $leaderboardId, ownerId: $ownerId, username: $username, score: $score, subscore: $subscore, numScore: $numScore, metadata: $metadata, createTime: $createTime, updateTime: $updateTime, expiryTime: $expiryTime, rank: $rank, maxNumScore: $maxNumScore)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $LeaderboardRecordCopyWith<$Res> {
-  factory $LeaderboardRecordCopyWith(
-          LeaderboardRecord value, $Res Function(LeaderboardRecord) then) =
-      _$LeaderboardRecordCopyWithImpl<$Res, LeaderboardRecord>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'leaderboard_id') String? leaderboardId,
-      @JsonKey(name: 'owner_id') String? ownerId,
-      @JsonKey(name: 'username') String? username,
-      @JsonKey(name: 'score') String? score,
-      @JsonKey(name: 'subscore') int? subscore,
-      @JsonKey(name: 'num_score') int? numScore,
-      @JsonKey(name: 'metadata') String? metadata,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'update_time') DateTime? updateTime,
-      @JsonKey(name: 'expiry_time') DateTime? expiryTime,
-      @JsonKey(name: 'rank') String? rank,
-      @JsonKey(name: 'max_num_score') int? maxNumScore});
-}
+abstract mixin class $LeaderboardRecordCopyWith<$Res>  {
+  factory $LeaderboardRecordCopyWith(LeaderboardRecord value, $Res Function(LeaderboardRecord) _then) = _$LeaderboardRecordCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score') String? score,@JsonKey(name: 'subscore') int? subscore,@JsonKey(name: 'num_score') int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank') String? rank,@JsonKey(name: 'max_num_score') int? maxNumScore
+});
 
+
+
+
+}
 /// @nodoc
-class _$LeaderboardRecordCopyWithImpl<$Res, $Val extends LeaderboardRecord>
+class _$LeaderboardRecordCopyWithImpl<$Res>
     implements $LeaderboardRecordCopyWith<$Res> {
-  _$LeaderboardRecordCopyWithImpl(this._value, this._then);
+  _$LeaderboardRecordCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final LeaderboardRecord _self;
+  final $Res Function(LeaderboardRecord) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? leaderboardId = freezed,
-    Object? ownerId = freezed,
-    Object? username = freezed,
-    Object? score = freezed,
-    Object? subscore = freezed,
-    Object? numScore = freezed,
-    Object? metadata = freezed,
-    Object? createTime = freezed,
-    Object? updateTime = freezed,
-    Object? expiryTime = freezed,
-    Object? rank = freezed,
-    Object? maxNumScore = freezed,
-  }) {
-    return _then(_value.copyWith(
-      leaderboardId: freezed == leaderboardId
-          ? _value.leaderboardId
-          : leaderboardId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      ownerId: freezed == ownerId
-          ? _value.ownerId
-          : ownerId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      username: freezed == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String?,
-      score: freezed == score
-          ? _value.score
-          : score // ignore: cast_nullable_to_non_nullable
-              as String?,
-      subscore: freezed == subscore
-          ? _value.subscore
-          : subscore // ignore: cast_nullable_to_non_nullable
-              as int?,
-      numScore: freezed == numScore
-          ? _value.numScore
-          : numScore // ignore: cast_nullable_to_non_nullable
-              as int?,
-      metadata: freezed == metadata
-          ? _value.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as String?,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updateTime: freezed == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      expiryTime: freezed == expiryTime
-          ? _value.expiryTime
-          : expiryTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      rank: freezed == rank
-          ? _value.rank
-          : rank // ignore: cast_nullable_to_non_nullable
-              as String?,
-      maxNumScore: freezed == maxNumScore
-          ? _value.maxNumScore
-          : maxNumScore // ignore: cast_nullable_to_non_nullable
-              as int?,
-    ) as $Val);
-  }
+/// Create a copy of LeaderboardRecord
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? leaderboardId = freezed,Object? ownerId = freezed,Object? username = freezed,Object? score = freezed,Object? subscore = freezed,Object? numScore = freezed,Object? metadata = freezed,Object? createTime = freezed,Object? updateTime = freezed,Object? expiryTime = freezed,Object? rank = freezed,Object? maxNumScore = freezed,}) {
+  return _then(_self.copyWith(
+leaderboardId: freezed == leaderboardId ? _self.leaderboardId : leaderboardId // ignore: cast_nullable_to_non_nullable
+as String?,ownerId: freezed == ownerId ? _self.ownerId : ownerId // ignore: cast_nullable_to_non_nullable
+as String?,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String?,score: freezed == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as String?,subscore: freezed == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
+as int?,numScore: freezed == numScore ? _self.numScore : numScore // ignore: cast_nullable_to_non_nullable
+as int?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,expiryTime: freezed == expiryTime ? _self.expiryTime : expiryTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,rank: freezed == rank ? _self.rank : rank // ignore: cast_nullable_to_non_nullable
+as String?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$LeaderboardRecordImplCopyWith<$Res>
-    implements $LeaderboardRecordCopyWith<$Res> {
-  factory _$$LeaderboardRecordImplCopyWith(_$LeaderboardRecordImpl value,
-          $Res Function(_$LeaderboardRecordImpl) then) =
-      __$$LeaderboardRecordImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'leaderboard_id') String? leaderboardId,
-      @JsonKey(name: 'owner_id') String? ownerId,
-      @JsonKey(name: 'username') String? username,
-      @JsonKey(name: 'score') String? score,
-      @JsonKey(name: 'subscore') int? subscore,
-      @JsonKey(name: 'num_score') int? numScore,
-      @JsonKey(name: 'metadata') String? metadata,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'update_time') DateTime? updateTime,
-      @JsonKey(name: 'expiry_time') DateTime? expiryTime,
-      @JsonKey(name: 'rank') String? rank,
-      @JsonKey(name: 'max_num_score') int? maxNumScore});
 }
 
-/// @nodoc
-class __$$LeaderboardRecordImplCopyWithImpl<$Res>
-    extends _$LeaderboardRecordCopyWithImpl<$Res, _$LeaderboardRecordImpl>
-    implements _$$LeaderboardRecordImplCopyWith<$Res> {
-  __$$LeaderboardRecordImplCopyWithImpl(_$LeaderboardRecordImpl _value,
-      $Res Function(_$LeaderboardRecordImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? leaderboardId = freezed,
-    Object? ownerId = freezed,
-    Object? username = freezed,
-    Object? score = freezed,
-    Object? subscore = freezed,
-    Object? numScore = freezed,
-    Object? metadata = freezed,
-    Object? createTime = freezed,
-    Object? updateTime = freezed,
-    Object? expiryTime = freezed,
-    Object? rank = freezed,
-    Object? maxNumScore = freezed,
-  }) {
-    return _then(_$LeaderboardRecordImpl(
-      leaderboardId: freezed == leaderboardId
-          ? _value.leaderboardId
-          : leaderboardId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      ownerId: freezed == ownerId
-          ? _value.ownerId
-          : ownerId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      username: freezed == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String?,
-      score: freezed == score
-          ? _value.score
-          : score // ignore: cast_nullable_to_non_nullable
-              as String?,
-      subscore: freezed == subscore
-          ? _value.subscore
-          : subscore // ignore: cast_nullable_to_non_nullable
-              as int?,
-      numScore: freezed == numScore
-          ? _value.numScore
-          : numScore // ignore: cast_nullable_to_non_nullable
-              as int?,
-      metadata: freezed == metadata
-          ? _value.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as String?,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updateTime: freezed == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      expiryTime: freezed == expiryTime
-          ? _value.expiryTime
-          : expiryTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      rank: freezed == rank
-          ? _value.rank
-          : rank // ignore: cast_nullable_to_non_nullable
-              as String?,
-      maxNumScore: freezed == maxNumScore
-          ? _value.maxNumScore
-          : maxNumScore // ignore: cast_nullable_to_non_nullable
-              as int?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [LeaderboardRecord].
+extension LeaderboardRecordPatterns on LeaderboardRecord {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _LeaderboardRecord value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _LeaderboardRecord() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _LeaderboardRecord value)  $default,){
+final _that = this;
+switch (_that) {
+case _LeaderboardRecord():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _LeaderboardRecord value)?  $default,){
+final _that = this;
+switch (_that) {
+case _LeaderboardRecord() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  String? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  String? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _LeaderboardRecord() when $default != null:
+return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  String? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  String? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)  $default,) {final _that = this;
+switch (_that) {
+case _LeaderboardRecord():
+return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  String? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  String? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)?  $default,) {final _that = this;
+switch (_that) {
+case _LeaderboardRecord() when $default != null:
+return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$LeaderboardRecordImpl extends _LeaderboardRecord {
-  const _$LeaderboardRecordImpl(
-      {@JsonKey(name: 'leaderboard_id') this.leaderboardId,
-      @JsonKey(name: 'owner_id') this.ownerId,
-      @JsonKey(name: 'username') this.username,
-      @JsonKey(name: 'score') this.score,
-      @JsonKey(name: 'subscore') this.subscore,
-      @JsonKey(name: 'num_score') this.numScore,
-      @JsonKey(name: 'metadata') this.metadata,
-      @JsonKey(name: 'create_time') this.createTime,
-      @JsonKey(name: 'update_time') this.updateTime,
-      @JsonKey(name: 'expiry_time') this.expiryTime,
-      @JsonKey(name: 'rank') this.rank,
-      @JsonKey(name: 'max_num_score') this.maxNumScore})
-      : super._();
 
-  factory _$LeaderboardRecordImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LeaderboardRecordImplFromJson(json);
+class _LeaderboardRecord extends LeaderboardRecord {
+  const _LeaderboardRecord({@JsonKey(name: 'leaderboard_id') this.leaderboardId, @JsonKey(name: 'owner_id') this.ownerId, @JsonKey(name: 'username') this.username, @JsonKey(name: 'score') this.score, @JsonKey(name: 'subscore') this.subscore, @JsonKey(name: 'num_score') this.numScore, @JsonKey(name: 'metadata') this.metadata, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'update_time') this.updateTime, @JsonKey(name: 'expiry_time') this.expiryTime, @JsonKey(name: 'rank') this.rank, @JsonKey(name: 'max_num_score') this.maxNumScore}): super._();
+  factory _LeaderboardRecord.fromJson(Map<String, dynamic> json) => _$LeaderboardRecordFromJson(json);
 
-  @override
-  @JsonKey(name: 'leaderboard_id')
-  final String? leaderboardId;
-  @override
-  @JsonKey(name: 'owner_id')
-  final String? ownerId;
-  @override
-  @JsonKey(name: 'username')
-  final String? username;
-  @override
-  @JsonKey(name: 'score')
-  final String? score;
-  @override
-  @JsonKey(name: 'subscore')
-  final int? subscore;
-  @override
-  @JsonKey(name: 'num_score')
-  final int? numScore;
-  @override
-  @JsonKey(name: 'metadata')
-  final String? metadata;
-  @override
-  @JsonKey(name: 'create_time')
-  final DateTime? createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  final DateTime? updateTime;
-  @override
-  @JsonKey(name: 'expiry_time')
-  final DateTime? expiryTime;
-  @override
-  @JsonKey(name: 'rank')
-  final String? rank;
-  @override
-  @JsonKey(name: 'max_num_score')
-  final int? maxNumScore;
+@override@JsonKey(name: 'leaderboard_id') final  String? leaderboardId;
+@override@JsonKey(name: 'owner_id') final  String? ownerId;
+@override@JsonKey(name: 'username') final  String? username;
+@override@JsonKey(name: 'score') final  String? score;
+@override@JsonKey(name: 'subscore') final  int? subscore;
+@override@JsonKey(name: 'num_score') final  int? numScore;
+@override@JsonKey(name: 'metadata') final  String? metadata;
+@override@JsonKey(name: 'create_time') final  DateTime? createTime;
+@override@JsonKey(name: 'update_time') final  DateTime? updateTime;
+@override@JsonKey(name: 'expiry_time') final  DateTime? expiryTime;
+@override@JsonKey(name: 'rank') final  String? rank;
+@override@JsonKey(name: 'max_num_score') final  int? maxNumScore;
 
-  @override
-  String toString() {
-    return 'LeaderboardRecord(leaderboardId: $leaderboardId, ownerId: $ownerId, username: $username, score: $score, subscore: $subscore, numScore: $numScore, metadata: $metadata, createTime: $createTime, updateTime: $updateTime, expiryTime: $expiryTime, rank: $rank, maxNumScore: $maxNumScore)';
-  }
+/// Create a copy of LeaderboardRecord
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LeaderboardRecordCopyWith<_LeaderboardRecord> get copyWith => __$LeaderboardRecordCopyWithImpl<_LeaderboardRecord>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$LeaderboardRecordImpl &&
-            (identical(other.leaderboardId, leaderboardId) ||
-                other.leaderboardId == leaderboardId) &&
-            (identical(other.ownerId, ownerId) || other.ownerId == ownerId) &&
-            (identical(other.username, username) ||
-                other.username == username) &&
-            (identical(other.score, score) || other.score == score) &&
-            (identical(other.subscore, subscore) ||
-                other.subscore == subscore) &&
-            (identical(other.numScore, numScore) ||
-                other.numScore == numScore) &&
-            (identical(other.metadata, metadata) ||
-                other.metadata == metadata) &&
-            (identical(other.createTime, createTime) ||
-                other.createTime == createTime) &&
-            (identical(other.updateTime, updateTime) ||
-                other.updateTime == updateTime) &&
-            (identical(other.expiryTime, expiryTime) ||
-                other.expiryTime == expiryTime) &&
-            (identical(other.rank, rank) || other.rank == rank) &&
-            (identical(other.maxNumScore, maxNumScore) ||
-                other.maxNumScore == maxNumScore));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      leaderboardId,
-      ownerId,
-      username,
-      score,
-      subscore,
-      numScore,
-      metadata,
-      createTime,
-      updateTime,
-      expiryTime,
-      rank,
-      maxNumScore);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$LeaderboardRecordImplCopyWith<_$LeaderboardRecordImpl> get copyWith =>
-      __$$LeaderboardRecordImplCopyWithImpl<_$LeaderboardRecordImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$LeaderboardRecordImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$LeaderboardRecordToJson(this, );
 }
 
-abstract class _LeaderboardRecord extends LeaderboardRecord {
-  const factory _LeaderboardRecord(
-          {@JsonKey(name: 'leaderboard_id') final String? leaderboardId,
-          @JsonKey(name: 'owner_id') final String? ownerId,
-          @JsonKey(name: 'username') final String? username,
-          @JsonKey(name: 'score') final String? score,
-          @JsonKey(name: 'subscore') final int? subscore,
-          @JsonKey(name: 'num_score') final int? numScore,
-          @JsonKey(name: 'metadata') final String? metadata,
-          @JsonKey(name: 'create_time') final DateTime? createTime,
-          @JsonKey(name: 'update_time') final DateTime? updateTime,
-          @JsonKey(name: 'expiry_time') final DateTime? expiryTime,
-          @JsonKey(name: 'rank') final String? rank,
-          @JsonKey(name: 'max_num_score') final int? maxNumScore}) =
-      _$LeaderboardRecordImpl;
-  const _LeaderboardRecord._() : super._();
-
-  factory _LeaderboardRecord.fromJson(Map<String, dynamic> json) =
-      _$LeaderboardRecordImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'leaderboard_id')
-  String? get leaderboardId;
-  @override
-  @JsonKey(name: 'owner_id')
-  String? get ownerId;
-  @override
-  @JsonKey(name: 'username')
-  String? get username;
-  @override
-  @JsonKey(name: 'score')
-  String? get score;
-  @override
-  @JsonKey(name: 'subscore')
-  int? get subscore;
-  @override
-  @JsonKey(name: 'num_score')
-  int? get numScore;
-  @override
-  @JsonKey(name: 'metadata')
-  String? get metadata;
-  @override
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  DateTime? get updateTime;
-  @override
-  @JsonKey(name: 'expiry_time')
-  DateTime? get expiryTime;
-  @override
-  @JsonKey(name: 'rank')
-  String? get rank;
-  @override
-  @JsonKey(name: 'max_num_score')
-  int? get maxNumScore;
-  @override
-  @JsonKey(ignore: true)
-  _$$LeaderboardRecordImplCopyWith<_$LeaderboardRecordImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LeaderboardRecord&&(identical(other.leaderboardId, leaderboardId) || other.leaderboardId == leaderboardId)&&(identical(other.ownerId, ownerId) || other.ownerId == ownerId)&&(identical(other.username, username) || other.username == username)&&(identical(other.score, score) || other.score == score)&&(identical(other.subscore, subscore) || other.subscore == subscore)&&(identical(other.numScore, numScore) || other.numScore == numScore)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime)&&(identical(other.expiryTime, expiryTime) || other.expiryTime == expiryTime)&&(identical(other.rank, rank) || other.rank == rank)&&(identical(other.maxNumScore, maxNumScore) || other.maxNumScore == maxNumScore));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,leaderboardId,ownerId,username,score,subscore,numScore,metadata,createTime,updateTime,expiryTime,rank,maxNumScore);
+
+@override
+String toString() {
+  return 'LeaderboardRecord(leaderboardId: $leaderboardId, ownerId: $ownerId, username: $username, score: $score, subscore: $subscore, numScore: $numScore, metadata: $metadata, createTime: $createTime, updateTime: $updateTime, expiryTime: $expiryTime, rank: $rank, maxNumScore: $maxNumScore)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LeaderboardRecordCopyWith<$Res> implements $LeaderboardRecordCopyWith<$Res> {
+  factory _$LeaderboardRecordCopyWith(_LeaderboardRecord value, $Res Function(_LeaderboardRecord) _then) = __$LeaderboardRecordCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score') String? score,@JsonKey(name: 'subscore') int? subscore,@JsonKey(name: 'num_score') int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank') String? rank,@JsonKey(name: 'max_num_score') int? maxNumScore
+});
+
+
+
+
+}
+/// @nodoc
+class __$LeaderboardRecordCopyWithImpl<$Res>
+    implements _$LeaderboardRecordCopyWith<$Res> {
+  __$LeaderboardRecordCopyWithImpl(this._self, this._then);
+
+  final _LeaderboardRecord _self;
+  final $Res Function(_LeaderboardRecord) _then;
+
+/// Create a copy of LeaderboardRecord
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? leaderboardId = freezed,Object? ownerId = freezed,Object? username = freezed,Object? score = freezed,Object? subscore = freezed,Object? numScore = freezed,Object? metadata = freezed,Object? createTime = freezed,Object? updateTime = freezed,Object? expiryTime = freezed,Object? rank = freezed,Object? maxNumScore = freezed,}) {
+  return _then(_LeaderboardRecord(
+leaderboardId: freezed == leaderboardId ? _self.leaderboardId : leaderboardId // ignore: cast_nullable_to_non_nullable
+as String?,ownerId: freezed == ownerId ? _self.ownerId : ownerId // ignore: cast_nullable_to_non_nullable
+as String?,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String?,score: freezed == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as String?,subscore: freezed == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
+as int?,numScore: freezed == numScore ? _self.numScore : numScore // ignore: cast_nullable_to_non_nullable
+as int?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,expiryTime: freezed == expiryTime ? _self.expiryTime : expiryTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,rank: freezed == rank ? _self.rank : rank // ignore: cast_nullable_to_non_nullable
+as String?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/nakama/lib/src/models/leaderboard.g.dart
+++ b/nakama/lib/src/models/leaderboard.g.dart
@@ -6,37 +6,36 @@ part of 'leaderboard.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$LeaderboardRecordListImpl _$$LeaderboardRecordListImplFromJson(
-        Map<String, dynamic> json) =>
-    _$LeaderboardRecordListImpl(
-      records: (json['records'] as List<dynamic>?)
-          ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      ownerRecords: (json['owner_records'] as List<dynamic>?)
-          ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      nextCursor: json['next_cursor'] as String?,
-      prevCursor: json['prev_cursor'] as String?,
-    );
+_LeaderboardRecordList _$LeaderboardRecordListFromJson(
+  Map<String, dynamic> json,
+) => _LeaderboardRecordList(
+  records: (json['records'] as List<dynamic>?)
+      ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  ownerRecords: (json['owner_records'] as List<dynamic>?)
+      ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  nextCursor: json['next_cursor'] as String?,
+  prevCursor: json['prev_cursor'] as String?,
+);
 
-Map<String, dynamic> _$$LeaderboardRecordListImplToJson(
-        _$LeaderboardRecordListImpl instance) =>
-    <String, dynamic>{
-      'records': instance.records,
-      'owner_records': instance.ownerRecords,
-      'next_cursor': instance.nextCursor,
-      'prev_cursor': instance.prevCursor,
-    };
+Map<String, dynamic> _$LeaderboardRecordListToJson(
+  _LeaderboardRecordList instance,
+) => <String, dynamic>{
+  'records': instance.records,
+  'owner_records': instance.ownerRecords,
+  'next_cursor': instance.nextCursor,
+  'prev_cursor': instance.prevCursor,
+};
 
-_$LeaderboardRecordImpl _$$LeaderboardRecordImplFromJson(
-        Map<String, dynamic> json) =>
-    _$LeaderboardRecordImpl(
+_LeaderboardRecord _$LeaderboardRecordFromJson(Map<String, dynamic> json) =>
+    _LeaderboardRecord(
       leaderboardId: json['leaderboard_id'] as String?,
       ownerId: json['owner_id'] as String?,
       username: json['username'] as String?,
       score: json['score'] as String?,
-      subscore: json['subscore'] as int?,
-      numScore: json['num_score'] as int?,
+      subscore: (json['subscore'] as num?)?.toInt(),
+      numScore: (json['num_score'] as num?)?.toInt(),
       metadata: json['metadata'] as String?,
       createTime: json['create_time'] == null
           ? null
@@ -48,11 +47,10 @@ _$LeaderboardRecordImpl _$$LeaderboardRecordImplFromJson(
           ? null
           : DateTime.parse(json['expiry_time'] as String),
       rank: json['rank'] as String?,
-      maxNumScore: json['max_num_score'] as int?,
+      maxNumScore: (json['max_num_score'] as num?)?.toInt(),
     );
 
-Map<String, dynamic> _$$LeaderboardRecordImplToJson(
-        _$LeaderboardRecordImpl instance) =>
+Map<String, dynamic> _$LeaderboardRecordToJson(_LeaderboardRecord instance) =>
     <String, dynamic>{
       'leaderboard_id': instance.leaderboardId,
       'owner_id': instance.ownerId,

--- a/nakama/lib/src/models/match.dart
+++ b/nakama/lib/src/models/match.dart
@@ -7,7 +7,7 @@ part 'match.freezed.dart';
 part 'match.g.dart';
 
 @freezed
-class Match with _$Match {
+sealed class Match with _$Match {
   const Match._();
 
   const factory Match({
@@ -20,19 +20,9 @@ class Match with _$Match {
     @JsonKey(name: 'presences') required List<UserPresence> presences,
   }) = _Match;
 
-  factory Match.realtime({
-    required String matchId,
-    required bool authoritative,
-    required String label,
-    required int size,
-    int? tickRate,
-    String? handlerName,
-    required List<UserPresence> presences,
-  }) = RealtimeMatch;
-
   factory Match.fromJson(Map<String, Object?> json) => _$MatchFromJson(json);
 
-  factory Match.fromDto(api.Match dto) => Match.realtime(
+  factory Match.fromDto(api.Match dto) => Match(
         matchId: dto.matchId,
         authoritative: dto.authoritative,
         handlerName: dto.handlerName,
@@ -42,7 +32,7 @@ class Match with _$Match {
         presences: [],
       );
 
-  factory Match.fromRtpb(rtpb.Match dto) => Match.realtime(
+  factory Match.fromRtpb(rtpb.Match dto) => Match(
         matchId: dto.matchId,
         authoritative: dto.authoritative,
         label: dto.label.value,
@@ -52,7 +42,7 @@ class Match with _$Match {
 }
 
 @freezed
-class Party with _$Party {
+sealed class Party with _$Party {
   const Party._();
 
   const factory Party({

--- a/nakama/lib/src/models/match.freezed.dart
+++ b/nakama/lib/src/models/match.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,1114 +9,608 @@ part of 'match.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-Match _$MatchFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
-    case 'default':
-      return _Match.fromJson(json);
-    case 'realtime':
-      return RealtimeMatch.fromJson(json);
-
-    default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'Match',
-          'Invalid union type "${json['runtimeType']}"!');
-  }
-}
 
 /// @nodoc
 mixin _$Match {
-  @JsonKey(name: 'match_id')
-  String get matchId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'authoritative')
-  bool get authoritative => throw _privateConstructorUsedError;
-  @JsonKey(name: 'label')
-  String get label => throw _privateConstructorUsedError;
-  @JsonKey(name: 'size')
-  int get size => throw _privateConstructorUsedError;
-  @JsonKey(name: 'tick_rate')
-  int? get tickRate => throw _privateConstructorUsedError;
-  @JsonKey(name: 'handler_name')
-  String? get handlerName => throw _privateConstructorUsedError;
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)
-        $default, {
-    required TResult Function(
-            String matchId,
-            bool authoritative,
-            String label,
-            int size,
-            int? tickRate,
-            String? handlerName,
-            List<UserPresence> presences)
-        realtime,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)?
-        $default, {
-    TResult? Function(
-            String matchId,
-            bool authoritative,
-            String label,
-            int size,
-            int? tickRate,
-            String? handlerName,
-            List<UserPresence> presences)?
-        realtime,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)?
-        $default, {
-    TResult Function(String matchId, bool authoritative, String label, int size,
-            int? tickRate, String? handlerName, List<UserPresence> presences)?
-        realtime,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Match value) $default, {
-    required TResult Function(RealtimeMatch value) realtime,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Match value)? $default, {
-    TResult? Function(RealtimeMatch value)? realtime,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Match value)? $default, {
-    TResult Function(RealtimeMatch value)? realtime,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $MatchCopyWith<Match> get copyWith => throw _privateConstructorUsedError;
+
+@JsonKey(name: 'match_id') String get matchId;@JsonKey(name: 'authoritative') bool get authoritative;@JsonKey(name: 'label') String get label;@JsonKey(name: 'size') int get size;@JsonKey(name: 'tick_rate') int? get tickRate;@JsonKey(name: 'handler_name') String? get handlerName;@JsonKey(name: 'presences') List<UserPresence> get presences;
+/// Create a copy of Match
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchCopyWith<Match> get copyWith => _$MatchCopyWithImpl<Match>(this as Match, _$identity);
+
+  /// Serializes this Match to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Match&&(identical(other.matchId, matchId) || other.matchId == matchId)&&(identical(other.authoritative, authoritative) || other.authoritative == authoritative)&&(identical(other.label, label) || other.label == label)&&(identical(other.size, size) || other.size == size)&&(identical(other.tickRate, tickRate) || other.tickRate == tickRate)&&(identical(other.handlerName, handlerName) || other.handlerName == handlerName)&&const DeepCollectionEquality().equals(other.presences, presences));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,matchId,authoritative,label,size,tickRate,handlerName,const DeepCollectionEquality().hash(presences));
+
+@override
+String toString() {
+  return 'Match(matchId: $matchId, authoritative: $authoritative, label: $label, size: $size, tickRate: $tickRate, handlerName: $handlerName, presences: $presences)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $MatchCopyWith<$Res> {
-  factory $MatchCopyWith(Match value, $Res Function(Match) then) =
-      _$MatchCopyWithImpl<$Res, Match>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'match_id') String matchId,
-      @JsonKey(name: 'authoritative') bool authoritative,
-      @JsonKey(name: 'label') String label,
-      @JsonKey(name: 'size') int size,
-      @JsonKey(name: 'tick_rate') int? tickRate,
-      @JsonKey(name: 'handler_name') String? handlerName,
-      @JsonKey(name: 'presences') List<UserPresence> presences});
-}
+abstract mixin class $MatchCopyWith<$Res>  {
+  factory $MatchCopyWith(Match value, $Res Function(Match) _then) = _$MatchCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'match_id') String matchId,@JsonKey(name: 'authoritative') bool authoritative,@JsonKey(name: 'label') String label,@JsonKey(name: 'size') int size,@JsonKey(name: 'tick_rate') int? tickRate,@JsonKey(name: 'handler_name') String? handlerName,@JsonKey(name: 'presences') List<UserPresence> presences
+});
 
+
+
+
+}
 /// @nodoc
-class _$MatchCopyWithImpl<$Res, $Val extends Match>
+class _$MatchCopyWithImpl<$Res>
     implements $MatchCopyWith<$Res> {
-  _$MatchCopyWithImpl(this._value, this._then);
+  _$MatchCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Match _self;
+  final $Res Function(Match) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? matchId = null,
-    Object? authoritative = null,
-    Object? label = null,
-    Object? size = null,
-    Object? tickRate = freezed,
-    Object? handlerName = freezed,
-    Object? presences = null,
-  }) {
-    return _then(_value.copyWith(
-      matchId: null == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      authoritative: null == authoritative
-          ? _value.authoritative
-          : authoritative // ignore: cast_nullable_to_non_nullable
-              as bool,
-      label: null == label
-          ? _value.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String,
-      size: null == size
-          ? _value.size
-          : size // ignore: cast_nullable_to_non_nullable
-              as int,
-      tickRate: freezed == tickRate
-          ? _value.tickRate
-          : tickRate // ignore: cast_nullable_to_non_nullable
-              as int?,
-      handlerName: freezed == handlerName
-          ? _value.handlerName
-          : handlerName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      presences: null == presences
-          ? _value.presences
-          : presences // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ) as $Val);
-  }
+/// Create a copy of Match
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? matchId = null,Object? authoritative = null,Object? label = null,Object? size = null,Object? tickRate = freezed,Object? handlerName = freezed,Object? presences = null,}) {
+  return _then(_self.copyWith(
+matchId: null == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String,authoritative: null == authoritative ? _self.authoritative : authoritative // ignore: cast_nullable_to_non_nullable
+as bool,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,size: null == size ? _self.size : size // ignore: cast_nullable_to_non_nullable
+as int,tickRate: freezed == tickRate ? _self.tickRate : tickRate // ignore: cast_nullable_to_non_nullable
+as int?,handlerName: freezed == handlerName ? _self.handlerName : handlerName // ignore: cast_nullable_to_non_nullable
+as String?,presences: null == presences ? _self.presences : presences // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
 }
 
-/// @nodoc
-abstract class _$$MatchImplCopyWith<$Res> implements $MatchCopyWith<$Res> {
-  factory _$$MatchImplCopyWith(
-          _$MatchImpl value, $Res Function(_$MatchImpl) then) =
-      __$$MatchImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'match_id') String matchId,
-      @JsonKey(name: 'authoritative') bool authoritative,
-      @JsonKey(name: 'label') String label,
-      @JsonKey(name: 'size') int size,
-      @JsonKey(name: 'tick_rate') int? tickRate,
-      @JsonKey(name: 'handler_name') String? handlerName,
-      @JsonKey(name: 'presences') List<UserPresence> presences});
 }
 
-/// @nodoc
-class __$$MatchImplCopyWithImpl<$Res>
-    extends _$MatchCopyWithImpl<$Res, _$MatchImpl>
-    implements _$$MatchImplCopyWith<$Res> {
-  __$$MatchImplCopyWithImpl(
-      _$MatchImpl _value, $Res Function(_$MatchImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? matchId = null,
-    Object? authoritative = null,
-    Object? label = null,
-    Object? size = null,
-    Object? tickRate = freezed,
-    Object? handlerName = freezed,
-    Object? presences = null,
-  }) {
-    return _then(_$MatchImpl(
-      matchId: null == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      authoritative: null == authoritative
-          ? _value.authoritative
-          : authoritative // ignore: cast_nullable_to_non_nullable
-              as bool,
-      label: null == label
-          ? _value.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String,
-      size: null == size
-          ? _value.size
-          : size // ignore: cast_nullable_to_non_nullable
-              as int,
-      tickRate: freezed == tickRate
-          ? _value.tickRate
-          : tickRate // ignore: cast_nullable_to_non_nullable
-              as int?,
-      handlerName: freezed == handlerName
-          ? _value.handlerName
-          : handlerName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      presences: null == presences
-          ? _value._presences
-          : presences // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Match].
+extension MatchPatterns on Match {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Match value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Match() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Match value)  $default,){
+final _that = this;
+switch (_that) {
+case _Match():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Match value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Match() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'authoritative')  bool authoritative, @JsonKey(name: 'label')  String label, @JsonKey(name: 'size')  int size, @JsonKey(name: 'tick_rate')  int? tickRate, @JsonKey(name: 'handler_name')  String? handlerName, @JsonKey(name: 'presences')  List<UserPresence> presences)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Match() when $default != null:
+return $default(_that.matchId,_that.authoritative,_that.label,_that.size,_that.tickRate,_that.handlerName,_that.presences);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'authoritative')  bool authoritative, @JsonKey(name: 'label')  String label, @JsonKey(name: 'size')  int size, @JsonKey(name: 'tick_rate')  int? tickRate, @JsonKey(name: 'handler_name')  String? handlerName, @JsonKey(name: 'presences')  List<UserPresence> presences)  $default,) {final _that = this;
+switch (_that) {
+case _Match():
+return $default(_that.matchId,_that.authoritative,_that.label,_that.size,_that.tickRate,_that.handlerName,_that.presences);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'authoritative')  bool authoritative, @JsonKey(name: 'label')  String label, @JsonKey(name: 'size')  int size, @JsonKey(name: 'tick_rate')  int? tickRate, @JsonKey(name: 'handler_name')  String? handlerName, @JsonKey(name: 'presences')  List<UserPresence> presences)?  $default,) {final _that = this;
+switch (_that) {
+case _Match() when $default != null:
+return $default(_that.matchId,_that.authoritative,_that.label,_that.size,_that.tickRate,_that.handlerName,_that.presences);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$MatchImpl extends _Match {
-  const _$MatchImpl(
-      {@JsonKey(name: 'match_id') required this.matchId,
-      @JsonKey(name: 'authoritative') required this.authoritative,
-      @JsonKey(name: 'label') required this.label,
-      @JsonKey(name: 'size') required this.size,
-      @JsonKey(name: 'tick_rate') this.tickRate,
-      @JsonKey(name: 'handler_name') this.handlerName,
-      @JsonKey(name: 'presences') required final List<UserPresence> presences,
-      final String? $type})
-      : _presences = presences,
-        $type = $type ?? 'default',
-        super._();
 
-  factory _$MatchImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MatchImplFromJson(json);
+class _Match extends Match {
+  const _Match({@JsonKey(name: 'match_id') required this.matchId, @JsonKey(name: 'authoritative') required this.authoritative, @JsonKey(name: 'label') required this.label, @JsonKey(name: 'size') required this.size, @JsonKey(name: 'tick_rate') this.tickRate, @JsonKey(name: 'handler_name') this.handlerName, @JsonKey(name: 'presences') required final  List<UserPresence> presences}): _presences = presences,super._();
+  factory _Match.fromJson(Map<String, dynamic> json) => _$MatchFromJson(json);
 
-  @override
-  @JsonKey(name: 'match_id')
-  final String matchId;
-  @override
-  @JsonKey(name: 'authoritative')
-  final bool authoritative;
-  @override
-  @JsonKey(name: 'label')
-  final String label;
-  @override
-  @JsonKey(name: 'size')
-  final int size;
-  @override
-  @JsonKey(name: 'tick_rate')
-  final int? tickRate;
-  @override
-  @JsonKey(name: 'handler_name')
-  final String? handlerName;
-  final List<UserPresence> _presences;
-  @override
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences {
-    if (_presences is EqualUnmodifiableListView) return _presences;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_presences);
-  }
-
-  @JsonKey(name: 'runtimeType')
-  final String $type;
-
-  @override
-  String toString() {
-    return 'Match(matchId: $matchId, authoritative: $authoritative, label: $label, size: $size, tickRate: $tickRate, handlerName: $handlerName, presences: $presences)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MatchImpl &&
-            (identical(other.matchId, matchId) || other.matchId == matchId) &&
-            (identical(other.authoritative, authoritative) ||
-                other.authoritative == authoritative) &&
-            (identical(other.label, label) || other.label == label) &&
-            (identical(other.size, size) || other.size == size) &&
-            (identical(other.tickRate, tickRate) ||
-                other.tickRate == tickRate) &&
-            (identical(other.handlerName, handlerName) ||
-                other.handlerName == handlerName) &&
-            const DeepCollectionEquality()
-                .equals(other._presences, _presences));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      matchId,
-      authoritative,
-      label,
-      size,
-      tickRate,
-      handlerName,
-      const DeepCollectionEquality().hash(_presences));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MatchImplCopyWith<_$MatchImpl> get copyWith =>
-      __$$MatchImplCopyWithImpl<_$MatchImpl>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)
-        $default, {
-    required TResult Function(
-            String matchId,
-            bool authoritative,
-            String label,
-            int size,
-            int? tickRate,
-            String? handlerName,
-            List<UserPresence> presences)
-        realtime,
-  }) {
-    return $default(
-        matchId, authoritative, label, size, tickRate, handlerName, presences);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)?
-        $default, {
-    TResult? Function(
-            String matchId,
-            bool authoritative,
-            String label,
-            int size,
-            int? tickRate,
-            String? handlerName,
-            List<UserPresence> presences)?
-        realtime,
-  }) {
-    return $default?.call(
-        matchId, authoritative, label, size, tickRate, handlerName, presences);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)?
-        $default, {
-    TResult Function(String matchId, bool authoritative, String label, int size,
-            int? tickRate, String? handlerName, List<UserPresence> presences)?
-        realtime,
-    required TResult orElse(),
-  }) {
-    if ($default != null) {
-      return $default(matchId, authoritative, label, size, tickRate,
-          handlerName, presences);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Match value) $default, {
-    required TResult Function(RealtimeMatch value) realtime,
-  }) {
-    return $default(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Match value)? $default, {
-    TResult? Function(RealtimeMatch value)? realtime,
-  }) {
-    return $default?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Match value)? $default, {
-    TResult Function(RealtimeMatch value)? realtime,
-    required TResult orElse(),
-  }) {
-    if ($default != null) {
-      return $default(this);
-    }
-    return orElse();
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$MatchImplToJson(
-      this,
-    );
-  }
+@override@JsonKey(name: 'match_id') final  String matchId;
+@override@JsonKey(name: 'authoritative') final  bool authoritative;
+@override@JsonKey(name: 'label') final  String label;
+@override@JsonKey(name: 'size') final  int size;
+@override@JsonKey(name: 'tick_rate') final  int? tickRate;
+@override@JsonKey(name: 'handler_name') final  String? handlerName;
+ final  List<UserPresence> _presences;
+@override@JsonKey(name: 'presences') List<UserPresence> get presences {
+  if (_presences is EqualUnmodifiableListView) return _presences;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_presences);
 }
 
-abstract class _Match extends Match {
-  const factory _Match(
-      {@JsonKey(name: 'match_id') required final String matchId,
-      @JsonKey(name: 'authoritative') required final bool authoritative,
-      @JsonKey(name: 'label') required final String label,
-      @JsonKey(name: 'size') required final int size,
-      @JsonKey(name: 'tick_rate') final int? tickRate,
-      @JsonKey(name: 'handler_name') final String? handlerName,
-      @JsonKey(name: 'presences')
-      required final List<UserPresence> presences}) = _$MatchImpl;
-  const _Match._() : super._();
 
-  factory _Match.fromJson(Map<String, dynamic> json) = _$MatchImpl.fromJson;
+/// Create a copy of Match
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchCopyWith<_Match> get copyWith => __$MatchCopyWithImpl<_Match>(this, _$identity);
 
-  @override
-  @JsonKey(name: 'match_id')
-  String get matchId;
-  @override
-  @JsonKey(name: 'authoritative')
-  bool get authoritative;
-  @override
-  @JsonKey(name: 'label')
-  String get label;
-  @override
-  @JsonKey(name: 'size')
-  int get size;
-  @override
-  @JsonKey(name: 'tick_rate')
-  int? get tickRate;
-  @override
-  @JsonKey(name: 'handler_name')
-  String? get handlerName;
-  @override
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences;
-  @override
-  @JsonKey(ignore: true)
-  _$$MatchImplCopyWith<_$MatchImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$MatchToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Match&&(identical(other.matchId, matchId) || other.matchId == matchId)&&(identical(other.authoritative, authoritative) || other.authoritative == authoritative)&&(identical(other.label, label) || other.label == label)&&(identical(other.size, size) || other.size == size)&&(identical(other.tickRate, tickRate) || other.tickRate == tickRate)&&(identical(other.handlerName, handlerName) || other.handlerName == handlerName)&&const DeepCollectionEquality().equals(other._presences, _presences));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,matchId,authoritative,label,size,tickRate,handlerName,const DeepCollectionEquality().hash(_presences));
+
+@override
+String toString() {
+  return 'Match(matchId: $matchId, authoritative: $authoritative, label: $label, size: $size, tickRate: $tickRate, handlerName: $handlerName, presences: $presences)';
+}
+
+
 }
 
 /// @nodoc
-abstract class _$$RealtimeMatchImplCopyWith<$Res>
-    implements $MatchCopyWith<$Res> {
-  factory _$$RealtimeMatchImplCopyWith(
-          _$RealtimeMatchImpl value, $Res Function(_$RealtimeMatchImpl) then) =
-      __$$RealtimeMatchImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String matchId,
-      bool authoritative,
-      String label,
-      int size,
-      int? tickRate,
-      String? handlerName,
-      List<UserPresence> presences});
-}
+abstract mixin class _$MatchCopyWith<$Res> implements $MatchCopyWith<$Res> {
+  factory _$MatchCopyWith(_Match value, $Res Function(_Match) _then) = __$MatchCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'match_id') String matchId,@JsonKey(name: 'authoritative') bool authoritative,@JsonKey(name: 'label') String label,@JsonKey(name: 'size') int size,@JsonKey(name: 'tick_rate') int? tickRate,@JsonKey(name: 'handler_name') String? handlerName,@JsonKey(name: 'presences') List<UserPresence> presences
+});
 
+
+
+
+}
 /// @nodoc
-class __$$RealtimeMatchImplCopyWithImpl<$Res>
-    extends _$MatchCopyWithImpl<$Res, _$RealtimeMatchImpl>
-    implements _$$RealtimeMatchImplCopyWith<$Res> {
-  __$$RealtimeMatchImplCopyWithImpl(
-      _$RealtimeMatchImpl _value, $Res Function(_$RealtimeMatchImpl) _then)
-      : super(_value, _then);
+class __$MatchCopyWithImpl<$Res>
+    implements _$MatchCopyWith<$Res> {
+  __$MatchCopyWithImpl(this._self, this._then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? matchId = null,
-    Object? authoritative = null,
-    Object? label = null,
-    Object? size = null,
-    Object? tickRate = freezed,
-    Object? handlerName = freezed,
-    Object? presences = null,
-  }) {
-    return _then(_$RealtimeMatchImpl(
-      matchId: null == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      authoritative: null == authoritative
-          ? _value.authoritative
-          : authoritative // ignore: cast_nullable_to_non_nullable
-              as bool,
-      label: null == label
-          ? _value.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String,
-      size: null == size
-          ? _value.size
-          : size // ignore: cast_nullable_to_non_nullable
-              as int,
-      tickRate: freezed == tickRate
-          ? _value.tickRate
-          : tickRate // ignore: cast_nullable_to_non_nullable
-              as int?,
-      handlerName: freezed == handlerName
-          ? _value.handlerName
-          : handlerName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      presences: null == presences
-          ? _value._presences
-          : presences // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ));
-  }
+  final _Match _self;
+  final $Res Function(_Match) _then;
+
+/// Create a copy of Match
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? matchId = null,Object? authoritative = null,Object? label = null,Object? size = null,Object? tickRate = freezed,Object? handlerName = freezed,Object? presences = null,}) {
+  return _then(_Match(
+matchId: null == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String,authoritative: null == authoritative ? _self.authoritative : authoritative // ignore: cast_nullable_to_non_nullable
+as bool,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,size: null == size ? _self.size : size // ignore: cast_nullable_to_non_nullable
+as int,tickRate: freezed == tickRate ? _self.tickRate : tickRate // ignore: cast_nullable_to_non_nullable
+as int?,handlerName: freezed == handlerName ? _self.handlerName : handlerName // ignore: cast_nullable_to_non_nullable
+as String?,presences: null == presences ? _self._presences : presences // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
 }
 
-/// @nodoc
-@JsonSerializable()
-class _$RealtimeMatchImpl extends RealtimeMatch {
-  _$RealtimeMatchImpl(
-      {required this.matchId,
-      required this.authoritative,
-      required this.label,
-      required this.size,
-      this.tickRate,
-      this.handlerName,
-      required final List<UserPresence> presences,
-      final String? $type})
-      : _presences = presences,
-        $type = $type ?? 'realtime',
-        super._();
 
-  factory _$RealtimeMatchImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RealtimeMatchImplFromJson(json);
-
-  @override
-  final String matchId;
-  @override
-  final bool authoritative;
-  @override
-  final String label;
-  @override
-  final int size;
-  @override
-  final int? tickRate;
-  @override
-  final String? handlerName;
-  final List<UserPresence> _presences;
-  @override
-  List<UserPresence> get presences {
-    if (_presences is EqualUnmodifiableListView) return _presences;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_presences);
-  }
-
-  @JsonKey(name: 'runtimeType')
-  final String $type;
-
-  @override
-  String toString() {
-    return 'Match.realtime(matchId: $matchId, authoritative: $authoritative, label: $label, size: $size, tickRate: $tickRate, handlerName: $handlerName, presences: $presences)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$RealtimeMatchImpl &&
-            (identical(other.matchId, matchId) || other.matchId == matchId) &&
-            (identical(other.authoritative, authoritative) ||
-                other.authoritative == authoritative) &&
-            (identical(other.label, label) || other.label == label) &&
-            (identical(other.size, size) || other.size == size) &&
-            (identical(other.tickRate, tickRate) ||
-                other.tickRate == tickRate) &&
-            (identical(other.handlerName, handlerName) ||
-                other.handlerName == handlerName) &&
-            const DeepCollectionEquality()
-                .equals(other._presences, _presences));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      matchId,
-      authoritative,
-      label,
-      size,
-      tickRate,
-      handlerName,
-      const DeepCollectionEquality().hash(_presences));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$RealtimeMatchImplCopyWith<_$RealtimeMatchImpl> get copyWith =>
-      __$$RealtimeMatchImplCopyWithImpl<_$RealtimeMatchImpl>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)
-        $default, {
-    required TResult Function(
-            String matchId,
-            bool authoritative,
-            String label,
-            int size,
-            int? tickRate,
-            String? handlerName,
-            List<UserPresence> presences)
-        realtime,
-  }) {
-    return realtime(
-        matchId, authoritative, label, size, tickRate, handlerName, presences);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)?
-        $default, {
-    TResult? Function(
-            String matchId,
-            bool authoritative,
-            String label,
-            int size,
-            int? tickRate,
-            String? handlerName,
-            List<UserPresence> presences)?
-        realtime,
-  }) {
-    return realtime?.call(
-        matchId, authoritative, label, size, tickRate, handlerName, presences);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'authoritative') bool authoritative,
-            @JsonKey(name: 'label') String label,
-            @JsonKey(name: 'size') int size,
-            @JsonKey(name: 'tick_rate') int? tickRate,
-            @JsonKey(name: 'handler_name') String? handlerName,
-            @JsonKey(name: 'presences') List<UserPresence> presences)?
-        $default, {
-    TResult Function(String matchId, bool authoritative, String label, int size,
-            int? tickRate, String? handlerName, List<UserPresence> presences)?
-        realtime,
-    required TResult orElse(),
-  }) {
-    if (realtime != null) {
-      return realtime(matchId, authoritative, label, size, tickRate,
-          handlerName, presences);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Match value) $default, {
-    required TResult Function(RealtimeMatch value) realtime,
-  }) {
-    return realtime(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Match value)? $default, {
-    TResult? Function(RealtimeMatch value)? realtime,
-  }) {
-    return realtime?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Match value)? $default, {
-    TResult Function(RealtimeMatch value)? realtime,
-    required TResult orElse(),
-  }) {
-    if (realtime != null) {
-      return realtime(this);
-    }
-    return orElse();
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$RealtimeMatchImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class RealtimeMatch extends Match {
-  factory RealtimeMatch(
-      {required final String matchId,
-      required final bool authoritative,
-      required final String label,
-      required final int size,
-      final int? tickRate,
-      final String? handlerName,
-      required final List<UserPresence> presences}) = _$RealtimeMatchImpl;
-  RealtimeMatch._() : super._();
-
-  factory RealtimeMatch.fromJson(Map<String, dynamic> json) =
-      _$RealtimeMatchImpl.fromJson;
-
-  @override
-  String get matchId;
-  @override
-  bool get authoritative;
-  @override
-  String get label;
-  @override
-  int get size;
-  @override
-  int? get tickRate;
-  @override
-  String? get handlerName;
-  @override
-  List<UserPresence> get presences;
-  @override
-  @JsonKey(ignore: true)
-  _$$RealtimeMatchImplCopyWith<_$RealtimeMatchImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 mixin _$Party {
-  /// Unique party identifier.
-  @JsonKey(name: 'party_id')
-  String get partyId => throw _privateConstructorUsedError;
 
-  /// Open flag.
-  @JsonKey(name: 'open')
-  bool get open => throw _privateConstructorUsedError;
+/// Unique party identifier.
+@JsonKey(name: 'party_id') String get partyId;/// Open flag.
+@JsonKey(name: 'open') bool get open;/// Maximum number of party members.
+@JsonKey(name: 'max_size') int get maxSize;/// Self.
+@JsonKey(name: 'self') UserPresence get self;/// Leader.
+@JsonKey(name: 'leader') UserPresence get leader;/// All current party members.
+@JsonKey(name: 'presences') List<UserPresence> get presences;
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartyCopyWith<Party> get copyWith => _$PartyCopyWithImpl<Party>(this as Party, _$identity);
 
-  /// Maximum number of party members.
-  @JsonKey(name: 'max_size')
-  int get maxSize => throw _privateConstructorUsedError;
 
-  /// Self.
-  @JsonKey(name: 'self')
-  UserPresence get self => throw _privateConstructorUsedError;
 
-  /// Leader.
-  @JsonKey(name: 'leader')
-  UserPresence get leader => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Party&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.open, open) || other.open == open)&&(identical(other.maxSize, maxSize) || other.maxSize == maxSize)&&(identical(other.self, self) || other.self == self)&&(identical(other.leader, leader) || other.leader == leader)&&const DeepCollectionEquality().equals(other.presences, presences));
+}
 
-  /// All current party members.
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $PartyCopyWith<Party> get copyWith => throw _privateConstructorUsedError;
+@override
+int get hashCode => Object.hash(runtimeType,partyId,open,maxSize,self,leader,const DeepCollectionEquality().hash(presences));
+
+@override
+String toString() {
+  return 'Party(partyId: $partyId, open: $open, maxSize: $maxSize, self: $self, leader: $leader, presences: $presences)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $PartyCopyWith<$Res> {
-  factory $PartyCopyWith(Party value, $Res Function(Party) then) =
-      _$PartyCopyWithImpl<$Res, Party>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'open') bool open,
-      @JsonKey(name: 'max_size') int maxSize,
-      @JsonKey(name: 'self') UserPresence self,
-      @JsonKey(name: 'leader') UserPresence leader,
-      @JsonKey(name: 'presences') List<UserPresence> presences});
+abstract mixin class $PartyCopyWith<$Res>  {
+  factory $PartyCopyWith(Party value, $Res Function(Party) _then) = _$PartyCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'open') bool open,@JsonKey(name: 'max_size') int maxSize,@JsonKey(name: 'self') UserPresence self,@JsonKey(name: 'leader') UserPresence leader,@JsonKey(name: 'presences') List<UserPresence> presences
+});
 
-  $UserPresenceCopyWith<$Res> get self;
-  $UserPresenceCopyWith<$Res> get leader;
+
+$UserPresenceCopyWith<$Res> get self;$UserPresenceCopyWith<$Res> get leader;
+
 }
-
 /// @nodoc
-class _$PartyCopyWithImpl<$Res, $Val extends Party>
+class _$PartyCopyWithImpl<$Res>
     implements $PartyCopyWith<$Res> {
-  _$PartyCopyWithImpl(this._value, this._then);
+  _$PartyCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Party _self;
+  final $Res Function(Party) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? open = null,
-    Object? maxSize = null,
-    Object? self = null,
-    Object? leader = null,
-    Object? presences = null,
-  }) {
-    return _then(_value.copyWith(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      open: null == open
-          ? _value.open
-          : open // ignore: cast_nullable_to_non_nullable
-              as bool,
-      maxSize: null == maxSize
-          ? _value.maxSize
-          : maxSize // ignore: cast_nullable_to_non_nullable
-              as int,
-      self: null == self
-          ? _value.self
-          : self // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      leader: null == leader
-          ? _value.leader
-          : leader // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      presences: null == presences
-          ? _value.presences
-          : presences // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ) as $Val);
-  }
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,Object? open = null,Object? maxSize = null,Object? self = null,Object? leader = null,Object? presences = null,}) {
+  return _then(_self.copyWith(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,open: null == open ? _self.open : open // ignore: cast_nullable_to_non_nullable
+as bool,maxSize: null == maxSize ? _self.maxSize : maxSize // ignore: cast_nullable_to_non_nullable
+as int,self: null == self ? _self.self : self // ignore: cast_nullable_to_non_nullable
+as UserPresence,leader: null == leader ? _self.leader : leader // ignore: cast_nullable_to_non_nullable
+as UserPresence,presences: null == presences ? _self.presences : presences // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
+}
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get self {
+  
+  return $UserPresenceCopyWith<$Res>(_self.self, (value) {
+    return _then(_self.copyWith(self: value));
+  });
+}/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get leader {
+  
+  return $UserPresenceCopyWith<$Res>(_self.leader, (value) {
+    return _then(_self.copyWith(leader: value));
+  });
+}
+}
 
-  @override
-  @pragma('vm:prefer-inline')
-  $UserPresenceCopyWith<$Res> get self {
-    return $UserPresenceCopyWith<$Res>(_value.self, (value) {
-      return _then(_value.copyWith(self: value) as $Val);
-    });
-  }
 
-  @override
-  @pragma('vm:prefer-inline')
-  $UserPresenceCopyWith<$Res> get leader {
-    return $UserPresenceCopyWith<$Res>(_value.leader, (value) {
-      return _then(_value.copyWith(leader: value) as $Val);
-    });
-  }
+/// Adds pattern-matching-related methods to [Party].
+extension PartyPatterns on Party {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Party value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Party() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Party value)  $default,){
+final _that = this;
+switch (_that) {
+case _Party():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Party value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Party() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'open')  bool open, @JsonKey(name: 'max_size')  int maxSize, @JsonKey(name: 'self')  UserPresence self, @JsonKey(name: 'leader')  UserPresence leader, @JsonKey(name: 'presences')  List<UserPresence> presences)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Party() when $default != null:
+return $default(_that.partyId,_that.open,_that.maxSize,_that.self,_that.leader,_that.presences);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'open')  bool open, @JsonKey(name: 'max_size')  int maxSize, @JsonKey(name: 'self')  UserPresence self, @JsonKey(name: 'leader')  UserPresence leader, @JsonKey(name: 'presences')  List<UserPresence> presences)  $default,) {final _that = this;
+switch (_that) {
+case _Party():
+return $default(_that.partyId,_that.open,_that.maxSize,_that.self,_that.leader,_that.presences);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'open')  bool open, @JsonKey(name: 'max_size')  int maxSize, @JsonKey(name: 'self')  UserPresence self, @JsonKey(name: 'leader')  UserPresence leader, @JsonKey(name: 'presences')  List<UserPresence> presences)?  $default,) {final _that = this;
+switch (_that) {
+case _Party() when $default != null:
+return $default(_that.partyId,_that.open,_that.maxSize,_that.self,_that.leader,_that.presences);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$PartyImplCopyWith<$Res> implements $PartyCopyWith<$Res> {
-  factory _$$PartyImplCopyWith(
-          _$PartyImpl value, $Res Function(_$PartyImpl) then) =
-      __$$PartyImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'open') bool open,
-      @JsonKey(name: 'max_size') int maxSize,
-      @JsonKey(name: 'self') UserPresence self,
-      @JsonKey(name: 'leader') UserPresence leader,
-      @JsonKey(name: 'presences') List<UserPresence> presences});
 
-  @override
-  $UserPresenceCopyWith<$Res> get self;
-  @override
-  $UserPresenceCopyWith<$Res> get leader;
+
+class _Party extends Party {
+  const _Party({@JsonKey(name: 'party_id') required this.partyId, @JsonKey(name: 'open') required this.open, @JsonKey(name: 'max_size') required this.maxSize, @JsonKey(name: 'self') required this.self, @JsonKey(name: 'leader') required this.leader, @JsonKey(name: 'presences') required final  List<UserPresence> presences}): _presences = presences,super._();
+  
+
+/// Unique party identifier.
+@override@JsonKey(name: 'party_id') final  String partyId;
+/// Open flag.
+@override@JsonKey(name: 'open') final  bool open;
+/// Maximum number of party members.
+@override@JsonKey(name: 'max_size') final  int maxSize;
+/// Self.
+@override@JsonKey(name: 'self') final  UserPresence self;
+/// Leader.
+@override@JsonKey(name: 'leader') final  UserPresence leader;
+/// All current party members.
+ final  List<UserPresence> _presences;
+/// All current party members.
+@override@JsonKey(name: 'presences') List<UserPresence> get presences {
+  if (_presences is EqualUnmodifiableListView) return _presences;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_presences);
+}
+
+
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartyCopyWith<_Party> get copyWith => __$PartyCopyWithImpl<_Party>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Party&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.open, open) || other.open == open)&&(identical(other.maxSize, maxSize) || other.maxSize == maxSize)&&(identical(other.self, self) || other.self == self)&&(identical(other.leader, leader) || other.leader == leader)&&const DeepCollectionEquality().equals(other._presences, _presences));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,open,maxSize,self,leader,const DeepCollectionEquality().hash(_presences));
+
+@override
+String toString() {
+  return 'Party(partyId: $partyId, open: $open, maxSize: $maxSize, self: $self, leader: $leader, presences: $presences)';
+}
+
+
 }
 
 /// @nodoc
-class __$$PartyImplCopyWithImpl<$Res>
-    extends _$PartyCopyWithImpl<$Res, _$PartyImpl>
-    implements _$$PartyImplCopyWith<$Res> {
-  __$$PartyImplCopyWithImpl(
-      _$PartyImpl _value, $Res Function(_$PartyImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$PartyCopyWith<$Res> implements $PartyCopyWith<$Res> {
+  factory _$PartyCopyWith(_Party value, $Res Function(_Party) _then) = __$PartyCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'open') bool open,@JsonKey(name: 'max_size') int maxSize,@JsonKey(name: 'self') UserPresence self,@JsonKey(name: 'leader') UserPresence leader,@JsonKey(name: 'presences') List<UserPresence> presences
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? open = null,
-    Object? maxSize = null,
-    Object? self = null,
-    Object? leader = null,
-    Object? presences = null,
-  }) {
-    return _then(_$PartyImpl(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      open: null == open
-          ? _value.open
-          : open // ignore: cast_nullable_to_non_nullable
-              as bool,
-      maxSize: null == maxSize
-          ? _value.maxSize
-          : maxSize // ignore: cast_nullable_to_non_nullable
-              as int,
-      self: null == self
-          ? _value.self
-          : self // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      leader: null == leader
-          ? _value.leader
-          : leader // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      presences: null == presences
-          ? _value._presences
-          : presences // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ));
-  }
+
+@override $UserPresenceCopyWith<$Res> get self;@override $UserPresenceCopyWith<$Res> get leader;
+
 }
-
 /// @nodoc
+class __$PartyCopyWithImpl<$Res>
+    implements _$PartyCopyWith<$Res> {
+  __$PartyCopyWithImpl(this._self, this._then);
 
-class _$PartyImpl extends _Party {
-  const _$PartyImpl(
-      {@JsonKey(name: 'party_id') required this.partyId,
-      @JsonKey(name: 'open') required this.open,
-      @JsonKey(name: 'max_size') required this.maxSize,
-      @JsonKey(name: 'self') required this.self,
-      @JsonKey(name: 'leader') required this.leader,
-      @JsonKey(name: 'presences') required final List<UserPresence> presences})
-      : _presences = presences,
-        super._();
+  final _Party _self;
+  final $Res Function(_Party) _then;
 
-  /// Unique party identifier.
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-
-  /// Open flag.
-  @override
-  @JsonKey(name: 'open')
-  final bool open;
-
-  /// Maximum number of party members.
-  @override
-  @JsonKey(name: 'max_size')
-  final int maxSize;
-
-  /// Self.
-  @override
-  @JsonKey(name: 'self')
-  final UserPresence self;
-
-  /// Leader.
-  @override
-  @JsonKey(name: 'leader')
-  final UserPresence leader;
-
-  /// All current party members.
-  final List<UserPresence> _presences;
-
-  /// All current party members.
-  @override
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences {
-    if (_presences is EqualUnmodifiableListView) return _presences;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_presences);
-  }
-
-  @override
-  String toString() {
-    return 'Party(partyId: $partyId, open: $open, maxSize: $maxSize, self: $self, leader: $leader, presences: $presences)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$PartyImpl &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.open, open) || other.open == open) &&
-            (identical(other.maxSize, maxSize) || other.maxSize == maxSize) &&
-            (identical(other.self, self) || other.self == self) &&
-            (identical(other.leader, leader) || other.leader == leader) &&
-            const DeepCollectionEquality()
-                .equals(other._presences, _presences));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, partyId, open, maxSize, self,
-      leader, const DeepCollectionEquality().hash(_presences));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$PartyImplCopyWith<_$PartyImpl> get copyWith =>
-      __$$PartyImplCopyWithImpl<_$PartyImpl>(this, _$identity);
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,Object? open = null,Object? maxSize = null,Object? self = null,Object? leader = null,Object? presences = null,}) {
+  return _then(_Party(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,open: null == open ? _self.open : open // ignore: cast_nullable_to_non_nullable
+as bool,maxSize: null == maxSize ? _self.maxSize : maxSize // ignore: cast_nullable_to_non_nullable
+as int,self: null == self ? _self.self : self // ignore: cast_nullable_to_non_nullable
+as UserPresence,leader: null == leader ? _self.leader : leader // ignore: cast_nullable_to_non_nullable
+as UserPresence,presences: null == presences ? _self._presences : presences // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
 }
 
-abstract class _Party extends Party {
-  const factory _Party(
-      {@JsonKey(name: 'party_id') required final String partyId,
-      @JsonKey(name: 'open') required final bool open,
-      @JsonKey(name: 'max_size') required final int maxSize,
-      @JsonKey(name: 'self') required final UserPresence self,
-      @JsonKey(name: 'leader') required final UserPresence leader,
-      @JsonKey(name: 'presences')
-      required final List<UserPresence> presences}) = _$PartyImpl;
-  const _Party._() : super._();
-
-  @override
-
-  /// Unique party identifier.
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  @override
-
-  /// Open flag.
-  @JsonKey(name: 'open')
-  bool get open;
-  @override
-
-  /// Maximum number of party members.
-  @JsonKey(name: 'max_size')
-  int get maxSize;
-  @override
-
-  /// Self.
-  @JsonKey(name: 'self')
-  UserPresence get self;
-  @override
-
-  /// Leader.
-  @JsonKey(name: 'leader')
-  UserPresence get leader;
-  @override
-
-  /// All current party members.
-  @JsonKey(name: 'presences')
-  List<UserPresence> get presences;
-  @override
-  @JsonKey(ignore: true)
-  _$$PartyImplCopyWith<_$PartyImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get self {
+  
+  return $UserPresenceCopyWith<$Res>(_self.self, (value) {
+    return _then(_self.copyWith(self: value));
+  });
+}/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get leader {
+  
+  return $UserPresenceCopyWith<$Res>(_self.leader, (value) {
+    return _then(_self.copyWith(leader: value));
+  });
 }
+}
+
+// dart format on

--- a/nakama/lib/src/models/match.g.dart
+++ b/nakama/lib/src/models/match.g.dart
@@ -6,53 +6,24 @@ part of 'match.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$MatchImpl _$$MatchImplFromJson(Map<String, dynamic> json) => _$MatchImpl(
-      matchId: json['match_id'] as String,
-      authoritative: json['authoritative'] as bool,
-      label: json['label'] as String,
-      size: json['size'] as int,
-      tickRate: json['tick_rate'] as int?,
-      handlerName: json['handler_name'] as String?,
-      presences: (json['presences'] as List<dynamic>)
-          .map((e) => UserPresence.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      $type: json['runtimeType'] as String?,
-    );
+_Match _$MatchFromJson(Map<String, dynamic> json) => _Match(
+  matchId: json['match_id'] as String,
+  authoritative: json['authoritative'] as bool,
+  label: json['label'] as String,
+  size: (json['size'] as num).toInt(),
+  tickRate: (json['tick_rate'] as num?)?.toInt(),
+  handlerName: json['handler_name'] as String?,
+  presences: (json['presences'] as List<dynamic>)
+      .map((e) => UserPresence.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$$MatchImplToJson(_$MatchImpl instance) =>
-    <String, dynamic>{
-      'match_id': instance.matchId,
-      'authoritative': instance.authoritative,
-      'label': instance.label,
-      'size': instance.size,
-      'tick_rate': instance.tickRate,
-      'handler_name': instance.handlerName,
-      'presences': instance.presences,
-      'runtimeType': instance.$type,
-    };
-
-_$RealtimeMatchImpl _$$RealtimeMatchImplFromJson(Map<String, dynamic> json) =>
-    _$RealtimeMatchImpl(
-      matchId: json['match_id'] as String,
-      authoritative: json['authoritative'] as bool,
-      label: json['label'] as String,
-      size: json['size'] as int,
-      tickRate: json['tick_rate'] as int?,
-      handlerName: json['handler_name'] as String?,
-      presences: (json['presences'] as List<dynamic>)
-          .map((e) => UserPresence.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      $type: json['runtimeType'] as String?,
-    );
-
-Map<String, dynamic> _$$RealtimeMatchImplToJson(_$RealtimeMatchImpl instance) =>
-    <String, dynamic>{
-      'match_id': instance.matchId,
-      'authoritative': instance.authoritative,
-      'label': instance.label,
-      'size': instance.size,
-      'tick_rate': instance.tickRate,
-      'handler_name': instance.handlerName,
-      'presences': instance.presences,
-      'runtimeType': instance.$type,
-    };
+Map<String, dynamic> _$MatchToJson(_Match instance) => <String, dynamic>{
+  'match_id': instance.matchId,
+  'authoritative': instance.authoritative,
+  'label': instance.label,
+  'size': instance.size,
+  'tick_rate': instance.tickRate,
+  'handler_name': instance.handlerName,
+  'presences': instance.presences,
+};

--- a/nakama/lib/src/models/matchmaker.dart
+++ b/nakama/lib/src/models/matchmaker.dart
@@ -5,7 +5,7 @@ import 'package:nakama/src/api/rtapi.dart' as rtpb;
 part 'matchmaker.freezed.dart';
 
 @freezed
-class MatchmakerTicket with _$MatchmakerTicket {
+sealed class MatchmakerTicket with _$MatchmakerTicket {
   const MatchmakerTicket._();
 
   const factory MatchmakerTicket({
@@ -19,7 +19,7 @@ class MatchmakerTicket with _$MatchmakerTicket {
 }
 
 @freezed
-class PartyMatchmakerTicket with _$PartyMatchmakerTicket {
+sealed class PartyMatchmakerTicket with _$PartyMatchmakerTicket {
   const PartyMatchmakerTicket._();
 
   const factory PartyMatchmakerTicket({
@@ -37,7 +37,7 @@ class PartyMatchmakerTicket with _$PartyMatchmakerTicket {
 }
 
 @freezed
-class ChannelPresenceEvent with _$ChannelPresenceEvent {
+sealed class ChannelPresenceEvent with _$ChannelPresenceEvent {
   const ChannelPresenceEvent._();
 
   const factory ChannelPresenceEvent({
@@ -79,7 +79,7 @@ class ChannelPresenceEvent with _$ChannelPresenceEvent {
 }
 
 @freezed
-class MatchmakerUser with _$MatchmakerUser {
+sealed class MatchmakerUser with _$MatchmakerUser {
   const MatchmakerUser._();
 
   const factory MatchmakerUser({
@@ -105,7 +105,7 @@ class MatchmakerUser with _$MatchmakerUser {
 }
 
 @freezed
-class MatchmakerMatched with _$MatchmakerMatched {
+sealed class MatchmakerMatched with _$MatchmakerMatched {
   const MatchmakerMatched._();
 
   const factory MatchmakerMatched({
@@ -135,7 +135,7 @@ class MatchmakerMatched with _$MatchmakerMatched {
 }
 
 @freezed
-class MatchData with _$MatchData {
+sealed class MatchData with _$MatchData {
   const MatchData._();
 
   const factory MatchData({
@@ -165,7 +165,7 @@ class MatchData with _$MatchData {
 }
 
 @freezed
-class MatchPresenceEvent with _$MatchPresenceEvent {
+sealed class MatchPresenceEvent with _$MatchPresenceEvent {
   const MatchPresenceEvent._();
 
   const factory MatchPresenceEvent({

--- a/nakama/lib/src/models/matchmaker.freezed.dart
+++ b/nakama/lib/src/models/matchmaker.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,1640 +9,1982 @@ part of 'matchmaker.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
 /// @nodoc
 mixin _$MatchmakerTicket {
-  /// The ticket that can be used to cancel matchmaking.
-  String get ticket => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $MatchmakerTicketCopyWith<MatchmakerTicket> get copyWith =>
-      throw _privateConstructorUsedError;
+/// The ticket that can be used to cancel matchmaking.
+ String get ticket;
+/// Create a copy of MatchmakerTicket
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchmakerTicketCopyWith<MatchmakerTicket> get copyWith => _$MatchmakerTicketCopyWithImpl<MatchmakerTicket>(this as MatchmakerTicket, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchmakerTicket&&(identical(other.ticket, ticket) || other.ticket == ticket));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,ticket);
+
+@override
+String toString() {
+  return 'MatchmakerTicket(ticket: $ticket)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $MatchmakerTicketCopyWith<$Res> {
-  factory $MatchmakerTicketCopyWith(
-          MatchmakerTicket value, $Res Function(MatchmakerTicket) then) =
-      _$MatchmakerTicketCopyWithImpl<$Res, MatchmakerTicket>;
-  @useResult
-  $Res call({String ticket});
-}
+abstract mixin class $MatchmakerTicketCopyWith<$Res>  {
+  factory $MatchmakerTicketCopyWith(MatchmakerTicket value, $Res Function(MatchmakerTicket) _then) = _$MatchmakerTicketCopyWithImpl;
+@useResult
+$Res call({
+ String ticket
+});
 
+
+
+
+}
 /// @nodoc
-class _$MatchmakerTicketCopyWithImpl<$Res, $Val extends MatchmakerTicket>
+class _$MatchmakerTicketCopyWithImpl<$Res>
     implements $MatchmakerTicketCopyWith<$Res> {
-  _$MatchmakerTicketCopyWithImpl(this._value, this._then);
+  _$MatchmakerTicketCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final MatchmakerTicket _self;
+  final $Res Function(MatchmakerTicket) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? ticket = null,
-  }) {
-    return _then(_value.copyWith(
-      ticket: null == ticket
-          ? _value.ticket
-          : ticket // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
+/// Create a copy of MatchmakerTicket
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? ticket = null,}) {
+  return _then(_self.copyWith(
+ticket: null == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MatchmakerTicket].
+extension MatchmakerTicketPatterns on MatchmakerTicket {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MatchmakerTicket value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MatchmakerTicket() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MatchmakerTicket value)  $default,){
+final _that = this;
+switch (_that) {
+case _MatchmakerTicket():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MatchmakerTicket value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MatchmakerTicket() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String ticket)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MatchmakerTicket() when $default != null:
+return $default(_that.ticket);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String ticket)  $default,) {final _that = this;
+switch (_that) {
+case _MatchmakerTicket():
+return $default(_that.ticket);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String ticket)?  $default,) {final _that = this;
+switch (_that) {
+case _MatchmakerTicket() when $default != null:
+return $default(_that.ticket);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$MatchmakerTicketImplCopyWith<$Res>
-    implements $MatchmakerTicketCopyWith<$Res> {
-  factory _$$MatchmakerTicketImplCopyWith(_$MatchmakerTicketImpl value,
-          $Res Function(_$MatchmakerTicketImpl) then) =
-      __$$MatchmakerTicketImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String ticket});
+
+
+class _MatchmakerTicket extends MatchmakerTicket {
+  const _MatchmakerTicket({required this.ticket}): super._();
+  
+
+/// The ticket that can be used to cancel matchmaking.
+@override final  String ticket;
+
+/// Create a copy of MatchmakerTicket
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchmakerTicketCopyWith<_MatchmakerTicket> get copyWith => __$MatchmakerTicketCopyWithImpl<_MatchmakerTicket>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchmakerTicket&&(identical(other.ticket, ticket) || other.ticket == ticket));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,ticket);
+
+@override
+String toString() {
+  return 'MatchmakerTicket(ticket: $ticket)';
+}
+
+
 }
 
 /// @nodoc
-class __$$MatchmakerTicketImplCopyWithImpl<$Res>
-    extends _$MatchmakerTicketCopyWithImpl<$Res, _$MatchmakerTicketImpl>
-    implements _$$MatchmakerTicketImplCopyWith<$Res> {
-  __$$MatchmakerTicketImplCopyWithImpl(_$MatchmakerTicketImpl _value,
-      $Res Function(_$MatchmakerTicketImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$MatchmakerTicketCopyWith<$Res> implements $MatchmakerTicketCopyWith<$Res> {
+  factory _$MatchmakerTicketCopyWith(_MatchmakerTicket value, $Res Function(_MatchmakerTicket) _then) = __$MatchmakerTicketCopyWithImpl;
+@override @useResult
+$Res call({
+ String ticket
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? ticket = null,
-  }) {
-    return _then(_$MatchmakerTicketImpl(
-      ticket: null == ticket
-          ? _value.ticket
-          : ticket // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+
+
+
 }
-
 /// @nodoc
+class __$MatchmakerTicketCopyWithImpl<$Res>
+    implements _$MatchmakerTicketCopyWith<$Res> {
+  __$MatchmakerTicketCopyWithImpl(this._self, this._then);
 
-class _$MatchmakerTicketImpl extends _MatchmakerTicket {
-  const _$MatchmakerTicketImpl({required this.ticket}) : super._();
+  final _MatchmakerTicket _self;
+  final $Res Function(_MatchmakerTicket) _then;
 
-  /// The ticket that can be used to cancel matchmaking.
-  @override
-  final String ticket;
-
-  @override
-  String toString() {
-    return 'MatchmakerTicket(ticket: $ticket)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MatchmakerTicketImpl &&
-            (identical(other.ticket, ticket) || other.ticket == ticket));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, ticket);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MatchmakerTicketImplCopyWith<_$MatchmakerTicketImpl> get copyWith =>
-      __$$MatchmakerTicketImplCopyWithImpl<_$MatchmakerTicketImpl>(
-          this, _$identity);
+/// Create a copy of MatchmakerTicket
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? ticket = null,}) {
+  return _then(_MatchmakerTicket(
+ticket: null == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
 
-abstract class _MatchmakerTicket extends MatchmakerTicket {
-  const factory _MatchmakerTicket({required final String ticket}) =
-      _$MatchmakerTicketImpl;
-  const _MatchmakerTicket._() : super._();
 
-  @override
-
-  /// The ticket that can be used to cancel matchmaking.
-  String get ticket;
-  @override
-  @JsonKey(ignore: true)
-  _$$MatchmakerTicketImplCopyWith<_$MatchmakerTicketImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 mixin _$PartyMatchmakerTicket {
-  /// Party ID.
-  @JsonKey(name: 'party_id')
-  String get partyId => throw _privateConstructorUsedError;
 
-  /// The ticket that can be used to cancel matchmaking.
-  @JsonKey(name: 'ticket')
-  String get ticket => throw _privateConstructorUsedError;
+/// Party ID.
+@JsonKey(name: 'party_id') String get partyId;/// The ticket that can be used to cancel matchmaking.
+@JsonKey(name: 'ticket') String get ticket;
+/// Create a copy of PartyMatchmakerTicket
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartyMatchmakerTicketCopyWith<PartyMatchmakerTicket> get copyWith => _$PartyMatchmakerTicketCopyWithImpl<PartyMatchmakerTicket>(this as PartyMatchmakerTicket, _$identity);
 
-  @JsonKey(ignore: true)
-  $PartyMatchmakerTicketCopyWith<PartyMatchmakerTicket> get copyWith =>
-      throw _privateConstructorUsedError;
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartyMatchmakerTicket&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.ticket, ticket) || other.ticket == ticket));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,ticket);
+
+@override
+String toString() {
+  return 'PartyMatchmakerTicket(partyId: $partyId, ticket: $ticket)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $PartyMatchmakerTicketCopyWith<$Res> {
-  factory $PartyMatchmakerTicketCopyWith(PartyMatchmakerTicket value,
-          $Res Function(PartyMatchmakerTicket) then) =
-      _$PartyMatchmakerTicketCopyWithImpl<$Res, PartyMatchmakerTicket>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'ticket') String ticket});
-}
+abstract mixin class $PartyMatchmakerTicketCopyWith<$Res>  {
+  factory $PartyMatchmakerTicketCopyWith(PartyMatchmakerTicket value, $Res Function(PartyMatchmakerTicket) _then) = _$PartyMatchmakerTicketCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'ticket') String ticket
+});
 
+
+
+
+}
 /// @nodoc
-class _$PartyMatchmakerTicketCopyWithImpl<$Res,
-        $Val extends PartyMatchmakerTicket>
+class _$PartyMatchmakerTicketCopyWithImpl<$Res>
     implements $PartyMatchmakerTicketCopyWith<$Res> {
-  _$PartyMatchmakerTicketCopyWithImpl(this._value, this._then);
+  _$PartyMatchmakerTicketCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final PartyMatchmakerTicket _self;
+  final $Res Function(PartyMatchmakerTicket) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? ticket = null,
-  }) {
-    return _then(_value.copyWith(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticket: null == ticket
-          ? _value.ticket
-          : ticket // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
+/// Create a copy of PartyMatchmakerTicket
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,Object? ticket = null,}) {
+  return _then(_self.copyWith(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,ticket: null == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PartyMatchmakerTicket].
+extension PartyMatchmakerTicketPatterns on PartyMatchmakerTicket {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PartyMatchmakerTicket value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PartyMatchmakerTicket() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PartyMatchmakerTicket value)  $default,){
+final _that = this;
+switch (_that) {
+case _PartyMatchmakerTicket():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PartyMatchmakerTicket value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PartyMatchmakerTicket() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'ticket')  String ticket)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PartyMatchmakerTicket() when $default != null:
+return $default(_that.partyId,_that.ticket);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'ticket')  String ticket)  $default,) {final _that = this;
+switch (_that) {
+case _PartyMatchmakerTicket():
+return $default(_that.partyId,_that.ticket);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'ticket')  String ticket)?  $default,) {final _that = this;
+switch (_that) {
+case _PartyMatchmakerTicket() when $default != null:
+return $default(_that.partyId,_that.ticket);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$PartyMatchmakerTicketImplCopyWith<$Res>
-    implements $PartyMatchmakerTicketCopyWith<$Res> {
-  factory _$$PartyMatchmakerTicketImplCopyWith(
-          _$PartyMatchmakerTicketImpl value,
-          $Res Function(_$PartyMatchmakerTicketImpl) then) =
-      __$$PartyMatchmakerTicketImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'ticket') String ticket});
+
+
+class _PartyMatchmakerTicket extends PartyMatchmakerTicket {
+  const _PartyMatchmakerTicket({@JsonKey(name: 'party_id') required this.partyId, @JsonKey(name: 'ticket') required this.ticket}): super._();
+  
+
+/// Party ID.
+@override@JsonKey(name: 'party_id') final  String partyId;
+/// The ticket that can be used to cancel matchmaking.
+@override@JsonKey(name: 'ticket') final  String ticket;
+
+/// Create a copy of PartyMatchmakerTicket
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartyMatchmakerTicketCopyWith<_PartyMatchmakerTicket> get copyWith => __$PartyMatchmakerTicketCopyWithImpl<_PartyMatchmakerTicket>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartyMatchmakerTicket&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.ticket, ticket) || other.ticket == ticket));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,ticket);
+
+@override
+String toString() {
+  return 'PartyMatchmakerTicket(partyId: $partyId, ticket: $ticket)';
+}
+
+
 }
 
 /// @nodoc
-class __$$PartyMatchmakerTicketImplCopyWithImpl<$Res>
-    extends _$PartyMatchmakerTicketCopyWithImpl<$Res,
-        _$PartyMatchmakerTicketImpl>
-    implements _$$PartyMatchmakerTicketImplCopyWith<$Res> {
-  __$$PartyMatchmakerTicketImplCopyWithImpl(_$PartyMatchmakerTicketImpl _value,
-      $Res Function(_$PartyMatchmakerTicketImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$PartyMatchmakerTicketCopyWith<$Res> implements $PartyMatchmakerTicketCopyWith<$Res> {
+  factory _$PartyMatchmakerTicketCopyWith(_PartyMatchmakerTicket value, $Res Function(_PartyMatchmakerTicket) _then) = __$PartyMatchmakerTicketCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'ticket') String ticket
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? ticket = null,
-  }) {
-    return _then(_$PartyMatchmakerTicketImpl(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticket: null == ticket
-          ? _value.ticket
-          : ticket // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+
+
+
 }
-
 /// @nodoc
+class __$PartyMatchmakerTicketCopyWithImpl<$Res>
+    implements _$PartyMatchmakerTicketCopyWith<$Res> {
+  __$PartyMatchmakerTicketCopyWithImpl(this._self, this._then);
 
-class _$PartyMatchmakerTicketImpl extends _PartyMatchmakerTicket {
-  const _$PartyMatchmakerTicketImpl(
-      {@JsonKey(name: 'party_id') required this.partyId,
-      @JsonKey(name: 'ticket') required this.ticket})
-      : super._();
+  final _PartyMatchmakerTicket _self;
+  final $Res Function(_PartyMatchmakerTicket) _then;
 
-  /// Party ID.
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-
-  /// The ticket that can be used to cancel matchmaking.
-  @override
-  @JsonKey(name: 'ticket')
-  final String ticket;
-
-  @override
-  String toString() {
-    return 'PartyMatchmakerTicket(partyId: $partyId, ticket: $ticket)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$PartyMatchmakerTicketImpl &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.ticket, ticket) || other.ticket == ticket));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, partyId, ticket);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$PartyMatchmakerTicketImplCopyWith<_$PartyMatchmakerTicketImpl>
-      get copyWith => __$$PartyMatchmakerTicketImplCopyWithImpl<
-          _$PartyMatchmakerTicketImpl>(this, _$identity);
+/// Create a copy of PartyMatchmakerTicket
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,Object? ticket = null,}) {
+  return _then(_PartyMatchmakerTicket(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,ticket: null == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
 
-abstract class _PartyMatchmakerTicket extends PartyMatchmakerTicket {
-  const factory _PartyMatchmakerTicket(
-          {@JsonKey(name: 'party_id') required final String partyId,
-          @JsonKey(name: 'ticket') required final String ticket}) =
-      _$PartyMatchmakerTicketImpl;
-  const _PartyMatchmakerTicket._() : super._();
 
-  @override
-
-  /// Party ID.
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  @override
-
-  /// The ticket that can be used to cancel matchmaking.
-  @JsonKey(name: 'ticket')
-  String get ticket;
-  @override
-  @JsonKey(ignore: true)
-  _$$PartyMatchmakerTicketImplCopyWith<_$PartyMatchmakerTicketImpl>
-      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 mixin _$ChannelPresenceEvent {
-  /// The channel identifier this event is for.
-  @JsonKey(name: 'channel_id')
-  String get channelId => throw _privateConstructorUsedError;
 
-  /// Presences joining the channel as part of this event, if any.
-  @JsonKey(name: 'room_name')
-  String? get roomName => throw _privateConstructorUsedError;
+/// The channel identifier this event is for.
+@JsonKey(name: 'channel_id') String get channelId;/// Presences joining the channel as part of this event, if any.
+@JsonKey(name: 'room_name') String? get roomName;/// Presences leaving the channel as part of this event, if any.
+@JsonKey(name: 'group_id') String? get groupId;/// The name of the chat room, or an empty string if this message was not
+/// sent through a chat room.
+@JsonKey(name: 'joins') Iterable<UserPresence>? get joins;/// The ID of the group, or an empty string if this message was not sent
+/// through a group channel.
+@JsonKey(name: 'leaves') Iterable<UserPresence>? get leaves;/// The ID of the first DM user, or an empty string if this message was not
+/// sent through a DM chat.
+@JsonKey(name: 'user_id_one') String? get userIdOne;/// The ID of the second DM user, or an empty string if this message was not
+/// sent through a DM chat.
+@JsonKey(name: 'user_id_two') String? get userIdTwo;
+/// Create a copy of ChannelPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChannelPresenceEventCopyWith<ChannelPresenceEvent> get copyWith => _$ChannelPresenceEventCopyWithImpl<ChannelPresenceEvent>(this as ChannelPresenceEvent, _$identity);
 
-  /// Presences leaving the channel as part of this event, if any.
-  @JsonKey(name: 'group_id')
-  String? get groupId => throw _privateConstructorUsedError;
 
-  /// The name of the chat room, or an empty string if this message was not
-  /// sent through a chat room.
-  @JsonKey(name: 'joins')
-  Iterable<UserPresence>? get joins => throw _privateConstructorUsedError;
 
-  /// The ID of the group, or an empty string if this message was not sent
-  /// through a group channel.
-  @JsonKey(name: 'leaves')
-  Iterable<UserPresence>? get leaves => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChannelPresenceEvent&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.roomName, roomName) || other.roomName == roomName)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&const DeepCollectionEquality().equals(other.joins, joins)&&const DeepCollectionEquality().equals(other.leaves, leaves)&&(identical(other.userIdOne, userIdOne) || other.userIdOne == userIdOne)&&(identical(other.userIdTwo, userIdTwo) || other.userIdTwo == userIdTwo));
+}
 
-  /// The ID of the first DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @JsonKey(name: 'user_id_one')
-  String? get userIdOne => throw _privateConstructorUsedError;
 
-  /// The ID of the second DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @JsonKey(name: 'user_id_two')
-  String? get userIdTwo => throw _privateConstructorUsedError;
+@override
+int get hashCode => Object.hash(runtimeType,channelId,roomName,groupId,const DeepCollectionEquality().hash(joins),const DeepCollectionEquality().hash(leaves),userIdOne,userIdTwo);
 
-  @JsonKey(ignore: true)
-  $ChannelPresenceEventCopyWith<ChannelPresenceEvent> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+String toString() {
+  return 'ChannelPresenceEvent(channelId: $channelId, roomName: $roomName, groupId: $groupId, joins: $joins, leaves: $leaves, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $ChannelPresenceEventCopyWith<$Res> {
-  factory $ChannelPresenceEventCopyWith(ChannelPresenceEvent value,
-          $Res Function(ChannelPresenceEvent) then) =
-      _$ChannelPresenceEventCopyWithImpl<$Res, ChannelPresenceEvent>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'channel_id') String channelId,
-      @JsonKey(name: 'room_name') String? roomName,
-      @JsonKey(name: 'group_id') String? groupId,
-      @JsonKey(name: 'joins') Iterable<UserPresence>? joins,
-      @JsonKey(name: 'leaves') Iterable<UserPresence>? leaves,
-      @JsonKey(name: 'user_id_one') String? userIdOne,
-      @JsonKey(name: 'user_id_two') String? userIdTwo});
-}
+abstract mixin class $ChannelPresenceEventCopyWith<$Res>  {
+  factory $ChannelPresenceEventCopyWith(ChannelPresenceEvent value, $Res Function(ChannelPresenceEvent) _then) = _$ChannelPresenceEventCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'channel_id') String channelId,@JsonKey(name: 'room_name') String? roomName,@JsonKey(name: 'group_id') String? groupId,@JsonKey(name: 'joins') Iterable<UserPresence>? joins,@JsonKey(name: 'leaves') Iterable<UserPresence>? leaves,@JsonKey(name: 'user_id_one') String? userIdOne,@JsonKey(name: 'user_id_two') String? userIdTwo
+});
 
+
+
+
+}
 /// @nodoc
-class _$ChannelPresenceEventCopyWithImpl<$Res,
-        $Val extends ChannelPresenceEvent>
+class _$ChannelPresenceEventCopyWithImpl<$Res>
     implements $ChannelPresenceEventCopyWith<$Res> {
-  _$ChannelPresenceEventCopyWithImpl(this._value, this._then);
+  _$ChannelPresenceEventCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final ChannelPresenceEvent _self;
+  final $Res Function(ChannelPresenceEvent) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? channelId = null,
-    Object? roomName = freezed,
-    Object? groupId = freezed,
-    Object? joins = freezed,
-    Object? leaves = freezed,
-    Object? userIdOne = freezed,
-    Object? userIdTwo = freezed,
-  }) {
-    return _then(_value.copyWith(
-      channelId: null == channelId
-          ? _value.channelId
-          : channelId // ignore: cast_nullable_to_non_nullable
-              as String,
-      roomName: freezed == roomName
-          ? _value.roomName
-          : roomName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      groupId: freezed == groupId
-          ? _value.groupId
-          : groupId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      joins: freezed == joins
-          ? _value.joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as Iterable<UserPresence>?,
-      leaves: freezed == leaves
-          ? _value.leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as Iterable<UserPresence>?,
-      userIdOne: freezed == userIdOne
-          ? _value.userIdOne
-          : userIdOne // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userIdTwo: freezed == userIdTwo
-          ? _value.userIdTwo
-          : userIdTwo // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of ChannelPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? channelId = null,Object? roomName = freezed,Object? groupId = freezed,Object? joins = freezed,Object? leaves = freezed,Object? userIdOne = freezed,Object? userIdTwo = freezed,}) {
+  return _then(_self.copyWith(
+channelId: null == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String,roomName: freezed == roomName ? _self.roomName : roomName // ignore: cast_nullable_to_non_nullable
+as String?,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String?,joins: freezed == joins ? _self.joins : joins // ignore: cast_nullable_to_non_nullable
+as Iterable<UserPresence>?,leaves: freezed == leaves ? _self.leaves : leaves // ignore: cast_nullable_to_non_nullable
+as Iterable<UserPresence>?,userIdOne: freezed == userIdOne ? _self.userIdOne : userIdOne // ignore: cast_nullable_to_non_nullable
+as String?,userIdTwo: freezed == userIdTwo ? _self.userIdTwo : userIdTwo // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ChannelPresenceEvent].
+extension ChannelPresenceEventPatterns on ChannelPresenceEvent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChannelPresenceEvent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChannelPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChannelPresenceEvent value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelPresenceEvent():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChannelPresenceEvent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'room_name')  String? roomName, @JsonKey(name: 'group_id')  String? groupId, @JsonKey(name: 'joins')  Iterable<UserPresence>? joins, @JsonKey(name: 'leaves')  Iterable<UserPresence>? leaves, @JsonKey(name: 'user_id_one')  String? userIdOne, @JsonKey(name: 'user_id_two')  String? userIdTwo)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChannelPresenceEvent() when $default != null:
+return $default(_that.channelId,_that.roomName,_that.groupId,_that.joins,_that.leaves,_that.userIdOne,_that.userIdTwo);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'room_name')  String? roomName, @JsonKey(name: 'group_id')  String? groupId, @JsonKey(name: 'joins')  Iterable<UserPresence>? joins, @JsonKey(name: 'leaves')  Iterable<UserPresence>? leaves, @JsonKey(name: 'user_id_one')  String? userIdOne, @JsonKey(name: 'user_id_two')  String? userIdTwo)  $default,) {final _that = this;
+switch (_that) {
+case _ChannelPresenceEvent():
+return $default(_that.channelId,_that.roomName,_that.groupId,_that.joins,_that.leaves,_that.userIdOne,_that.userIdTwo);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'channel_id')  String channelId, @JsonKey(name: 'room_name')  String? roomName, @JsonKey(name: 'group_id')  String? groupId, @JsonKey(name: 'joins')  Iterable<UserPresence>? joins, @JsonKey(name: 'leaves')  Iterable<UserPresence>? leaves, @JsonKey(name: 'user_id_one')  String? userIdOne, @JsonKey(name: 'user_id_two')  String? userIdTwo)?  $default,) {final _that = this;
+switch (_that) {
+case _ChannelPresenceEvent() when $default != null:
+return $default(_that.channelId,_that.roomName,_that.groupId,_that.joins,_that.leaves,_that.userIdOne,_that.userIdTwo);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$ChannelPresenceEventImplCopyWith<$Res>
-    implements $ChannelPresenceEventCopyWith<$Res> {
-  factory _$$ChannelPresenceEventImplCopyWith(_$ChannelPresenceEventImpl value,
-          $Res Function(_$ChannelPresenceEventImpl) then) =
-      __$$ChannelPresenceEventImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'channel_id') String channelId,
-      @JsonKey(name: 'room_name') String? roomName,
-      @JsonKey(name: 'group_id') String? groupId,
-      @JsonKey(name: 'joins') Iterable<UserPresence>? joins,
-      @JsonKey(name: 'leaves') Iterable<UserPresence>? leaves,
-      @JsonKey(name: 'user_id_one') String? userIdOne,
-      @JsonKey(name: 'user_id_two') String? userIdTwo});
+
+
+class _ChannelPresenceEvent extends ChannelPresenceEvent {
+  const _ChannelPresenceEvent({@JsonKey(name: 'channel_id') required this.channelId, @JsonKey(name: 'room_name') this.roomName, @JsonKey(name: 'group_id') this.groupId, @JsonKey(name: 'joins') this.joins, @JsonKey(name: 'leaves') this.leaves, @JsonKey(name: 'user_id_one') this.userIdOne, @JsonKey(name: 'user_id_two') this.userIdTwo}): super._();
+  
+
+/// The channel identifier this event is for.
+@override@JsonKey(name: 'channel_id') final  String channelId;
+/// Presences joining the channel as part of this event, if any.
+@override@JsonKey(name: 'room_name') final  String? roomName;
+/// Presences leaving the channel as part of this event, if any.
+@override@JsonKey(name: 'group_id') final  String? groupId;
+/// The name of the chat room, or an empty string if this message was not
+/// sent through a chat room.
+@override@JsonKey(name: 'joins') final  Iterable<UserPresence>? joins;
+/// The ID of the group, or an empty string if this message was not sent
+/// through a group channel.
+@override@JsonKey(name: 'leaves') final  Iterable<UserPresence>? leaves;
+/// The ID of the first DM user, or an empty string if this message was not
+/// sent through a DM chat.
+@override@JsonKey(name: 'user_id_one') final  String? userIdOne;
+/// The ID of the second DM user, or an empty string if this message was not
+/// sent through a DM chat.
+@override@JsonKey(name: 'user_id_two') final  String? userIdTwo;
+
+/// Create a copy of ChannelPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChannelPresenceEventCopyWith<_ChannelPresenceEvent> get copyWith => __$ChannelPresenceEventCopyWithImpl<_ChannelPresenceEvent>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChannelPresenceEvent&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.roomName, roomName) || other.roomName == roomName)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&const DeepCollectionEquality().equals(other.joins, joins)&&const DeepCollectionEquality().equals(other.leaves, leaves)&&(identical(other.userIdOne, userIdOne) || other.userIdOne == userIdOne)&&(identical(other.userIdTwo, userIdTwo) || other.userIdTwo == userIdTwo));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,channelId,roomName,groupId,const DeepCollectionEquality().hash(joins),const DeepCollectionEquality().hash(leaves),userIdOne,userIdTwo);
+
+@override
+String toString() {
+  return 'ChannelPresenceEvent(channelId: $channelId, roomName: $roomName, groupId: $groupId, joins: $joins, leaves: $leaves, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
+}
+
+
 }
 
 /// @nodoc
-class __$$ChannelPresenceEventImplCopyWithImpl<$Res>
-    extends _$ChannelPresenceEventCopyWithImpl<$Res, _$ChannelPresenceEventImpl>
-    implements _$$ChannelPresenceEventImplCopyWith<$Res> {
-  __$$ChannelPresenceEventImplCopyWithImpl(_$ChannelPresenceEventImpl _value,
-      $Res Function(_$ChannelPresenceEventImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$ChannelPresenceEventCopyWith<$Res> implements $ChannelPresenceEventCopyWith<$Res> {
+  factory _$ChannelPresenceEventCopyWith(_ChannelPresenceEvent value, $Res Function(_ChannelPresenceEvent) _then) = __$ChannelPresenceEventCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'channel_id') String channelId,@JsonKey(name: 'room_name') String? roomName,@JsonKey(name: 'group_id') String? groupId,@JsonKey(name: 'joins') Iterable<UserPresence>? joins,@JsonKey(name: 'leaves') Iterable<UserPresence>? leaves,@JsonKey(name: 'user_id_one') String? userIdOne,@JsonKey(name: 'user_id_two') String? userIdTwo
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? channelId = null,
-    Object? roomName = freezed,
-    Object? groupId = freezed,
-    Object? joins = freezed,
-    Object? leaves = freezed,
-    Object? userIdOne = freezed,
-    Object? userIdTwo = freezed,
-  }) {
-    return _then(_$ChannelPresenceEventImpl(
-      channelId: null == channelId
-          ? _value.channelId
-          : channelId // ignore: cast_nullable_to_non_nullable
-              as String,
-      roomName: freezed == roomName
-          ? _value.roomName
-          : roomName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      groupId: freezed == groupId
-          ? _value.groupId
-          : groupId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      joins: freezed == joins
-          ? _value.joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as Iterable<UserPresence>?,
-      leaves: freezed == leaves
-          ? _value.leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as Iterable<UserPresence>?,
-      userIdOne: freezed == userIdOne
-          ? _value.userIdOne
-          : userIdOne // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userIdTwo: freezed == userIdTwo
-          ? _value.userIdTwo
-          : userIdTwo // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+
+
+
 }
-
 /// @nodoc
+class __$ChannelPresenceEventCopyWithImpl<$Res>
+    implements _$ChannelPresenceEventCopyWith<$Res> {
+  __$ChannelPresenceEventCopyWithImpl(this._self, this._then);
 
-class _$ChannelPresenceEventImpl extends _ChannelPresenceEvent {
-  const _$ChannelPresenceEventImpl(
-      {@JsonKey(name: 'channel_id') required this.channelId,
-      @JsonKey(name: 'room_name') this.roomName,
-      @JsonKey(name: 'group_id') this.groupId,
-      @JsonKey(name: 'joins') this.joins,
-      @JsonKey(name: 'leaves') this.leaves,
-      @JsonKey(name: 'user_id_one') this.userIdOne,
-      @JsonKey(name: 'user_id_two') this.userIdTwo})
-      : super._();
+  final _ChannelPresenceEvent _self;
+  final $Res Function(_ChannelPresenceEvent) _then;
 
-  /// The channel identifier this event is for.
-  @override
-  @JsonKey(name: 'channel_id')
-  final String channelId;
-
-  /// Presences joining the channel as part of this event, if any.
-  @override
-  @JsonKey(name: 'room_name')
-  final String? roomName;
-
-  /// Presences leaving the channel as part of this event, if any.
-  @override
-  @JsonKey(name: 'group_id')
-  final String? groupId;
-
-  /// The name of the chat room, or an empty string if this message was not
-  /// sent through a chat room.
-  @override
-  @JsonKey(name: 'joins')
-  final Iterable<UserPresence>? joins;
-
-  /// The ID of the group, or an empty string if this message was not sent
-  /// through a group channel.
-  @override
-  @JsonKey(name: 'leaves')
-  final Iterable<UserPresence>? leaves;
-
-  /// The ID of the first DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @override
-  @JsonKey(name: 'user_id_one')
-  final String? userIdOne;
-
-  /// The ID of the second DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @override
-  @JsonKey(name: 'user_id_two')
-  final String? userIdTwo;
-
-  @override
-  String toString() {
-    return 'ChannelPresenceEvent(channelId: $channelId, roomName: $roomName, groupId: $groupId, joins: $joins, leaves: $leaves, userIdOne: $userIdOne, userIdTwo: $userIdTwo)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ChannelPresenceEventImpl &&
-            (identical(other.channelId, channelId) ||
-                other.channelId == channelId) &&
-            (identical(other.roomName, roomName) ||
-                other.roomName == roomName) &&
-            (identical(other.groupId, groupId) || other.groupId == groupId) &&
-            const DeepCollectionEquality().equals(other.joins, joins) &&
-            const DeepCollectionEquality().equals(other.leaves, leaves) &&
-            (identical(other.userIdOne, userIdOne) ||
-                other.userIdOne == userIdOne) &&
-            (identical(other.userIdTwo, userIdTwo) ||
-                other.userIdTwo == userIdTwo));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      channelId,
-      roomName,
-      groupId,
-      const DeepCollectionEquality().hash(joins),
-      const DeepCollectionEquality().hash(leaves),
-      userIdOne,
-      userIdTwo);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ChannelPresenceEventImplCopyWith<_$ChannelPresenceEventImpl>
-      get copyWith =>
-          __$$ChannelPresenceEventImplCopyWithImpl<_$ChannelPresenceEventImpl>(
-              this, _$identity);
+/// Create a copy of ChannelPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? channelId = null,Object? roomName = freezed,Object? groupId = freezed,Object? joins = freezed,Object? leaves = freezed,Object? userIdOne = freezed,Object? userIdTwo = freezed,}) {
+  return _then(_ChannelPresenceEvent(
+channelId: null == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String,roomName: freezed == roomName ? _self.roomName : roomName // ignore: cast_nullable_to_non_nullable
+as String?,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String?,joins: freezed == joins ? _self.joins : joins // ignore: cast_nullable_to_non_nullable
+as Iterable<UserPresence>?,leaves: freezed == leaves ? _self.leaves : leaves // ignore: cast_nullable_to_non_nullable
+as Iterable<UserPresence>?,userIdOne: freezed == userIdOne ? _self.userIdOne : userIdOne // ignore: cast_nullable_to_non_nullable
+as String?,userIdTwo: freezed == userIdTwo ? _self.userIdTwo : userIdTwo // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-abstract class _ChannelPresenceEvent extends ChannelPresenceEvent {
-  const factory _ChannelPresenceEvent(
-          {@JsonKey(name: 'channel_id') required final String channelId,
-          @JsonKey(name: 'room_name') final String? roomName,
-          @JsonKey(name: 'group_id') final String? groupId,
-          @JsonKey(name: 'joins') final Iterable<UserPresence>? joins,
-          @JsonKey(name: 'leaves') final Iterable<UserPresence>? leaves,
-          @JsonKey(name: 'user_id_one') final String? userIdOne,
-          @JsonKey(name: 'user_id_two') final String? userIdTwo}) =
-      _$ChannelPresenceEventImpl;
-  const _ChannelPresenceEvent._() : super._();
 
-  @override
-
-  /// The channel identifier this event is for.
-  @JsonKey(name: 'channel_id')
-  String get channelId;
-  @override
-
-  /// Presences joining the channel as part of this event, if any.
-  @JsonKey(name: 'room_name')
-  String? get roomName;
-  @override
-
-  /// Presences leaving the channel as part of this event, if any.
-  @JsonKey(name: 'group_id')
-  String? get groupId;
-  @override
-
-  /// The name of the chat room, or an empty string if this message was not
-  /// sent through a chat room.
-  @JsonKey(name: 'joins')
-  Iterable<UserPresence>? get joins;
-  @override
-
-  /// The ID of the group, or an empty string if this message was not sent
-  /// through a group channel.
-  @JsonKey(name: 'leaves')
-  Iterable<UserPresence>? get leaves;
-  @override
-
-  /// The ID of the first DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @JsonKey(name: 'user_id_one')
-  String? get userIdOne;
-  @override
-
-  /// The ID of the second DM user, or an empty string if this message was not
-  /// sent through a DM chat.
-  @JsonKey(name: 'user_id_two')
-  String? get userIdTwo;
-  @override
-  @JsonKey(ignore: true)
-  _$$ChannelPresenceEventImplCopyWith<_$ChannelPresenceEventImpl>
-      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 mixin _$MatchmakerUser {
-  /// User info.
-  @JsonKey(name: 'presence')
-  UserPresence get presence => throw _privateConstructorUsedError;
 
-  /// Party identifier, if this user was matched as a party member.
-  @JsonKey(name: 'party_id')
-  String get partyId => throw _privateConstructorUsedError;
+/// User info.
+@JsonKey(name: 'presence') UserPresence get presence;/// Party identifier, if this user was matched as a party member.
+@JsonKey(name: 'party_id') String get partyId;/// String properties.
+@JsonKey(name: 'string_properties') Map<String, String> get stringProperties;/// Numeric properties.
+@JsonKey(name: 'numeric_properties') Map<String, double> get numericProperties;
+/// Create a copy of MatchmakerUser
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchmakerUserCopyWith<MatchmakerUser> get copyWith => _$MatchmakerUserCopyWithImpl<MatchmakerUser>(this as MatchmakerUser, _$identity);
 
-  /// String properties.
-  @JsonKey(name: 'string_properties')
-  Map<String, String> get stringProperties =>
-      throw _privateConstructorUsedError;
 
-  /// Numeric properties.
-  @JsonKey(name: 'numeric_properties')
-  Map<String, double> get numericProperties =>
-      throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $MatchmakerUserCopyWith<MatchmakerUser> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchmakerUser&&(identical(other.presence, presence) || other.presence == presence)&&(identical(other.partyId, partyId) || other.partyId == partyId)&&const DeepCollectionEquality().equals(other.stringProperties, stringProperties)&&const DeepCollectionEquality().equals(other.numericProperties, numericProperties));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,presence,partyId,const DeepCollectionEquality().hash(stringProperties),const DeepCollectionEquality().hash(numericProperties));
+
+@override
+String toString() {
+  return 'MatchmakerUser(presence: $presence, partyId: $partyId, stringProperties: $stringProperties, numericProperties: $numericProperties)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $MatchmakerUserCopyWith<$Res> {
-  factory $MatchmakerUserCopyWith(
-          MatchmakerUser value, $Res Function(MatchmakerUser) then) =
-      _$MatchmakerUserCopyWithImpl<$Res, MatchmakerUser>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'presence') UserPresence presence,
-      @JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'string_properties') Map<String, String> stringProperties,
-      @JsonKey(name: 'numeric_properties')
-      Map<String, double> numericProperties});
+abstract mixin class $MatchmakerUserCopyWith<$Res>  {
+  factory $MatchmakerUserCopyWith(MatchmakerUser value, $Res Function(MatchmakerUser) _then) = _$MatchmakerUserCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'presence') UserPresence presence,@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'string_properties') Map<String, String> stringProperties,@JsonKey(name: 'numeric_properties') Map<String, double> numericProperties
+});
 
-  $UserPresenceCopyWith<$Res> get presence;
+
+$UserPresenceCopyWith<$Res> get presence;
+
 }
-
 /// @nodoc
-class _$MatchmakerUserCopyWithImpl<$Res, $Val extends MatchmakerUser>
+class _$MatchmakerUserCopyWithImpl<$Res>
     implements $MatchmakerUserCopyWith<$Res> {
-  _$MatchmakerUserCopyWithImpl(this._value, this._then);
+  _$MatchmakerUserCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final MatchmakerUser _self;
+  final $Res Function(MatchmakerUser) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? presence = null,
-    Object? partyId = null,
-    Object? stringProperties = null,
-    Object? numericProperties = null,
-  }) {
-    return _then(_value.copyWith(
-      presence: null == presence
-          ? _value.presence
-          : presence // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      stringProperties: null == stringProperties
-          ? _value.stringProperties
-          : stringProperties // ignore: cast_nullable_to_non_nullable
-              as Map<String, String>,
-      numericProperties: null == numericProperties
-          ? _value.numericProperties
-          : numericProperties // ignore: cast_nullable_to_non_nullable
-              as Map<String, double>,
-    ) as $Val);
-  }
+/// Create a copy of MatchmakerUser
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? presence = null,Object? partyId = null,Object? stringProperties = null,Object? numericProperties = null,}) {
+  return _then(_self.copyWith(
+presence: null == presence ? _self.presence : presence // ignore: cast_nullable_to_non_nullable
+as UserPresence,partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,stringProperties: null == stringProperties ? _self.stringProperties : stringProperties // ignore: cast_nullable_to_non_nullable
+as Map<String, String>,numericProperties: null == numericProperties ? _self.numericProperties : numericProperties // ignore: cast_nullable_to_non_nullable
+as Map<String, double>,
+  ));
+}
+/// Create a copy of MatchmakerUser
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get presence {
+  
+  return $UserPresenceCopyWith<$Res>(_self.presence, (value) {
+    return _then(_self.copyWith(presence: value));
+  });
+}
+}
 
-  @override
-  @pragma('vm:prefer-inline')
-  $UserPresenceCopyWith<$Res> get presence {
-    return $UserPresenceCopyWith<$Res>(_value.presence, (value) {
-      return _then(_value.copyWith(presence: value) as $Val);
-    });
-  }
+
+/// Adds pattern-matching-related methods to [MatchmakerUser].
+extension MatchmakerUserPatterns on MatchmakerUser {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MatchmakerUser value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MatchmakerUser() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MatchmakerUser value)  $default,){
+final _that = this;
+switch (_that) {
+case _MatchmakerUser():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MatchmakerUser value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MatchmakerUser() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'presence')  UserPresence presence, @JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'string_properties')  Map<String, String> stringProperties, @JsonKey(name: 'numeric_properties')  Map<String, double> numericProperties)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MatchmakerUser() when $default != null:
+return $default(_that.presence,_that.partyId,_that.stringProperties,_that.numericProperties);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'presence')  UserPresence presence, @JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'string_properties')  Map<String, String> stringProperties, @JsonKey(name: 'numeric_properties')  Map<String, double> numericProperties)  $default,) {final _that = this;
+switch (_that) {
+case _MatchmakerUser():
+return $default(_that.presence,_that.partyId,_that.stringProperties,_that.numericProperties);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'presence')  UserPresence presence, @JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'string_properties')  Map<String, String> stringProperties, @JsonKey(name: 'numeric_properties')  Map<String, double> numericProperties)?  $default,) {final _that = this;
+switch (_that) {
+case _MatchmakerUser() when $default != null:
+return $default(_that.presence,_that.partyId,_that.stringProperties,_that.numericProperties);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$MatchmakerUserImplCopyWith<$Res>
-    implements $MatchmakerUserCopyWith<$Res> {
-  factory _$$MatchmakerUserImplCopyWith(_$MatchmakerUserImpl value,
-          $Res Function(_$MatchmakerUserImpl) then) =
-      __$$MatchmakerUserImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'presence') UserPresence presence,
-      @JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'string_properties') Map<String, String> stringProperties,
-      @JsonKey(name: 'numeric_properties')
-      Map<String, double> numericProperties});
 
-  @override
-  $UserPresenceCopyWith<$Res> get presence;
+
+class _MatchmakerUser extends MatchmakerUser {
+  const _MatchmakerUser({@JsonKey(name: 'presence') required this.presence, @JsonKey(name: 'party_id') required this.partyId, @JsonKey(name: 'string_properties') required final  Map<String, String> stringProperties, @JsonKey(name: 'numeric_properties') required final  Map<String, double> numericProperties}): _stringProperties = stringProperties,_numericProperties = numericProperties,super._();
+  
+
+/// User info.
+@override@JsonKey(name: 'presence') final  UserPresence presence;
+/// Party identifier, if this user was matched as a party member.
+@override@JsonKey(name: 'party_id') final  String partyId;
+/// String properties.
+ final  Map<String, String> _stringProperties;
+/// String properties.
+@override@JsonKey(name: 'string_properties') Map<String, String> get stringProperties {
+  if (_stringProperties is EqualUnmodifiableMapView) return _stringProperties;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_stringProperties);
+}
+
+/// Numeric properties.
+ final  Map<String, double> _numericProperties;
+/// Numeric properties.
+@override@JsonKey(name: 'numeric_properties') Map<String, double> get numericProperties {
+  if (_numericProperties is EqualUnmodifiableMapView) return _numericProperties;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_numericProperties);
+}
+
+
+/// Create a copy of MatchmakerUser
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchmakerUserCopyWith<_MatchmakerUser> get copyWith => __$MatchmakerUserCopyWithImpl<_MatchmakerUser>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchmakerUser&&(identical(other.presence, presence) || other.presence == presence)&&(identical(other.partyId, partyId) || other.partyId == partyId)&&const DeepCollectionEquality().equals(other._stringProperties, _stringProperties)&&const DeepCollectionEquality().equals(other._numericProperties, _numericProperties));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,presence,partyId,const DeepCollectionEquality().hash(_stringProperties),const DeepCollectionEquality().hash(_numericProperties));
+
+@override
+String toString() {
+  return 'MatchmakerUser(presence: $presence, partyId: $partyId, stringProperties: $stringProperties, numericProperties: $numericProperties)';
+}
+
+
 }
 
 /// @nodoc
-class __$$MatchmakerUserImplCopyWithImpl<$Res>
-    extends _$MatchmakerUserCopyWithImpl<$Res, _$MatchmakerUserImpl>
-    implements _$$MatchmakerUserImplCopyWith<$Res> {
-  __$$MatchmakerUserImplCopyWithImpl(
-      _$MatchmakerUserImpl _value, $Res Function(_$MatchmakerUserImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$MatchmakerUserCopyWith<$Res> implements $MatchmakerUserCopyWith<$Res> {
+  factory _$MatchmakerUserCopyWith(_MatchmakerUser value, $Res Function(_MatchmakerUser) _then) = __$MatchmakerUserCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'presence') UserPresence presence,@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'string_properties') Map<String, String> stringProperties,@JsonKey(name: 'numeric_properties') Map<String, double> numericProperties
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? presence = null,
-    Object? partyId = null,
-    Object? stringProperties = null,
-    Object? numericProperties = null,
-  }) {
-    return _then(_$MatchmakerUserImpl(
-      presence: null == presence
-          ? _value.presence
-          : presence // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      stringProperties: null == stringProperties
-          ? _value._stringProperties
-          : stringProperties // ignore: cast_nullable_to_non_nullable
-              as Map<String, String>,
-      numericProperties: null == numericProperties
-          ? _value._numericProperties
-          : numericProperties // ignore: cast_nullable_to_non_nullable
-              as Map<String, double>,
-    ));
-  }
+
+@override $UserPresenceCopyWith<$Res> get presence;
+
 }
-
 /// @nodoc
+class __$MatchmakerUserCopyWithImpl<$Res>
+    implements _$MatchmakerUserCopyWith<$Res> {
+  __$MatchmakerUserCopyWithImpl(this._self, this._then);
 
-class _$MatchmakerUserImpl extends _MatchmakerUser {
-  const _$MatchmakerUserImpl(
-      {@JsonKey(name: 'presence') required this.presence,
-      @JsonKey(name: 'party_id') required this.partyId,
-      @JsonKey(name: 'string_properties')
-      required final Map<String, String> stringProperties,
-      @JsonKey(name: 'numeric_properties')
-      required final Map<String, double> numericProperties})
-      : _stringProperties = stringProperties,
-        _numericProperties = numericProperties,
-        super._();
+  final _MatchmakerUser _self;
+  final $Res Function(_MatchmakerUser) _then;
 
-  /// User info.
-  @override
-  @JsonKey(name: 'presence')
-  final UserPresence presence;
-
-  /// Party identifier, if this user was matched as a party member.
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-
-  /// String properties.
-  final Map<String, String> _stringProperties;
-
-  /// String properties.
-  @override
-  @JsonKey(name: 'string_properties')
-  Map<String, String> get stringProperties {
-    if (_stringProperties is EqualUnmodifiableMapView) return _stringProperties;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_stringProperties);
-  }
-
-  /// Numeric properties.
-  final Map<String, double> _numericProperties;
-
-  /// Numeric properties.
-  @override
-  @JsonKey(name: 'numeric_properties')
-  Map<String, double> get numericProperties {
-    if (_numericProperties is EqualUnmodifiableMapView)
-      return _numericProperties;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_numericProperties);
-  }
-
-  @override
-  String toString() {
-    return 'MatchmakerUser(presence: $presence, partyId: $partyId, stringProperties: $stringProperties, numericProperties: $numericProperties)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MatchmakerUserImpl &&
-            (identical(other.presence, presence) ||
-                other.presence == presence) &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            const DeepCollectionEquality()
-                .equals(other._stringProperties, _stringProperties) &&
-            const DeepCollectionEquality()
-                .equals(other._numericProperties, _numericProperties));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      presence,
-      partyId,
-      const DeepCollectionEquality().hash(_stringProperties),
-      const DeepCollectionEquality().hash(_numericProperties));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MatchmakerUserImplCopyWith<_$MatchmakerUserImpl> get copyWith =>
-      __$$MatchmakerUserImplCopyWithImpl<_$MatchmakerUserImpl>(
-          this, _$identity);
+/// Create a copy of MatchmakerUser
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? presence = null,Object? partyId = null,Object? stringProperties = null,Object? numericProperties = null,}) {
+  return _then(_MatchmakerUser(
+presence: null == presence ? _self.presence : presence // ignore: cast_nullable_to_non_nullable
+as UserPresence,partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,stringProperties: null == stringProperties ? _self._stringProperties : stringProperties // ignore: cast_nullable_to_non_nullable
+as Map<String, String>,numericProperties: null == numericProperties ? _self._numericProperties : numericProperties // ignore: cast_nullable_to_non_nullable
+as Map<String, double>,
+  ));
 }
 
-abstract class _MatchmakerUser extends MatchmakerUser {
-  const factory _MatchmakerUser(
-          {@JsonKey(name: 'presence') required final UserPresence presence,
-          @JsonKey(name: 'party_id') required final String partyId,
-          @JsonKey(name: 'string_properties')
-          required final Map<String, String> stringProperties,
-          @JsonKey(name: 'numeric_properties')
-          required final Map<String, double> numericProperties}) =
-      _$MatchmakerUserImpl;
-  const _MatchmakerUser._() : super._();
-
-  @override
-
-  /// User info.
-  @JsonKey(name: 'presence')
-  UserPresence get presence;
-  @override
-
-  /// Party identifier, if this user was matched as a party member.
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  @override
-
-  /// String properties.
-  @JsonKey(name: 'string_properties')
-  Map<String, String> get stringProperties;
-  @override
-
-  /// Numeric properties.
-  @JsonKey(name: 'numeric_properties')
-  Map<String, double> get numericProperties;
-  @override
-  @JsonKey(ignore: true)
-  _$$MatchmakerUserImplCopyWith<_$MatchmakerUserImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+/// Create a copy of MatchmakerUser
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get presence {
+  
+  return $UserPresenceCopyWith<$Res>(_self.presence, (value) {
+    return _then(_self.copyWith(presence: value));
+  });
+}
 }
 
 /// @nodoc
 mixin _$MatchmakerMatched {
-  /// The matchmaking ticket that has completed.
-  @JsonKey(name: 'ticket')
-  String get ticket => throw _privateConstructorUsedError;
 
-  /// Match ID.
-  @JsonKey(name: 'match_id')
-  String? get matchId => throw _privateConstructorUsedError;
+/// The matchmaking ticket that has completed.
+@JsonKey(name: 'ticket') String get ticket;/// Match ID.
+@JsonKey(name: 'match_id') String? get matchId;/// Match ID.
+@JsonKey(name: 'token') String? get token;/// The users that have been matched together, and information about their matchmaking data.
+@JsonKey(name: 'users') Iterable<MatchmakerUser> get users;/// A reference to the current user and their properties.
+@JsonKey(name: 'self') MatchmakerUser get self;
+/// Create a copy of MatchmakerMatched
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchmakerMatchedCopyWith<MatchmakerMatched> get copyWith => _$MatchmakerMatchedCopyWithImpl<MatchmakerMatched>(this as MatchmakerMatched, _$identity);
 
-  /// Match ID.
-  @JsonKey(name: 'token')
-  String? get token => throw _privateConstructorUsedError;
 
-  /// The users that have been matched together, and information about their matchmaking data.
-  @JsonKey(name: 'users')
-  Iterable<MatchmakerUser> get users => throw _privateConstructorUsedError;
 
-  /// A reference to the current user and their properties.
-  @JsonKey(name: 'self')
-  MatchmakerUser get self => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchmakerMatched&&(identical(other.ticket, ticket) || other.ticket == ticket)&&(identical(other.matchId, matchId) || other.matchId == matchId)&&(identical(other.token, token) || other.token == token)&&const DeepCollectionEquality().equals(other.users, users)&&(identical(other.self, self) || other.self == self));
+}
 
-  @JsonKey(ignore: true)
-  $MatchmakerMatchedCopyWith<MatchmakerMatched> get copyWith =>
-      throw _privateConstructorUsedError;
+
+@override
+int get hashCode => Object.hash(runtimeType,ticket,matchId,token,const DeepCollectionEquality().hash(users),self);
+
+@override
+String toString() {
+  return 'MatchmakerMatched(ticket: $ticket, matchId: $matchId, token: $token, users: $users, self: $self)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $MatchmakerMatchedCopyWith<$Res> {
-  factory $MatchmakerMatchedCopyWith(
-          MatchmakerMatched value, $Res Function(MatchmakerMatched) then) =
-      _$MatchmakerMatchedCopyWithImpl<$Res, MatchmakerMatched>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'ticket') String ticket,
-      @JsonKey(name: 'match_id') String? matchId,
-      @JsonKey(name: 'token') String? token,
-      @JsonKey(name: 'users') Iterable<MatchmakerUser> users,
-      @JsonKey(name: 'self') MatchmakerUser self});
+abstract mixin class $MatchmakerMatchedCopyWith<$Res>  {
+  factory $MatchmakerMatchedCopyWith(MatchmakerMatched value, $Res Function(MatchmakerMatched) _then) = _$MatchmakerMatchedCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'ticket') String ticket,@JsonKey(name: 'match_id') String? matchId,@JsonKey(name: 'token') String? token,@JsonKey(name: 'users') Iterable<MatchmakerUser> users,@JsonKey(name: 'self') MatchmakerUser self
+});
 
-  $MatchmakerUserCopyWith<$Res> get self;
+
+$MatchmakerUserCopyWith<$Res> get self;
+
 }
-
 /// @nodoc
-class _$MatchmakerMatchedCopyWithImpl<$Res, $Val extends MatchmakerMatched>
+class _$MatchmakerMatchedCopyWithImpl<$Res>
     implements $MatchmakerMatchedCopyWith<$Res> {
-  _$MatchmakerMatchedCopyWithImpl(this._value, this._then);
+  _$MatchmakerMatchedCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final MatchmakerMatched _self;
+  final $Res Function(MatchmakerMatched) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? ticket = null,
-    Object? matchId = freezed,
-    Object? token = freezed,
-    Object? users = null,
-    Object? self = null,
-  }) {
-    return _then(_value.copyWith(
-      ticket: null == ticket
-          ? _value.ticket
-          : ticket // ignore: cast_nullable_to_non_nullable
-              as String,
-      matchId: freezed == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      token: freezed == token
-          ? _value.token
-          : token // ignore: cast_nullable_to_non_nullable
-              as String?,
-      users: null == users
-          ? _value.users
-          : users // ignore: cast_nullable_to_non_nullable
-              as Iterable<MatchmakerUser>,
-      self: null == self
-          ? _value.self
-          : self // ignore: cast_nullable_to_non_nullable
-              as MatchmakerUser,
-    ) as $Val);
-  }
+/// Create a copy of MatchmakerMatched
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? ticket = null,Object? matchId = freezed,Object? token = freezed,Object? users = null,Object? self = null,}) {
+  return _then(_self.copyWith(
+ticket: null == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
+as String,matchId: freezed == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String?,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String?,users: null == users ? _self.users : users // ignore: cast_nullable_to_non_nullable
+as Iterable<MatchmakerUser>,self: null == self ? _self.self : self // ignore: cast_nullable_to_non_nullable
+as MatchmakerUser,
+  ));
+}
+/// Create a copy of MatchmakerMatched
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$MatchmakerUserCopyWith<$Res> get self {
+  
+  return $MatchmakerUserCopyWith<$Res>(_self.self, (value) {
+    return _then(_self.copyWith(self: value));
+  });
+}
+}
 
-  @override
-  @pragma('vm:prefer-inline')
-  $MatchmakerUserCopyWith<$Res> get self {
-    return $MatchmakerUserCopyWith<$Res>(_value.self, (value) {
-      return _then(_value.copyWith(self: value) as $Val);
-    });
-  }
+
+/// Adds pattern-matching-related methods to [MatchmakerMatched].
+extension MatchmakerMatchedPatterns on MatchmakerMatched {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MatchmakerMatched value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MatchmakerMatched() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MatchmakerMatched value)  $default,){
+final _that = this;
+switch (_that) {
+case _MatchmakerMatched():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MatchmakerMatched value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MatchmakerMatched() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'ticket')  String ticket, @JsonKey(name: 'match_id')  String? matchId, @JsonKey(name: 'token')  String? token, @JsonKey(name: 'users')  Iterable<MatchmakerUser> users, @JsonKey(name: 'self')  MatchmakerUser self)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MatchmakerMatched() when $default != null:
+return $default(_that.ticket,_that.matchId,_that.token,_that.users,_that.self);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'ticket')  String ticket, @JsonKey(name: 'match_id')  String? matchId, @JsonKey(name: 'token')  String? token, @JsonKey(name: 'users')  Iterable<MatchmakerUser> users, @JsonKey(name: 'self')  MatchmakerUser self)  $default,) {final _that = this;
+switch (_that) {
+case _MatchmakerMatched():
+return $default(_that.ticket,_that.matchId,_that.token,_that.users,_that.self);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'ticket')  String ticket, @JsonKey(name: 'match_id')  String? matchId, @JsonKey(name: 'token')  String? token, @JsonKey(name: 'users')  Iterable<MatchmakerUser> users, @JsonKey(name: 'self')  MatchmakerUser self)?  $default,) {final _that = this;
+switch (_that) {
+case _MatchmakerMatched() when $default != null:
+return $default(_that.ticket,_that.matchId,_that.token,_that.users,_that.self);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$MatchmakerMatchedImplCopyWith<$Res>
-    implements $MatchmakerMatchedCopyWith<$Res> {
-  factory _$$MatchmakerMatchedImplCopyWith(_$MatchmakerMatchedImpl value,
-          $Res Function(_$MatchmakerMatchedImpl) then) =
-      __$$MatchmakerMatchedImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'ticket') String ticket,
-      @JsonKey(name: 'match_id') String? matchId,
-      @JsonKey(name: 'token') String? token,
-      @JsonKey(name: 'users') Iterable<MatchmakerUser> users,
-      @JsonKey(name: 'self') MatchmakerUser self});
 
-  @override
-  $MatchmakerUserCopyWith<$Res> get self;
+
+class _MatchmakerMatched extends MatchmakerMatched {
+  const _MatchmakerMatched({@JsonKey(name: 'ticket') required this.ticket, @JsonKey(name: 'match_id') this.matchId, @JsonKey(name: 'token') this.token, @JsonKey(name: 'users') required this.users, @JsonKey(name: 'self') required this.self}): super._();
+  
+
+/// The matchmaking ticket that has completed.
+@override@JsonKey(name: 'ticket') final  String ticket;
+/// Match ID.
+@override@JsonKey(name: 'match_id') final  String? matchId;
+/// Match ID.
+@override@JsonKey(name: 'token') final  String? token;
+/// The users that have been matched together, and information about their matchmaking data.
+@override@JsonKey(name: 'users') final  Iterable<MatchmakerUser> users;
+/// A reference to the current user and their properties.
+@override@JsonKey(name: 'self') final  MatchmakerUser self;
+
+/// Create a copy of MatchmakerMatched
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchmakerMatchedCopyWith<_MatchmakerMatched> get copyWith => __$MatchmakerMatchedCopyWithImpl<_MatchmakerMatched>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchmakerMatched&&(identical(other.ticket, ticket) || other.ticket == ticket)&&(identical(other.matchId, matchId) || other.matchId == matchId)&&(identical(other.token, token) || other.token == token)&&const DeepCollectionEquality().equals(other.users, users)&&(identical(other.self, self) || other.self == self));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,ticket,matchId,token,const DeepCollectionEquality().hash(users),self);
+
+@override
+String toString() {
+  return 'MatchmakerMatched(ticket: $ticket, matchId: $matchId, token: $token, users: $users, self: $self)';
+}
+
+
 }
 
 /// @nodoc
-class __$$MatchmakerMatchedImplCopyWithImpl<$Res>
-    extends _$MatchmakerMatchedCopyWithImpl<$Res, _$MatchmakerMatchedImpl>
-    implements _$$MatchmakerMatchedImplCopyWith<$Res> {
-  __$$MatchmakerMatchedImplCopyWithImpl(_$MatchmakerMatchedImpl _value,
-      $Res Function(_$MatchmakerMatchedImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$MatchmakerMatchedCopyWith<$Res> implements $MatchmakerMatchedCopyWith<$Res> {
+  factory _$MatchmakerMatchedCopyWith(_MatchmakerMatched value, $Res Function(_MatchmakerMatched) _then) = __$MatchmakerMatchedCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'ticket') String ticket,@JsonKey(name: 'match_id') String? matchId,@JsonKey(name: 'token') String? token,@JsonKey(name: 'users') Iterable<MatchmakerUser> users,@JsonKey(name: 'self') MatchmakerUser self
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? ticket = null,
-    Object? matchId = freezed,
-    Object? token = freezed,
-    Object? users = null,
-    Object? self = null,
-  }) {
-    return _then(_$MatchmakerMatchedImpl(
-      ticket: null == ticket
-          ? _value.ticket
-          : ticket // ignore: cast_nullable_to_non_nullable
-              as String,
-      matchId: freezed == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      token: freezed == token
-          ? _value.token
-          : token // ignore: cast_nullable_to_non_nullable
-              as String?,
-      users: null == users
-          ? _value.users
-          : users // ignore: cast_nullable_to_non_nullable
-              as Iterable<MatchmakerUser>,
-      self: null == self
-          ? _value.self
-          : self // ignore: cast_nullable_to_non_nullable
-              as MatchmakerUser,
-    ));
-  }
+
+@override $MatchmakerUserCopyWith<$Res> get self;
+
 }
-
 /// @nodoc
+class __$MatchmakerMatchedCopyWithImpl<$Res>
+    implements _$MatchmakerMatchedCopyWith<$Res> {
+  __$MatchmakerMatchedCopyWithImpl(this._self, this._then);
 
-class _$MatchmakerMatchedImpl extends _MatchmakerMatched {
-  const _$MatchmakerMatchedImpl(
-      {@JsonKey(name: 'ticket') required this.ticket,
-      @JsonKey(name: 'match_id') this.matchId,
-      @JsonKey(name: 'token') this.token,
-      @JsonKey(name: 'users') required this.users,
-      @JsonKey(name: 'self') required this.self})
-      : super._();
+  final _MatchmakerMatched _self;
+  final $Res Function(_MatchmakerMatched) _then;
 
-  /// The matchmaking ticket that has completed.
-  @override
-  @JsonKey(name: 'ticket')
-  final String ticket;
-
-  /// Match ID.
-  @override
-  @JsonKey(name: 'match_id')
-  final String? matchId;
-
-  /// Match ID.
-  @override
-  @JsonKey(name: 'token')
-  final String? token;
-
-  /// The users that have been matched together, and information about their matchmaking data.
-  @override
-  @JsonKey(name: 'users')
-  final Iterable<MatchmakerUser> users;
-
-  /// A reference to the current user and their properties.
-  @override
-  @JsonKey(name: 'self')
-  final MatchmakerUser self;
-
-  @override
-  String toString() {
-    return 'MatchmakerMatched(ticket: $ticket, matchId: $matchId, token: $token, users: $users, self: $self)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MatchmakerMatchedImpl &&
-            (identical(other.ticket, ticket) || other.ticket == ticket) &&
-            (identical(other.matchId, matchId) || other.matchId == matchId) &&
-            (identical(other.token, token) || other.token == token) &&
-            const DeepCollectionEquality().equals(other.users, users) &&
-            (identical(other.self, self) || other.self == self));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, ticket, matchId, token,
-      const DeepCollectionEquality().hash(users), self);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MatchmakerMatchedImplCopyWith<_$MatchmakerMatchedImpl> get copyWith =>
-      __$$MatchmakerMatchedImplCopyWithImpl<_$MatchmakerMatchedImpl>(
-          this, _$identity);
+/// Create a copy of MatchmakerMatched
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? ticket = null,Object? matchId = freezed,Object? token = freezed,Object? users = null,Object? self = null,}) {
+  return _then(_MatchmakerMatched(
+ticket: null == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
+as String,matchId: freezed == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String?,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String?,users: null == users ? _self.users : users // ignore: cast_nullable_to_non_nullable
+as Iterable<MatchmakerUser>,self: null == self ? _self.self : self // ignore: cast_nullable_to_non_nullable
+as MatchmakerUser,
+  ));
 }
 
-abstract class _MatchmakerMatched extends MatchmakerMatched {
-  const factory _MatchmakerMatched(
-          {@JsonKey(name: 'ticket') required final String ticket,
-          @JsonKey(name: 'match_id') final String? matchId,
-          @JsonKey(name: 'token') final String? token,
-          @JsonKey(name: 'users') required final Iterable<MatchmakerUser> users,
-          @JsonKey(name: 'self') required final MatchmakerUser self}) =
-      _$MatchmakerMatchedImpl;
-  const _MatchmakerMatched._() : super._();
-
-  @override
-
-  /// The matchmaking ticket that has completed.
-  @JsonKey(name: 'ticket')
-  String get ticket;
-  @override
-
-  /// Match ID.
-  @JsonKey(name: 'match_id')
-  String? get matchId;
-  @override
-
-  /// Match ID.
-  @JsonKey(name: 'token')
-  String? get token;
-  @override
-
-  /// The users that have been matched together, and information about their matchmaking data.
-  @JsonKey(name: 'users')
-  Iterable<MatchmakerUser> get users;
-  @override
-
-  /// A reference to the current user and their properties.
-  @JsonKey(name: 'self')
-  MatchmakerUser get self;
-  @override
-  @JsonKey(ignore: true)
-  _$$MatchmakerMatchedImplCopyWith<_$MatchmakerMatchedImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+/// Create a copy of MatchmakerMatched
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$MatchmakerUserCopyWith<$Res> get self {
+  
+  return $MatchmakerUserCopyWith<$Res>(_self.self, (value) {
+    return _then(_self.copyWith(self: value));
+  });
+}
 }
 
 /// @nodoc
 mixin _$MatchData {
-  /// The match unique ID.
-  @JsonKey(name: 'match_id')
-  String get matchId => throw _privateConstructorUsedError;
 
-  /// A reference to the user presence that sent this data, if any.
-  @JsonKey(name: 'presence')
-  UserPresence? get presence => throw _privateConstructorUsedError;
+/// The match unique ID.
+@JsonKey(name: 'match_id') String get matchId;/// A reference to the user presence that sent this data, if any.
+@JsonKey(name: 'presence') UserPresence? get presence;/// Op code value.
+@JsonKey(name: 'op_code') int get opCode;/// Data payload, if any.
+@JsonKey(name: 'data') List<int>? get data;/// True if this data was delivered reliably, false otherwise.
+@JsonKey(name: 'reliable') bool get reliable;
+/// Create a copy of MatchData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchDataCopyWith<MatchData> get copyWith => _$MatchDataCopyWithImpl<MatchData>(this as MatchData, _$identity);
 
-  /// Op code value.
-  @JsonKey(name: 'op_code')
-  int get opCode => throw _privateConstructorUsedError;
 
-  /// Data payload, if any.
-  @JsonKey(name: 'data')
-  List<int>? get data => throw _privateConstructorUsedError;
 
-  /// True if this data was delivered reliably, false otherwise.
-  @JsonKey(name: 'reliable')
-  bool get reliable => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchData&&(identical(other.matchId, matchId) || other.matchId == matchId)&&(identical(other.presence, presence) || other.presence == presence)&&(identical(other.opCode, opCode) || other.opCode == opCode)&&const DeepCollectionEquality().equals(other.data, data)&&(identical(other.reliable, reliable) || other.reliable == reliable));
+}
 
-  @JsonKey(ignore: true)
-  $MatchDataCopyWith<MatchData> get copyWith =>
-      throw _privateConstructorUsedError;
+
+@override
+int get hashCode => Object.hash(runtimeType,matchId,presence,opCode,const DeepCollectionEquality().hash(data),reliable);
+
+@override
+String toString() {
+  return 'MatchData(matchId: $matchId, presence: $presence, opCode: $opCode, data: $data, reliable: $reliable)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $MatchDataCopyWith<$Res> {
-  factory $MatchDataCopyWith(MatchData value, $Res Function(MatchData) then) =
-      _$MatchDataCopyWithImpl<$Res, MatchData>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'match_id') String matchId,
-      @JsonKey(name: 'presence') UserPresence? presence,
-      @JsonKey(name: 'op_code') int opCode,
-      @JsonKey(name: 'data') List<int>? data,
-      @JsonKey(name: 'reliable') bool reliable});
+abstract mixin class $MatchDataCopyWith<$Res>  {
+  factory $MatchDataCopyWith(MatchData value, $Res Function(MatchData) _then) = _$MatchDataCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'match_id') String matchId,@JsonKey(name: 'presence') UserPresence? presence,@JsonKey(name: 'op_code') int opCode,@JsonKey(name: 'data') List<int>? data,@JsonKey(name: 'reliable') bool reliable
+});
 
-  $UserPresenceCopyWith<$Res>? get presence;
+
+$UserPresenceCopyWith<$Res>? get presence;
+
 }
-
 /// @nodoc
-class _$MatchDataCopyWithImpl<$Res, $Val extends MatchData>
+class _$MatchDataCopyWithImpl<$Res>
     implements $MatchDataCopyWith<$Res> {
-  _$MatchDataCopyWithImpl(this._value, this._then);
+  _$MatchDataCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final MatchData _self;
+  final $Res Function(MatchData) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? matchId = null,
-    Object? presence = freezed,
-    Object? opCode = null,
-    Object? data = freezed,
-    Object? reliable = null,
-  }) {
-    return _then(_value.copyWith(
-      matchId: null == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      presence: freezed == presence
-          ? _value.presence
-          : presence // ignore: cast_nullable_to_non_nullable
-              as UserPresence?,
-      opCode: null == opCode
-          ? _value.opCode
-          : opCode // ignore: cast_nullable_to_non_nullable
-              as int,
-      data: freezed == data
-          ? _value.data
-          : data // ignore: cast_nullable_to_non_nullable
-              as List<int>?,
-      reliable: null == reliable
-          ? _value.reliable
-          : reliable // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+/// Create a copy of MatchData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? matchId = null,Object? presence = freezed,Object? opCode = null,Object? data = freezed,Object? reliable = null,}) {
+  return _then(_self.copyWith(
+matchId: null == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String,presence: freezed == presence ? _self.presence : presence // ignore: cast_nullable_to_non_nullable
+as UserPresence?,opCode: null == opCode ? _self.opCode : opCode // ignore: cast_nullable_to_non_nullable
+as int,data: freezed == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as List<int>?,reliable: null == reliable ? _self.reliable : reliable // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+/// Create a copy of MatchData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res>? get presence {
+    if (_self.presence == null) {
+    return null;
   }
 
-  @override
-  @pragma('vm:prefer-inline')
-  $UserPresenceCopyWith<$Res>? get presence {
-    if (_value.presence == null) {
-      return null;
-    }
+  return $UserPresenceCopyWith<$Res>(_self.presence!, (value) {
+    return _then(_self.copyWith(presence: value));
+  });
+}
+}
 
-    return $UserPresenceCopyWith<$Res>(_value.presence!, (value) {
-      return _then(_value.copyWith(presence: value) as $Val);
-    });
-  }
+
+/// Adds pattern-matching-related methods to [MatchData].
+extension MatchDataPatterns on MatchData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MatchData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MatchData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MatchData value)  $default,){
+final _that = this;
+switch (_that) {
+case _MatchData():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MatchData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MatchData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'presence')  UserPresence? presence, @JsonKey(name: 'op_code')  int opCode, @JsonKey(name: 'data')  List<int>? data, @JsonKey(name: 'reliable')  bool reliable)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MatchData() when $default != null:
+return $default(_that.matchId,_that.presence,_that.opCode,_that.data,_that.reliable);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'presence')  UserPresence? presence, @JsonKey(name: 'op_code')  int opCode, @JsonKey(name: 'data')  List<int>? data, @JsonKey(name: 'reliable')  bool reliable)  $default,) {final _that = this;
+switch (_that) {
+case _MatchData():
+return $default(_that.matchId,_that.presence,_that.opCode,_that.data,_that.reliable);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'presence')  UserPresence? presence, @JsonKey(name: 'op_code')  int opCode, @JsonKey(name: 'data')  List<int>? data, @JsonKey(name: 'reliable')  bool reliable)?  $default,) {final _that = this;
+switch (_that) {
+case _MatchData() when $default != null:
+return $default(_that.matchId,_that.presence,_that.opCode,_that.data,_that.reliable);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$MatchDataImplCopyWith<$Res>
-    implements $MatchDataCopyWith<$Res> {
-  factory _$$MatchDataImplCopyWith(
-          _$MatchDataImpl value, $Res Function(_$MatchDataImpl) then) =
-      __$$MatchDataImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'match_id') String matchId,
-      @JsonKey(name: 'presence') UserPresence? presence,
-      @JsonKey(name: 'op_code') int opCode,
-      @JsonKey(name: 'data') List<int>? data,
-      @JsonKey(name: 'reliable') bool reliable});
 
-  @override
-  $UserPresenceCopyWith<$Res>? get presence;
+
+class _MatchData extends MatchData {
+  const _MatchData({@JsonKey(name: 'match_id') required this.matchId, @JsonKey(name: 'presence') this.presence, @JsonKey(name: 'op_code') required this.opCode, @JsonKey(name: 'data') final  List<int>? data, @JsonKey(name: 'reliable') required this.reliable}): _data = data,super._();
+  
+
+/// The match unique ID.
+@override@JsonKey(name: 'match_id') final  String matchId;
+/// A reference to the user presence that sent this data, if any.
+@override@JsonKey(name: 'presence') final  UserPresence? presence;
+/// Op code value.
+@override@JsonKey(name: 'op_code') final  int opCode;
+/// Data payload, if any.
+ final  List<int>? _data;
+/// Data payload, if any.
+@override@JsonKey(name: 'data') List<int>? get data {
+  final value = _data;
+  if (value == null) return null;
+  if (_data is EqualUnmodifiableListView) return _data;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+/// True if this data was delivered reliably, false otherwise.
+@override@JsonKey(name: 'reliable') final  bool reliable;
+
+/// Create a copy of MatchData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchDataCopyWith<_MatchData> get copyWith => __$MatchDataCopyWithImpl<_MatchData>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchData&&(identical(other.matchId, matchId) || other.matchId == matchId)&&(identical(other.presence, presence) || other.presence == presence)&&(identical(other.opCode, opCode) || other.opCode == opCode)&&const DeepCollectionEquality().equals(other._data, _data)&&(identical(other.reliable, reliable) || other.reliable == reliable));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,matchId,presence,opCode,const DeepCollectionEquality().hash(_data),reliable);
+
+@override
+String toString() {
+  return 'MatchData(matchId: $matchId, presence: $presence, opCode: $opCode, data: $data, reliable: $reliable)';
+}
+
+
 }
 
 /// @nodoc
-class __$$MatchDataImplCopyWithImpl<$Res>
-    extends _$MatchDataCopyWithImpl<$Res, _$MatchDataImpl>
-    implements _$$MatchDataImplCopyWith<$Res> {
-  __$$MatchDataImplCopyWithImpl(
-      _$MatchDataImpl _value, $Res Function(_$MatchDataImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$MatchDataCopyWith<$Res> implements $MatchDataCopyWith<$Res> {
+  factory _$MatchDataCopyWith(_MatchData value, $Res Function(_MatchData) _then) = __$MatchDataCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'match_id') String matchId,@JsonKey(name: 'presence') UserPresence? presence,@JsonKey(name: 'op_code') int opCode,@JsonKey(name: 'data') List<int>? data,@JsonKey(name: 'reliable') bool reliable
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? matchId = null,
-    Object? presence = freezed,
-    Object? opCode = null,
-    Object? data = freezed,
-    Object? reliable = null,
-  }) {
-    return _then(_$MatchDataImpl(
-      matchId: null == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      presence: freezed == presence
-          ? _value.presence
-          : presence // ignore: cast_nullable_to_non_nullable
-              as UserPresence?,
-      opCode: null == opCode
-          ? _value.opCode
-          : opCode // ignore: cast_nullable_to_non_nullable
-              as int,
-      data: freezed == data
-          ? _value._data
-          : data // ignore: cast_nullable_to_non_nullable
-              as List<int>?,
-      reliable: null == reliable
-          ? _value.reliable
-          : reliable // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+
+@override $UserPresenceCopyWith<$Res>? get presence;
+
 }
-
 /// @nodoc
+class __$MatchDataCopyWithImpl<$Res>
+    implements _$MatchDataCopyWith<$Res> {
+  __$MatchDataCopyWithImpl(this._self, this._then);
 
-class _$MatchDataImpl extends _MatchData {
-  const _$MatchDataImpl(
-      {@JsonKey(name: 'match_id') required this.matchId,
-      @JsonKey(name: 'presence') this.presence,
-      @JsonKey(name: 'op_code') required this.opCode,
-      @JsonKey(name: 'data') final List<int>? data,
-      @JsonKey(name: 'reliable') required this.reliable})
-      : _data = data,
-        super._();
+  final _MatchData _self;
+  final $Res Function(_MatchData) _then;
 
-  /// The match unique ID.
-  @override
-  @JsonKey(name: 'match_id')
-  final String matchId;
-
-  /// A reference to the user presence that sent this data, if any.
-  @override
-  @JsonKey(name: 'presence')
-  final UserPresence? presence;
-
-  /// Op code value.
-  @override
-  @JsonKey(name: 'op_code')
-  final int opCode;
-
-  /// Data payload, if any.
-  final List<int>? _data;
-
-  /// Data payload, if any.
-  @override
-  @JsonKey(name: 'data')
-  List<int>? get data {
-    final value = _data;
-    if (value == null) return null;
-    if (_data is EqualUnmodifiableListView) return _data;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  /// True if this data was delivered reliably, false otherwise.
-  @override
-  @JsonKey(name: 'reliable')
-  final bool reliable;
-
-  @override
-  String toString() {
-    return 'MatchData(matchId: $matchId, presence: $presence, opCode: $opCode, data: $data, reliable: $reliable)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MatchDataImpl &&
-            (identical(other.matchId, matchId) || other.matchId == matchId) &&
-            (identical(other.presence, presence) ||
-                other.presence == presence) &&
-            (identical(other.opCode, opCode) || other.opCode == opCode) &&
-            const DeepCollectionEquality().equals(other._data, _data) &&
-            (identical(other.reliable, reliable) ||
-                other.reliable == reliable));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, matchId, presence, opCode,
-      const DeepCollectionEquality().hash(_data), reliable);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MatchDataImplCopyWith<_$MatchDataImpl> get copyWith =>
-      __$$MatchDataImplCopyWithImpl<_$MatchDataImpl>(this, _$identity);
+/// Create a copy of MatchData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? matchId = null,Object? presence = freezed,Object? opCode = null,Object? data = freezed,Object? reliable = null,}) {
+  return _then(_MatchData(
+matchId: null == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String,presence: freezed == presence ? _self.presence : presence // ignore: cast_nullable_to_non_nullable
+as UserPresence?,opCode: null == opCode ? _self.opCode : opCode // ignore: cast_nullable_to_non_nullable
+as int,data: freezed == data ? _self._data : data // ignore: cast_nullable_to_non_nullable
+as List<int>?,reliable: null == reliable ? _self.reliable : reliable // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
 
-abstract class _MatchData extends MatchData {
-  const factory _MatchData(
-          {@JsonKey(name: 'match_id') required final String matchId,
-          @JsonKey(name: 'presence') final UserPresence? presence,
-          @JsonKey(name: 'op_code') required final int opCode,
-          @JsonKey(name: 'data') final List<int>? data,
-          @JsonKey(name: 'reliable') required final bool reliable}) =
-      _$MatchDataImpl;
-  const _MatchData._() : super._();
+/// Create a copy of MatchData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res>? get presence {
+    if (_self.presence == null) {
+    return null;
+  }
 
-  @override
-
-  /// The match unique ID.
-  @JsonKey(name: 'match_id')
-  String get matchId;
-  @override
-
-  /// A reference to the user presence that sent this data, if any.
-  @JsonKey(name: 'presence')
-  UserPresence? get presence;
-  @override
-
-  /// Op code value.
-  @JsonKey(name: 'op_code')
-  int get opCode;
-  @override
-
-  /// Data payload, if any.
-  @JsonKey(name: 'data')
-  List<int>? get data;
-  @override
-
-  /// True if this data was delivered reliably, false otherwise.
-  @JsonKey(name: 'reliable')
-  bool get reliable;
-  @override
-  @JsonKey(ignore: true)
-  _$$MatchDataImplCopyWith<_$MatchDataImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  return $UserPresenceCopyWith<$Res>(_self.presence!, (value) {
+    return _then(_self.copyWith(presence: value));
+  });
+}
 }
 
 /// @nodoc
 mixin _$MatchPresenceEvent {
-  /// The match unique ID.
-  @JsonKey(name: 'match_id')
-  String get matchId => throw _privateConstructorUsedError;
 
-  /// The user presence that joined the match.
-  @JsonKey(name: 'joins')
-  List<UserPresence> get joins => throw _privateConstructorUsedError;
+/// The match unique ID.
+@JsonKey(name: 'match_id') String get matchId;/// The user presence that joined the match.
+@JsonKey(name: 'joins') List<UserPresence> get joins;/// The user presence that left the match.
+@JsonKey(name: 'leaves') List<UserPresence> get leaves;
+/// Create a copy of MatchPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchPresenceEventCopyWith<MatchPresenceEvent> get copyWith => _$MatchPresenceEventCopyWithImpl<MatchPresenceEvent>(this as MatchPresenceEvent, _$identity);
 
-  /// The user presence that left the match.
-  @JsonKey(name: 'leaves')
-  List<UserPresence> get leaves => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $MatchPresenceEventCopyWith<MatchPresenceEvent> get copyWith =>
-      throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchPresenceEvent&&(identical(other.matchId, matchId) || other.matchId == matchId)&&const DeepCollectionEquality().equals(other.joins, joins)&&const DeepCollectionEquality().equals(other.leaves, leaves));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,matchId,const DeepCollectionEquality().hash(joins),const DeepCollectionEquality().hash(leaves));
+
+@override
+String toString() {
+  return 'MatchPresenceEvent(matchId: $matchId, joins: $joins, leaves: $leaves)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $MatchPresenceEventCopyWith<$Res> {
-  factory $MatchPresenceEventCopyWith(
-          MatchPresenceEvent value, $Res Function(MatchPresenceEvent) then) =
-      _$MatchPresenceEventCopyWithImpl<$Res, MatchPresenceEvent>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'match_id') String matchId,
-      @JsonKey(name: 'joins') List<UserPresence> joins,
-      @JsonKey(name: 'leaves') List<UserPresence> leaves});
-}
+abstract mixin class $MatchPresenceEventCopyWith<$Res>  {
+  factory $MatchPresenceEventCopyWith(MatchPresenceEvent value, $Res Function(MatchPresenceEvent) _then) = _$MatchPresenceEventCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'match_id') String matchId,@JsonKey(name: 'joins') List<UserPresence> joins,@JsonKey(name: 'leaves') List<UserPresence> leaves
+});
 
+
+
+
+}
 /// @nodoc
-class _$MatchPresenceEventCopyWithImpl<$Res, $Val extends MatchPresenceEvent>
+class _$MatchPresenceEventCopyWithImpl<$Res>
     implements $MatchPresenceEventCopyWith<$Res> {
-  _$MatchPresenceEventCopyWithImpl(this._value, this._then);
+  _$MatchPresenceEventCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final MatchPresenceEvent _self;
+  final $Res Function(MatchPresenceEvent) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? matchId = null,
-    Object? joins = null,
-    Object? leaves = null,
-  }) {
-    return _then(_value.copyWith(
-      matchId: null == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      joins: null == joins
-          ? _value.joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-      leaves: null == leaves
-          ? _value.leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ) as $Val);
-  }
+/// Create a copy of MatchPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? matchId = null,Object? joins = null,Object? leaves = null,}) {
+  return _then(_self.copyWith(
+matchId: null == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String,joins: null == joins ? _self.joins : joins // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,leaves: null == leaves ? _self.leaves : leaves // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MatchPresenceEvent].
+extension MatchPresenceEventPatterns on MatchPresenceEvent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MatchPresenceEvent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MatchPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MatchPresenceEvent value)  $default,){
+final _that = this;
+switch (_that) {
+case _MatchPresenceEvent():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MatchPresenceEvent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MatchPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'joins')  List<UserPresence> joins, @JsonKey(name: 'leaves')  List<UserPresence> leaves)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MatchPresenceEvent() when $default != null:
+return $default(_that.matchId,_that.joins,_that.leaves);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'joins')  List<UserPresence> joins, @JsonKey(name: 'leaves')  List<UserPresence> leaves)  $default,) {final _that = this;
+switch (_that) {
+case _MatchPresenceEvent():
+return $default(_that.matchId,_that.joins,_that.leaves);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'joins')  List<UserPresence> joins, @JsonKey(name: 'leaves')  List<UserPresence> leaves)?  $default,) {final _that = this;
+switch (_that) {
+case _MatchPresenceEvent() when $default != null:
+return $default(_that.matchId,_that.joins,_that.leaves);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$MatchPresenceEventImplCopyWith<$Res>
-    implements $MatchPresenceEventCopyWith<$Res> {
-  factory _$$MatchPresenceEventImplCopyWith(_$MatchPresenceEventImpl value,
-          $Res Function(_$MatchPresenceEventImpl) then) =
-      __$$MatchPresenceEventImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'match_id') String matchId,
-      @JsonKey(name: 'joins') List<UserPresence> joins,
-      @JsonKey(name: 'leaves') List<UserPresence> leaves});
+
+
+class _MatchPresenceEvent extends MatchPresenceEvent {
+  const _MatchPresenceEvent({@JsonKey(name: 'match_id') required this.matchId, @JsonKey(name: 'joins') required final  List<UserPresence> joins, @JsonKey(name: 'leaves') required final  List<UserPresence> leaves}): _joins = joins,_leaves = leaves,super._();
+  
+
+/// The match unique ID.
+@override@JsonKey(name: 'match_id') final  String matchId;
+/// The user presence that joined the match.
+ final  List<UserPresence> _joins;
+/// The user presence that joined the match.
+@override@JsonKey(name: 'joins') List<UserPresence> get joins {
+  if (_joins is EqualUnmodifiableListView) return _joins;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_joins);
+}
+
+/// The user presence that left the match.
+ final  List<UserPresence> _leaves;
+/// The user presence that left the match.
+@override@JsonKey(name: 'leaves') List<UserPresence> get leaves {
+  if (_leaves is EqualUnmodifiableListView) return _leaves;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_leaves);
+}
+
+
+/// Create a copy of MatchPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchPresenceEventCopyWith<_MatchPresenceEvent> get copyWith => __$MatchPresenceEventCopyWithImpl<_MatchPresenceEvent>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchPresenceEvent&&(identical(other.matchId, matchId) || other.matchId == matchId)&&const DeepCollectionEquality().equals(other._joins, _joins)&&const DeepCollectionEquality().equals(other._leaves, _leaves));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,matchId,const DeepCollectionEquality().hash(_joins),const DeepCollectionEquality().hash(_leaves));
+
+@override
+String toString() {
+  return 'MatchPresenceEvent(matchId: $matchId, joins: $joins, leaves: $leaves)';
+}
+
+
 }
 
 /// @nodoc
-class __$$MatchPresenceEventImplCopyWithImpl<$Res>
-    extends _$MatchPresenceEventCopyWithImpl<$Res, _$MatchPresenceEventImpl>
-    implements _$$MatchPresenceEventImplCopyWith<$Res> {
-  __$$MatchPresenceEventImplCopyWithImpl(_$MatchPresenceEventImpl _value,
-      $Res Function(_$MatchPresenceEventImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$MatchPresenceEventCopyWith<$Res> implements $MatchPresenceEventCopyWith<$Res> {
+  factory _$MatchPresenceEventCopyWith(_MatchPresenceEvent value, $Res Function(_MatchPresenceEvent) _then) = __$MatchPresenceEventCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'match_id') String matchId,@JsonKey(name: 'joins') List<UserPresence> joins,@JsonKey(name: 'leaves') List<UserPresence> leaves
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? matchId = null,
-    Object? joins = null,
-    Object? leaves = null,
-  }) {
-    return _then(_$MatchPresenceEventImpl(
-      matchId: null == matchId
-          ? _value.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      joins: null == joins
-          ? _value._joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-      leaves: null == leaves
-          ? _value._leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ));
-  }
+
+
+
 }
-
 /// @nodoc
+class __$MatchPresenceEventCopyWithImpl<$Res>
+    implements _$MatchPresenceEventCopyWith<$Res> {
+  __$MatchPresenceEventCopyWithImpl(this._self, this._then);
 
-class _$MatchPresenceEventImpl extends _MatchPresenceEvent {
-  const _$MatchPresenceEventImpl(
-      {@JsonKey(name: 'match_id') required this.matchId,
-      @JsonKey(name: 'joins') required final List<UserPresence> joins,
-      @JsonKey(name: 'leaves') required final List<UserPresence> leaves})
-      : _joins = joins,
-        _leaves = leaves,
-        super._();
+  final _MatchPresenceEvent _self;
+  final $Res Function(_MatchPresenceEvent) _then;
 
-  /// The match unique ID.
-  @override
-  @JsonKey(name: 'match_id')
-  final String matchId;
-
-  /// The user presence that joined the match.
-  final List<UserPresence> _joins;
-
-  /// The user presence that joined the match.
-  @override
-  @JsonKey(name: 'joins')
-  List<UserPresence> get joins {
-    if (_joins is EqualUnmodifiableListView) return _joins;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_joins);
-  }
-
-  /// The user presence that left the match.
-  final List<UserPresence> _leaves;
-
-  /// The user presence that left the match.
-  @override
-  @JsonKey(name: 'leaves')
-  List<UserPresence> get leaves {
-    if (_leaves is EqualUnmodifiableListView) return _leaves;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_leaves);
-  }
-
-  @override
-  String toString() {
-    return 'MatchPresenceEvent(matchId: $matchId, joins: $joins, leaves: $leaves)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MatchPresenceEventImpl &&
-            (identical(other.matchId, matchId) || other.matchId == matchId) &&
-            const DeepCollectionEquality().equals(other._joins, _joins) &&
-            const DeepCollectionEquality().equals(other._leaves, _leaves));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      matchId,
-      const DeepCollectionEquality().hash(_joins),
-      const DeepCollectionEquality().hash(_leaves));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MatchPresenceEventImplCopyWith<_$MatchPresenceEventImpl> get copyWith =>
-      __$$MatchPresenceEventImplCopyWithImpl<_$MatchPresenceEventImpl>(
-          this, _$identity);
+/// Create a copy of MatchPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? matchId = null,Object? joins = null,Object? leaves = null,}) {
+  return _then(_MatchPresenceEvent(
+matchId: null == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String,joins: null == joins ? _self._joins : joins // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,leaves: null == leaves ? _self._leaves : leaves // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
 }
 
-abstract class _MatchPresenceEvent extends MatchPresenceEvent {
-  const factory _MatchPresenceEvent(
-          {@JsonKey(name: 'match_id') required final String matchId,
-          @JsonKey(name: 'joins') required final List<UserPresence> joins,
-          @JsonKey(name: 'leaves') required final List<UserPresence> leaves}) =
-      _$MatchPresenceEventImpl;
-  const _MatchPresenceEvent._() : super._();
 
-  @override
-
-  /// The match unique ID.
-  @JsonKey(name: 'match_id')
-  String get matchId;
-  @override
-
-  /// The user presence that joined the match.
-  @JsonKey(name: 'joins')
-  List<UserPresence> get joins;
-  @override
-
-  /// The user presence that left the match.
-  @JsonKey(name: 'leaves')
-  List<UserPresence> get leaves;
-  @override
-  @JsonKey(ignore: true)
-  _$$MatchPresenceEventImplCopyWith<_$MatchPresenceEventImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
+
+// dart format on

--- a/nakama/lib/src/models/notification.dart
+++ b/nakama/lib/src/models/notification.dart
@@ -5,7 +5,7 @@ part 'notification.freezed.dart';
 part 'notification.g.dart';
 
 @freezed
-class Notification with _$Notification {
+sealed class Notification with _$Notification {
   const Notification._();
 
   const factory Notification({
@@ -32,7 +32,7 @@ class Notification with _$Notification {
 }
 
 @freezed
-class NotificationList with _$NotificationList {
+sealed class NotificationList with _$NotificationList {
   const NotificationList._();
 
   const factory NotificationList({

--- a/nakama/lib/src/models/notification.freezed.dart
+++ b/nakama/lib/src/models/notification.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,475 +9,547 @@ part of 'notification.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-Notification _$NotificationFromJson(Map<String, dynamic> json) {
-  return _Notification.fromJson(json);
-}
 
 /// @nodoc
 mixin _$Notification {
-  @JsonKey(name: 'id')
-  String get id => throw _privateConstructorUsedError;
-  @JsonKey(name: 'subject')
-  String? get subject => throw _privateConstructorUsedError;
-  @JsonKey(name: 'content')
-  String? get content => throw _privateConstructorUsedError;
-  @JsonKey(name: 'code')
-  int get code => throw _privateConstructorUsedError;
-  @JsonKey(name: 'sender_id')
-  String get senderId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'create_time')
-  DateTime get createTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'persistent')
-  bool get persistent => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $NotificationCopyWith<Notification> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'id') String get id;@JsonKey(name: 'subject') String? get subject;@JsonKey(name: 'content') String? get content;@JsonKey(name: 'code') int get code;@JsonKey(name: 'sender_id') String get senderId;@JsonKey(name: 'create_time') DateTime get createTime;@JsonKey(name: 'persistent') bool get persistent;
+/// Create a copy of Notification
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NotificationCopyWith<Notification> get copyWith => _$NotificationCopyWithImpl<Notification>(this as Notification, _$identity);
+
+  /// Serializes this Notification to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Notification&&(identical(other.id, id) || other.id == id)&&(identical(other.subject, subject) || other.subject == subject)&&(identical(other.content, content) || other.content == content)&&(identical(other.code, code) || other.code == code)&&(identical(other.senderId, senderId) || other.senderId == senderId)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.persistent, persistent) || other.persistent == persistent));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,subject,content,code,senderId,createTime,persistent);
+
+@override
+String toString() {
+  return 'Notification(id: $id, subject: $subject, content: $content, code: $code, senderId: $senderId, createTime: $createTime, persistent: $persistent)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $NotificationCopyWith<$Res> {
-  factory $NotificationCopyWith(
-          Notification value, $Res Function(Notification) then) =
-      _$NotificationCopyWithImpl<$Res, Notification>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'id') String id,
-      @JsonKey(name: 'subject') String? subject,
-      @JsonKey(name: 'content') String? content,
-      @JsonKey(name: 'code') int code,
-      @JsonKey(name: 'sender_id') String senderId,
-      @JsonKey(name: 'create_time') DateTime createTime,
-      @JsonKey(name: 'persistent') bool persistent});
-}
+abstract mixin class $NotificationCopyWith<$Res>  {
+  factory $NotificationCopyWith(Notification value, $Res Function(Notification) _then) = _$NotificationCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'id') String id,@JsonKey(name: 'subject') String? subject,@JsonKey(name: 'content') String? content,@JsonKey(name: 'code') int code,@JsonKey(name: 'sender_id') String senderId,@JsonKey(name: 'create_time') DateTime createTime,@JsonKey(name: 'persistent') bool persistent
+});
 
+
+
+
+}
 /// @nodoc
-class _$NotificationCopyWithImpl<$Res, $Val extends Notification>
+class _$NotificationCopyWithImpl<$Res>
     implements $NotificationCopyWith<$Res> {
-  _$NotificationCopyWithImpl(this._value, this._then);
+  _$NotificationCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Notification _self;
+  final $Res Function(Notification) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? subject = freezed,
-    Object? content = freezed,
-    Object? code = null,
-    Object? senderId = null,
-    Object? createTime = null,
-    Object? persistent = null,
-  }) {
-    return _then(_value.copyWith(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      subject: freezed == subject
-          ? _value.subject
-          : subject // ignore: cast_nullable_to_non_nullable
-              as String?,
-      content: freezed == content
-          ? _value.content
-          : content // ignore: cast_nullable_to_non_nullable
-              as String?,
-      code: null == code
-          ? _value.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as int,
-      senderId: null == senderId
-          ? _value.senderId
-          : senderId // ignore: cast_nullable_to_non_nullable
-              as String,
-      createTime: null == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      persistent: null == persistent
-          ? _value.persistent
-          : persistent // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
-  }
+/// Create a copy of Notification
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? subject = freezed,Object? content = freezed,Object? code = null,Object? senderId = null,Object? createTime = null,Object? persistent = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,subject: freezed == subject ? _self.subject : subject // ignore: cast_nullable_to_non_nullable
+as String?,content: freezed == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
+as String?,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as int,senderId: null == senderId ? _self.senderId : senderId // ignore: cast_nullable_to_non_nullable
+as String,createTime: null == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime,persistent: null == persistent ? _self.persistent : persistent // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
 
-/// @nodoc
-abstract class _$$NotificationImplCopyWith<$Res>
-    implements $NotificationCopyWith<$Res> {
-  factory _$$NotificationImplCopyWith(
-          _$NotificationImpl value, $Res Function(_$NotificationImpl) then) =
-      __$$NotificationImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'id') String id,
-      @JsonKey(name: 'subject') String? subject,
-      @JsonKey(name: 'content') String? content,
-      @JsonKey(name: 'code') int code,
-      @JsonKey(name: 'sender_id') String senderId,
-      @JsonKey(name: 'create_time') DateTime createTime,
-      @JsonKey(name: 'persistent') bool persistent});
 }
 
-/// @nodoc
-class __$$NotificationImplCopyWithImpl<$Res>
-    extends _$NotificationCopyWithImpl<$Res, _$NotificationImpl>
-    implements _$$NotificationImplCopyWith<$Res> {
-  __$$NotificationImplCopyWithImpl(
-      _$NotificationImpl _value, $Res Function(_$NotificationImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? subject = freezed,
-    Object? content = freezed,
-    Object? code = null,
-    Object? senderId = null,
-    Object? createTime = null,
-    Object? persistent = null,
-  }) {
-    return _then(_$NotificationImpl(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      subject: freezed == subject
-          ? _value.subject
-          : subject // ignore: cast_nullable_to_non_nullable
-              as String?,
-      content: freezed == content
-          ? _value.content
-          : content // ignore: cast_nullable_to_non_nullable
-              as String?,
-      code: null == code
-          ? _value.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as int,
-      senderId: null == senderId
-          ? _value.senderId
-          : senderId // ignore: cast_nullable_to_non_nullable
-              as String,
-      createTime: null == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      persistent: null == persistent
-          ? _value.persistent
-          : persistent // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Notification].
+extension NotificationPatterns on Notification {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Notification value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Notification() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Notification value)  $default,){
+final _that = this;
+switch (_that) {
+case _Notification():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Notification value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Notification() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'subject')  String? subject, @JsonKey(name: 'content')  String? content, @JsonKey(name: 'code')  int code, @JsonKey(name: 'sender_id')  String senderId, @JsonKey(name: 'create_time')  DateTime createTime, @JsonKey(name: 'persistent')  bool persistent)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Notification() when $default != null:
+return $default(_that.id,_that.subject,_that.content,_that.code,_that.senderId,_that.createTime,_that.persistent);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'subject')  String? subject, @JsonKey(name: 'content')  String? content, @JsonKey(name: 'code')  int code, @JsonKey(name: 'sender_id')  String senderId, @JsonKey(name: 'create_time')  DateTime createTime, @JsonKey(name: 'persistent')  bool persistent)  $default,) {final _that = this;
+switch (_that) {
+case _Notification():
+return $default(_that.id,_that.subject,_that.content,_that.code,_that.senderId,_that.createTime,_that.persistent);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'subject')  String? subject, @JsonKey(name: 'content')  String? content, @JsonKey(name: 'code')  int code, @JsonKey(name: 'sender_id')  String senderId, @JsonKey(name: 'create_time')  DateTime createTime, @JsonKey(name: 'persistent')  bool persistent)?  $default,) {final _that = this;
+switch (_that) {
+case _Notification() when $default != null:
+return $default(_that.id,_that.subject,_that.content,_that.code,_that.senderId,_that.createTime,_that.persistent);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$NotificationImpl extends _Notification {
-  const _$NotificationImpl(
-      {@JsonKey(name: 'id') required this.id,
-      @JsonKey(name: 'subject') this.subject,
-      @JsonKey(name: 'content') this.content,
-      @JsonKey(name: 'code') required this.code,
-      @JsonKey(name: 'sender_id') required this.senderId,
-      @JsonKey(name: 'create_time') required this.createTime,
-      @JsonKey(name: 'persistent') required this.persistent})
-      : super._();
 
-  factory _$NotificationImpl.fromJson(Map<String, dynamic> json) =>
-      _$$NotificationImplFromJson(json);
+class _Notification extends Notification {
+  const _Notification({@JsonKey(name: 'id') required this.id, @JsonKey(name: 'subject') this.subject, @JsonKey(name: 'content') this.content, @JsonKey(name: 'code') required this.code, @JsonKey(name: 'sender_id') required this.senderId, @JsonKey(name: 'create_time') required this.createTime, @JsonKey(name: 'persistent') required this.persistent}): super._();
+  factory _Notification.fromJson(Map<String, dynamic> json) => _$NotificationFromJson(json);
 
-  @override
-  @JsonKey(name: 'id')
-  final String id;
-  @override
-  @JsonKey(name: 'subject')
-  final String? subject;
-  @override
-  @JsonKey(name: 'content')
-  final String? content;
-  @override
-  @JsonKey(name: 'code')
-  final int code;
-  @override
-  @JsonKey(name: 'sender_id')
-  final String senderId;
-  @override
-  @JsonKey(name: 'create_time')
-  final DateTime createTime;
-  @override
-  @JsonKey(name: 'persistent')
-  final bool persistent;
+@override@JsonKey(name: 'id') final  String id;
+@override@JsonKey(name: 'subject') final  String? subject;
+@override@JsonKey(name: 'content') final  String? content;
+@override@JsonKey(name: 'code') final  int code;
+@override@JsonKey(name: 'sender_id') final  String senderId;
+@override@JsonKey(name: 'create_time') final  DateTime createTime;
+@override@JsonKey(name: 'persistent') final  bool persistent;
 
-  @override
-  String toString() {
-    return 'Notification(id: $id, subject: $subject, content: $content, code: $code, senderId: $senderId, createTime: $createTime, persistent: $persistent)';
-  }
+/// Create a copy of Notification
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$NotificationCopyWith<_Notification> get copyWith => __$NotificationCopyWithImpl<_Notification>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$NotificationImpl &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.subject, subject) || other.subject == subject) &&
-            (identical(other.content, content) || other.content == content) &&
-            (identical(other.code, code) || other.code == code) &&
-            (identical(other.senderId, senderId) ||
-                other.senderId == senderId) &&
-            (identical(other.createTime, createTime) ||
-                other.createTime == createTime) &&
-            (identical(other.persistent, persistent) ||
-                other.persistent == persistent));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, subject, content, code,
-      senderId, createTime, persistent);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$NotificationImplCopyWith<_$NotificationImpl> get copyWith =>
-      __$$NotificationImplCopyWithImpl<_$NotificationImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$NotificationImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$NotificationToJson(this, );
 }
 
-abstract class _Notification extends Notification {
-  const factory _Notification(
-          {@JsonKey(name: 'id') required final String id,
-          @JsonKey(name: 'subject') final String? subject,
-          @JsonKey(name: 'content') final String? content,
-          @JsonKey(name: 'code') required final int code,
-          @JsonKey(name: 'sender_id') required final String senderId,
-          @JsonKey(name: 'create_time') required final DateTime createTime,
-          @JsonKey(name: 'persistent') required final bool persistent}) =
-      _$NotificationImpl;
-  const _Notification._() : super._();
-
-  factory _Notification.fromJson(Map<String, dynamic> json) =
-      _$NotificationImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'id')
-  String get id;
-  @override
-  @JsonKey(name: 'subject')
-  String? get subject;
-  @override
-  @JsonKey(name: 'content')
-  String? get content;
-  @override
-  @JsonKey(name: 'code')
-  int get code;
-  @override
-  @JsonKey(name: 'sender_id')
-  String get senderId;
-  @override
-  @JsonKey(name: 'create_time')
-  DateTime get createTime;
-  @override
-  @JsonKey(name: 'persistent')
-  bool get persistent;
-  @override
-  @JsonKey(ignore: true)
-  _$$NotificationImplCopyWith<_$NotificationImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Notification&&(identical(other.id, id) || other.id == id)&&(identical(other.subject, subject) || other.subject == subject)&&(identical(other.content, content) || other.content == content)&&(identical(other.code, code) || other.code == code)&&(identical(other.senderId, senderId) || other.senderId == senderId)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.persistent, persistent) || other.persistent == persistent));
 }
 
-NotificationList _$NotificationListFromJson(Map<String, dynamic> json) {
-  return _NotificationList.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,subject,content,code,senderId,createTime,persistent);
+
+@override
+String toString() {
+  return 'Notification(id: $id, subject: $subject, content: $content, code: $code, senderId: $senderId, createTime: $createTime, persistent: $persistent)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$NotificationCopyWith<$Res> implements $NotificationCopyWith<$Res> {
+  factory _$NotificationCopyWith(_Notification value, $Res Function(_Notification) _then) = __$NotificationCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'id') String id,@JsonKey(name: 'subject') String? subject,@JsonKey(name: 'content') String? content,@JsonKey(name: 'code') int code,@JsonKey(name: 'sender_id') String senderId,@JsonKey(name: 'create_time') DateTime createTime,@JsonKey(name: 'persistent') bool persistent
+});
+
+
+
+
+}
+/// @nodoc
+class __$NotificationCopyWithImpl<$Res>
+    implements _$NotificationCopyWith<$Res> {
+  __$NotificationCopyWithImpl(this._self, this._then);
+
+  final _Notification _self;
+  final $Res Function(_Notification) _then;
+
+/// Create a copy of Notification
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? subject = freezed,Object? content = freezed,Object? code = null,Object? senderId = null,Object? createTime = null,Object? persistent = null,}) {
+  return _then(_Notification(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,subject: freezed == subject ? _self.subject : subject // ignore: cast_nullable_to_non_nullable
+as String?,content: freezed == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
+as String?,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as int,senderId: null == senderId ? _self.senderId : senderId // ignore: cast_nullable_to_non_nullable
+as String,createTime: null == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime,persistent: null == persistent ? _self.persistent : persistent // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$NotificationList {
-  @JsonKey(name: 'cacheable_cursor')
-  String? get cursor => throw _privateConstructorUsedError;
-  @JsonKey(name: 'notifications')
-  List<Notification> get notifications => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $NotificationListCopyWith<NotificationList> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'cacheable_cursor') String? get cursor;@JsonKey(name: 'notifications') List<Notification> get notifications;
+/// Create a copy of NotificationList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NotificationListCopyWith<NotificationList> get copyWith => _$NotificationListCopyWithImpl<NotificationList>(this as NotificationList, _$identity);
+
+  /// Serializes this NotificationList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.notifications, notifications));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(notifications));
+
+@override
+String toString() {
+  return 'NotificationList(cursor: $cursor, notifications: $notifications)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $NotificationListCopyWith<$Res> {
-  factory $NotificationListCopyWith(
-          NotificationList value, $Res Function(NotificationList) then) =
-      _$NotificationListCopyWithImpl<$Res, NotificationList>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'cacheable_cursor') String? cursor,
-      @JsonKey(name: 'notifications') List<Notification> notifications});
-}
+abstract mixin class $NotificationListCopyWith<$Res>  {
+  factory $NotificationListCopyWith(NotificationList value, $Res Function(NotificationList) _then) = _$NotificationListCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'cacheable_cursor') String? cursor,@JsonKey(name: 'notifications') List<Notification> notifications
+});
 
+
+
+
+}
 /// @nodoc
-class _$NotificationListCopyWithImpl<$Res, $Val extends NotificationList>
+class _$NotificationListCopyWithImpl<$Res>
     implements $NotificationListCopyWith<$Res> {
-  _$NotificationListCopyWithImpl(this._value, this._then);
+  _$NotificationListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final NotificationList _self;
+  final $Res Function(NotificationList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? notifications = null,
-  }) {
-    return _then(_value.copyWith(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      notifications: null == notifications
-          ? _value.notifications
-          : notifications // ignore: cast_nullable_to_non_nullable
-              as List<Notification>,
-    ) as $Val);
-  }
+/// Create a copy of NotificationList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? notifications = null,}) {
+  return _then(_self.copyWith(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,notifications: null == notifications ? _self.notifications : notifications // ignore: cast_nullable_to_non_nullable
+as List<Notification>,
+  ));
 }
 
-/// @nodoc
-abstract class _$$NotificationListImplCopyWith<$Res>
-    implements $NotificationListCopyWith<$Res> {
-  factory _$$NotificationListImplCopyWith(_$NotificationListImpl value,
-          $Res Function(_$NotificationListImpl) then) =
-      __$$NotificationListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'cacheable_cursor') String? cursor,
-      @JsonKey(name: 'notifications') List<Notification> notifications});
 }
 
-/// @nodoc
-class __$$NotificationListImplCopyWithImpl<$Res>
-    extends _$NotificationListCopyWithImpl<$Res, _$NotificationListImpl>
-    implements _$$NotificationListImplCopyWith<$Res> {
-  __$$NotificationListImplCopyWithImpl(_$NotificationListImpl _value,
-      $Res Function(_$NotificationListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? notifications = null,
-  }) {
-    return _then(_$NotificationListImpl(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      notifications: null == notifications
-          ? _value._notifications
-          : notifications // ignore: cast_nullable_to_non_nullable
-              as List<Notification>,
-    ));
-  }
+/// Adds pattern-matching-related methods to [NotificationList].
+extension NotificationListPatterns on NotificationList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NotificationList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NotificationList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NotificationList value)  $default,){
+final _that = this;
+switch (_that) {
+case _NotificationList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NotificationList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NotificationList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'cacheable_cursor')  String? cursor, @JsonKey(name: 'notifications')  List<Notification> notifications)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NotificationList() when $default != null:
+return $default(_that.cursor,_that.notifications);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'cacheable_cursor')  String? cursor, @JsonKey(name: 'notifications')  List<Notification> notifications)  $default,) {final _that = this;
+switch (_that) {
+case _NotificationList():
+return $default(_that.cursor,_that.notifications);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'cacheable_cursor')  String? cursor, @JsonKey(name: 'notifications')  List<Notification> notifications)?  $default,) {final _that = this;
+switch (_that) {
+case _NotificationList() when $default != null:
+return $default(_that.cursor,_that.notifications);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$NotificationListImpl extends _NotificationList {
-  const _$NotificationListImpl(
-      {@JsonKey(name: 'cacheable_cursor') this.cursor,
-      @JsonKey(name: 'notifications')
-      required final List<Notification> notifications})
-      : _notifications = notifications,
-        super._();
 
-  factory _$NotificationListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$NotificationListImplFromJson(json);
+class _NotificationList extends NotificationList {
+  const _NotificationList({@JsonKey(name: 'cacheable_cursor') this.cursor, @JsonKey(name: 'notifications') required final  List<Notification> notifications}): _notifications = notifications,super._();
+  factory _NotificationList.fromJson(Map<String, dynamic> json) => _$NotificationListFromJson(json);
 
-  @override
-  @JsonKey(name: 'cacheable_cursor')
-  final String? cursor;
-  final List<Notification> _notifications;
-  @override
-  @JsonKey(name: 'notifications')
-  List<Notification> get notifications {
-    if (_notifications is EqualUnmodifiableListView) return _notifications;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_notifications);
-  }
-
-  @override
-  String toString() {
-    return 'NotificationList(cursor: $cursor, notifications: $notifications)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$NotificationListImpl &&
-            (identical(other.cursor, cursor) || other.cursor == cursor) &&
-            const DeepCollectionEquality()
-                .equals(other._notifications, _notifications));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, cursor, const DeepCollectionEquality().hash(_notifications));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$NotificationListImplCopyWith<_$NotificationListImpl> get copyWith =>
-      __$$NotificationListImplCopyWithImpl<_$NotificationListImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$NotificationListImplToJson(
-      this,
-    );
-  }
+@override@JsonKey(name: 'cacheable_cursor') final  String? cursor;
+ final  List<Notification> _notifications;
+@override@JsonKey(name: 'notifications') List<Notification> get notifications {
+  if (_notifications is EqualUnmodifiableListView) return _notifications;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_notifications);
 }
 
-abstract class _NotificationList extends NotificationList {
-  const factory _NotificationList(
-          {@JsonKey(name: 'cacheable_cursor') final String? cursor,
-          @JsonKey(name: 'notifications')
-          required final List<Notification> notifications}) =
-      _$NotificationListImpl;
-  const _NotificationList._() : super._();
 
-  factory _NotificationList.fromJson(Map<String, dynamic> json) =
-      _$NotificationListImpl.fromJson;
+/// Create a copy of NotificationList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$NotificationListCopyWith<_NotificationList> get copyWith => __$NotificationListCopyWithImpl<_NotificationList>(this, _$identity);
 
-  @override
-  @JsonKey(name: 'cacheable_cursor')
-  String? get cursor;
-  @override
-  @JsonKey(name: 'notifications')
-  List<Notification> get notifications;
-  @override
-  @JsonKey(ignore: true)
-  _$$NotificationListImplCopyWith<_$NotificationListImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$NotificationListToJson(this, );
 }
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._notifications, _notifications));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(_notifications));
+
+@override
+String toString() {
+  return 'NotificationList(cursor: $cursor, notifications: $notifications)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$NotificationListCopyWith<$Res> implements $NotificationListCopyWith<$Res> {
+  factory _$NotificationListCopyWith(_NotificationList value, $Res Function(_NotificationList) _then) = __$NotificationListCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'cacheable_cursor') String? cursor,@JsonKey(name: 'notifications') List<Notification> notifications
+});
+
+
+
+
+}
+/// @nodoc
+class __$NotificationListCopyWithImpl<$Res>
+    implements _$NotificationListCopyWith<$Res> {
+  __$NotificationListCopyWithImpl(this._self, this._then);
+
+  final _NotificationList _self;
+  final $Res Function(_NotificationList) _then;
+
+/// Create a copy of NotificationList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? notifications = null,}) {
+  return _then(_NotificationList(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,notifications: null == notifications ? _self._notifications : notifications // ignore: cast_nullable_to_non_nullable
+as List<Notification>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/nakama/lib/src/models/notification.g.dart
+++ b/nakama/lib/src/models/notification.g.dart
@@ -6,18 +6,18 @@ part of 'notification.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$NotificationImpl _$$NotificationImplFromJson(Map<String, dynamic> json) =>
-    _$NotificationImpl(
+_Notification _$NotificationFromJson(Map<String, dynamic> json) =>
+    _Notification(
       id: json['id'] as String,
       subject: json['subject'] as String?,
       content: json['content'] as String?,
-      code: json['code'] as int,
+      code: (json['code'] as num).toInt(),
       senderId: json['sender_id'] as String,
       createTime: DateTime.parse(json['create_time'] as String),
       persistent: json['persistent'] as bool,
     );
 
-Map<String, dynamic> _$$NotificationImplToJson(_$NotificationImpl instance) =>
+Map<String, dynamic> _$NotificationToJson(_Notification instance) =>
     <String, dynamic>{
       'id': instance.id,
       'subject': instance.subject,
@@ -28,17 +28,15 @@ Map<String, dynamic> _$$NotificationImplToJson(_$NotificationImpl instance) =>
       'persistent': instance.persistent,
     };
 
-_$NotificationListImpl _$$NotificationListImplFromJson(
-        Map<String, dynamic> json) =>
-    _$NotificationListImpl(
+_NotificationList _$NotificationListFromJson(Map<String, dynamic> json) =>
+    _NotificationList(
       cursor: json['cacheable_cursor'] as String?,
       notifications: (json['notifications'] as List<dynamic>)
           .map((e) => Notification.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$NotificationListImplToJson(
-        _$NotificationListImpl instance) =>
+Map<String, dynamic> _$NotificationListToJson(_NotificationList instance) =>
     <String, dynamic>{
       'cacheable_cursor': instance.cursor,
       'notifications': instance.notifications,

--- a/nakama/lib/src/models/party.dart
+++ b/nakama/lib/src/models/party.dart
@@ -5,7 +5,7 @@ import 'package:nakama/src/api/rtapi.dart' as rtpb;
 part 'party.freezed.dart';
 
 @freezed
-class PartyData with _$PartyData {
+sealed class PartyData with _$PartyData {
   const PartyData._();
 
   const factory PartyData({
@@ -30,7 +30,7 @@ class PartyData with _$PartyData {
       );
 }
 @freezed
-class PartyPresenceEvent with _$PartyPresenceEvent {
+sealed class PartyPresenceEvent with _$PartyPresenceEvent {
   const PartyPresenceEvent._();
 
   const factory PartyPresenceEvent({
@@ -52,7 +52,7 @@ class PartyPresenceEvent with _$PartyPresenceEvent {
 }
 
 @freezed
-class PartyLeader with _$PartyLeader {
+sealed class PartyLeader with _$PartyLeader {
   const PartyLeader._();
 
   const factory PartyLeader({

--- a/nakama/lib/src/models/party.freezed.dart
+++ b/nakama/lib/src/models/party.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,644 +9,870 @@ part of 'party.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
 /// @nodoc
 mixin _$PartyData {
-  /// The party unique ID.
-  @JsonKey(name: 'party_id')
-  String get partyId => throw _privateConstructorUsedError;
 
-  /// A reference to the user presence that sent this data, if any.
-  @JsonKey(name: 'presence')
-  UserPresence? get presence => throw _privateConstructorUsedError;
+/// The party unique ID.
+@JsonKey(name: 'party_id') String get partyId;/// A reference to the user presence that sent this data, if any.
+@JsonKey(name: 'presence') UserPresence? get presence;/// Op code value.
+@JsonKey(name: 'op_code') int get opCode;/// Data payload, if any.
+@JsonKey(name: 'data') List<int>? get data;
+/// Create a copy of PartyData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartyDataCopyWith<PartyData> get copyWith => _$PartyDataCopyWithImpl<PartyData>(this as PartyData, _$identity);
 
-  /// Op code value.
-  @JsonKey(name: 'op_code')
-  int get opCode => throw _privateConstructorUsedError;
 
-  /// Data payload, if any.
-  @JsonKey(name: 'data')
-  List<int>? get data => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $PartyDataCopyWith<PartyData> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartyData&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.presence, presence) || other.presence == presence)&&(identical(other.opCode, opCode) || other.opCode == opCode)&&const DeepCollectionEquality().equals(other.data, data));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,presence,opCode,const DeepCollectionEquality().hash(data));
+
+@override
+String toString() {
+  return 'PartyData(partyId: $partyId, presence: $presence, opCode: $opCode, data: $data)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $PartyDataCopyWith<$Res> {
-  factory $PartyDataCopyWith(PartyData value, $Res Function(PartyData) then) =
-      _$PartyDataCopyWithImpl<$Res, PartyData>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'presence') UserPresence? presence,
-      @JsonKey(name: 'op_code') int opCode,
-      @JsonKey(name: 'data') List<int>? data});
+abstract mixin class $PartyDataCopyWith<$Res>  {
+  factory $PartyDataCopyWith(PartyData value, $Res Function(PartyData) _then) = _$PartyDataCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'presence') UserPresence? presence,@JsonKey(name: 'op_code') int opCode,@JsonKey(name: 'data') List<int>? data
+});
 
-  $UserPresenceCopyWith<$Res>? get presence;
+
+$UserPresenceCopyWith<$Res>? get presence;
+
 }
-
 /// @nodoc
-class _$PartyDataCopyWithImpl<$Res, $Val extends PartyData>
+class _$PartyDataCopyWithImpl<$Res>
     implements $PartyDataCopyWith<$Res> {
-  _$PartyDataCopyWithImpl(this._value, this._then);
+  _$PartyDataCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final PartyData _self;
+  final $Res Function(PartyData) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? presence = freezed,
-    Object? opCode = null,
-    Object? data = freezed,
-  }) {
-    return _then(_value.copyWith(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      presence: freezed == presence
-          ? _value.presence
-          : presence // ignore: cast_nullable_to_non_nullable
-              as UserPresence?,
-      opCode: null == opCode
-          ? _value.opCode
-          : opCode // ignore: cast_nullable_to_non_nullable
-              as int,
-      data: freezed == data
-          ? _value.data
-          : data // ignore: cast_nullable_to_non_nullable
-              as List<int>?,
-    ) as $Val);
+/// Create a copy of PartyData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,Object? presence = freezed,Object? opCode = null,Object? data = freezed,}) {
+  return _then(_self.copyWith(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,presence: freezed == presence ? _self.presence : presence // ignore: cast_nullable_to_non_nullable
+as UserPresence?,opCode: null == opCode ? _self.opCode : opCode // ignore: cast_nullable_to_non_nullable
+as int,data: freezed == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as List<int>?,
+  ));
+}
+/// Create a copy of PartyData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res>? get presence {
+    if (_self.presence == null) {
+    return null;
   }
 
-  @override
-  @pragma('vm:prefer-inline')
-  $UserPresenceCopyWith<$Res>? get presence {
-    if (_value.presence == null) {
-      return null;
-    }
+  return $UserPresenceCopyWith<$Res>(_self.presence!, (value) {
+    return _then(_self.copyWith(presence: value));
+  });
+}
+}
 
-    return $UserPresenceCopyWith<$Res>(_value.presence!, (value) {
-      return _then(_value.copyWith(presence: value) as $Val);
-    });
-  }
+
+/// Adds pattern-matching-related methods to [PartyData].
+extension PartyDataPatterns on PartyData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PartyData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PartyData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PartyData value)  $default,){
+final _that = this;
+switch (_that) {
+case _PartyData():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PartyData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PartyData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presence')  UserPresence? presence, @JsonKey(name: 'op_code')  int opCode, @JsonKey(name: 'data')  List<int>? data)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PartyData() when $default != null:
+return $default(_that.partyId,_that.presence,_that.opCode,_that.data);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presence')  UserPresence? presence, @JsonKey(name: 'op_code')  int opCode, @JsonKey(name: 'data')  List<int>? data)  $default,) {final _that = this;
+switch (_that) {
+case _PartyData():
+return $default(_that.partyId,_that.presence,_that.opCode,_that.data);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presence')  UserPresence? presence, @JsonKey(name: 'op_code')  int opCode, @JsonKey(name: 'data')  List<int>? data)?  $default,) {final _that = this;
+switch (_that) {
+case _PartyData() when $default != null:
+return $default(_that.partyId,_that.presence,_that.opCode,_that.data);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$PartyDataImplCopyWith<$Res>
-    implements $PartyDataCopyWith<$Res> {
-  factory _$$PartyDataImplCopyWith(
-          _$PartyDataImpl value, $Res Function(_$PartyDataImpl) then) =
-      __$$PartyDataImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'presence') UserPresence? presence,
-      @JsonKey(name: 'op_code') int opCode,
-      @JsonKey(name: 'data') List<int>? data});
 
-  @override
-  $UserPresenceCopyWith<$Res>? get presence;
+
+class _PartyData extends PartyData {
+  const _PartyData({@JsonKey(name: 'party_id') required this.partyId, @JsonKey(name: 'presence') this.presence, @JsonKey(name: 'op_code') required this.opCode, @JsonKey(name: 'data') final  List<int>? data}): _data = data,super._();
+  
+
+/// The party unique ID.
+@override@JsonKey(name: 'party_id') final  String partyId;
+/// A reference to the user presence that sent this data, if any.
+@override@JsonKey(name: 'presence') final  UserPresence? presence;
+/// Op code value.
+@override@JsonKey(name: 'op_code') final  int opCode;
+/// Data payload, if any.
+ final  List<int>? _data;
+/// Data payload, if any.
+@override@JsonKey(name: 'data') List<int>? get data {
+  final value = _data;
+  if (value == null) return null;
+  if (_data is EqualUnmodifiableListView) return _data;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+
+/// Create a copy of PartyData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartyDataCopyWith<_PartyData> get copyWith => __$PartyDataCopyWithImpl<_PartyData>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartyData&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.presence, presence) || other.presence == presence)&&(identical(other.opCode, opCode) || other.opCode == opCode)&&const DeepCollectionEquality().equals(other._data, _data));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,presence,opCode,const DeepCollectionEquality().hash(_data));
+
+@override
+String toString() {
+  return 'PartyData(partyId: $partyId, presence: $presence, opCode: $opCode, data: $data)';
+}
+
+
 }
 
 /// @nodoc
-class __$$PartyDataImplCopyWithImpl<$Res>
-    extends _$PartyDataCopyWithImpl<$Res, _$PartyDataImpl>
-    implements _$$PartyDataImplCopyWith<$Res> {
-  __$$PartyDataImplCopyWithImpl(
-      _$PartyDataImpl _value, $Res Function(_$PartyDataImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$PartyDataCopyWith<$Res> implements $PartyDataCopyWith<$Res> {
+  factory _$PartyDataCopyWith(_PartyData value, $Res Function(_PartyData) _then) = __$PartyDataCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'presence') UserPresence? presence,@JsonKey(name: 'op_code') int opCode,@JsonKey(name: 'data') List<int>? data
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? presence = freezed,
-    Object? opCode = null,
-    Object? data = freezed,
-  }) {
-    return _then(_$PartyDataImpl(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      presence: freezed == presence
-          ? _value.presence
-          : presence // ignore: cast_nullable_to_non_nullable
-              as UserPresence?,
-      opCode: null == opCode
-          ? _value.opCode
-          : opCode // ignore: cast_nullable_to_non_nullable
-              as int,
-      data: freezed == data
-          ? _value._data
-          : data // ignore: cast_nullable_to_non_nullable
-              as List<int>?,
-    ));
-  }
+
+@override $UserPresenceCopyWith<$Res>? get presence;
+
 }
-
 /// @nodoc
+class __$PartyDataCopyWithImpl<$Res>
+    implements _$PartyDataCopyWith<$Res> {
+  __$PartyDataCopyWithImpl(this._self, this._then);
 
-class _$PartyDataImpl extends _PartyData {
-  const _$PartyDataImpl(
-      {@JsonKey(name: 'party_id') required this.partyId,
-      @JsonKey(name: 'presence') this.presence,
-      @JsonKey(name: 'op_code') required this.opCode,
-      @JsonKey(name: 'data') final List<int>? data})
-      : _data = data,
-        super._();
+  final _PartyData _self;
+  final $Res Function(_PartyData) _then;
 
-  /// The party unique ID.
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-
-  /// A reference to the user presence that sent this data, if any.
-  @override
-  @JsonKey(name: 'presence')
-  final UserPresence? presence;
-
-  /// Op code value.
-  @override
-  @JsonKey(name: 'op_code')
-  final int opCode;
-
-  /// Data payload, if any.
-  final List<int>? _data;
-
-  /// Data payload, if any.
-  @override
-  @JsonKey(name: 'data')
-  List<int>? get data {
-    final value = _data;
-    if (value == null) return null;
-    if (_data is EqualUnmodifiableListView) return _data;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'PartyData(partyId: $partyId, presence: $presence, opCode: $opCode, data: $data)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$PartyDataImpl &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.presence, presence) ||
-                other.presence == presence) &&
-            (identical(other.opCode, opCode) || other.opCode == opCode) &&
-            const DeepCollectionEquality().equals(other._data, _data));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, partyId, presence, opCode,
-      const DeepCollectionEquality().hash(_data));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$PartyDataImplCopyWith<_$PartyDataImpl> get copyWith =>
-      __$$PartyDataImplCopyWithImpl<_$PartyDataImpl>(this, _$identity);
+/// Create a copy of PartyData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,Object? presence = freezed,Object? opCode = null,Object? data = freezed,}) {
+  return _then(_PartyData(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,presence: freezed == presence ? _self.presence : presence // ignore: cast_nullable_to_non_nullable
+as UserPresence?,opCode: null == opCode ? _self.opCode : opCode // ignore: cast_nullable_to_non_nullable
+as int,data: freezed == data ? _self._data : data // ignore: cast_nullable_to_non_nullable
+as List<int>?,
+  ));
 }
 
-abstract class _PartyData extends PartyData {
-  const factory _PartyData(
-      {@JsonKey(name: 'party_id') required final String partyId,
-      @JsonKey(name: 'presence') final UserPresence? presence,
-      @JsonKey(name: 'op_code') required final int opCode,
-      @JsonKey(name: 'data') final List<int>? data}) = _$PartyDataImpl;
-  const _PartyData._() : super._();
+/// Create a copy of PartyData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res>? get presence {
+    if (_self.presence == null) {
+    return null;
+  }
 
-  @override
-
-  /// The party unique ID.
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  @override
-
-  /// A reference to the user presence that sent this data, if any.
-  @JsonKey(name: 'presence')
-  UserPresence? get presence;
-  @override
-
-  /// Op code value.
-  @JsonKey(name: 'op_code')
-  int get opCode;
-  @override
-
-  /// Data payload, if any.
-  @JsonKey(name: 'data')
-  List<int>? get data;
-  @override
-  @JsonKey(ignore: true)
-  _$$PartyDataImplCopyWith<_$PartyDataImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  return $UserPresenceCopyWith<$Res>(_self.presence!, (value) {
+    return _then(_self.copyWith(presence: value));
+  });
+}
 }
 
 /// @nodoc
 mixin _$PartyPresenceEvent {
-  /// The party unique ID.
-  @JsonKey(name: 'party_id')
-  String get partyId => throw _privateConstructorUsedError;
 
-  /// Presences that have joined the party.
-  @JsonKey(name: 'joins')
-  List<UserPresence>? get joins => throw _privateConstructorUsedError;
+/// The party unique ID.
+@JsonKey(name: 'party_id') String get partyId;/// Presences that have joined the party.
+@JsonKey(name: 'joins') List<UserPresence>? get joins;/// Presences that have left the party.
+@JsonKey(name: 'leaves') List<UserPresence>? get leaves;
+/// Create a copy of PartyPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartyPresenceEventCopyWith<PartyPresenceEvent> get copyWith => _$PartyPresenceEventCopyWithImpl<PartyPresenceEvent>(this as PartyPresenceEvent, _$identity);
 
-  /// Presences that have left the party.
-  @JsonKey(name: 'leaves')
-  List<UserPresence>? get leaves => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $PartyPresenceEventCopyWith<PartyPresenceEvent> get copyWith =>
-      throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartyPresenceEvent&&(identical(other.partyId, partyId) || other.partyId == partyId)&&const DeepCollectionEquality().equals(other.joins, joins)&&const DeepCollectionEquality().equals(other.leaves, leaves));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,const DeepCollectionEquality().hash(joins),const DeepCollectionEquality().hash(leaves));
+
+@override
+String toString() {
+  return 'PartyPresenceEvent(partyId: $partyId, joins: $joins, leaves: $leaves)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $PartyPresenceEventCopyWith<$Res> {
-  factory $PartyPresenceEventCopyWith(
-          PartyPresenceEvent value, $Res Function(PartyPresenceEvent) then) =
-      _$PartyPresenceEventCopyWithImpl<$Res, PartyPresenceEvent>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'joins') List<UserPresence>? joins,
-      @JsonKey(name: 'leaves') List<UserPresence>? leaves});
-}
+abstract mixin class $PartyPresenceEventCopyWith<$Res>  {
+  factory $PartyPresenceEventCopyWith(PartyPresenceEvent value, $Res Function(PartyPresenceEvent) _then) = _$PartyPresenceEventCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'joins') List<UserPresence>? joins,@JsonKey(name: 'leaves') List<UserPresence>? leaves
+});
 
+
+
+
+}
 /// @nodoc
-class _$PartyPresenceEventCopyWithImpl<$Res, $Val extends PartyPresenceEvent>
+class _$PartyPresenceEventCopyWithImpl<$Res>
     implements $PartyPresenceEventCopyWith<$Res> {
-  _$PartyPresenceEventCopyWithImpl(this._value, this._then);
+  _$PartyPresenceEventCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final PartyPresenceEvent _self;
+  final $Res Function(PartyPresenceEvent) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? joins = freezed,
-    Object? leaves = freezed,
-  }) {
-    return _then(_value.copyWith(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      joins: freezed == joins
-          ? _value.joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>?,
-      leaves: freezed == leaves
-          ? _value.leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>?,
-    ) as $Val);
-  }
+/// Create a copy of PartyPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,Object? joins = freezed,Object? leaves = freezed,}) {
+  return _then(_self.copyWith(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,joins: freezed == joins ? _self.joins : joins // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>?,leaves: freezed == leaves ? _self.leaves : leaves // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PartyPresenceEvent].
+extension PartyPresenceEventPatterns on PartyPresenceEvent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PartyPresenceEvent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PartyPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PartyPresenceEvent value)  $default,){
+final _that = this;
+switch (_that) {
+case _PartyPresenceEvent():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PartyPresenceEvent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PartyPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'joins')  List<UserPresence>? joins, @JsonKey(name: 'leaves')  List<UserPresence>? leaves)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PartyPresenceEvent() when $default != null:
+return $default(_that.partyId,_that.joins,_that.leaves);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'joins')  List<UserPresence>? joins, @JsonKey(name: 'leaves')  List<UserPresence>? leaves)  $default,) {final _that = this;
+switch (_that) {
+case _PartyPresenceEvent():
+return $default(_that.partyId,_that.joins,_that.leaves);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'joins')  List<UserPresence>? joins, @JsonKey(name: 'leaves')  List<UserPresence>? leaves)?  $default,) {final _that = this;
+switch (_that) {
+case _PartyPresenceEvent() when $default != null:
+return $default(_that.partyId,_that.joins,_that.leaves);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$PartyPresenceEventImplCopyWith<$Res>
-    implements $PartyPresenceEventCopyWith<$Res> {
-  factory _$$PartyPresenceEventImplCopyWith(_$PartyPresenceEventImpl value,
-          $Res Function(_$PartyPresenceEventImpl) then) =
-      __$$PartyPresenceEventImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'joins') List<UserPresence>? joins,
-      @JsonKey(name: 'leaves') List<UserPresence>? leaves});
+
+
+class _PartyPresenceEvent extends PartyPresenceEvent {
+  const _PartyPresenceEvent({@JsonKey(name: 'party_id') required this.partyId, @JsonKey(name: 'joins') final  List<UserPresence>? joins, @JsonKey(name: 'leaves') final  List<UserPresence>? leaves}): _joins = joins,_leaves = leaves,super._();
+  
+
+/// The party unique ID.
+@override@JsonKey(name: 'party_id') final  String partyId;
+/// Presences that have joined the party.
+ final  List<UserPresence>? _joins;
+/// Presences that have joined the party.
+@override@JsonKey(name: 'joins') List<UserPresence>? get joins {
+  final value = _joins;
+  if (value == null) return null;
+  if (_joins is EqualUnmodifiableListView) return _joins;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+/// Presences that have left the party.
+ final  List<UserPresence>? _leaves;
+/// Presences that have left the party.
+@override@JsonKey(name: 'leaves') List<UserPresence>? get leaves {
+  final value = _leaves;
+  if (value == null) return null;
+  if (_leaves is EqualUnmodifiableListView) return _leaves;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+
+/// Create a copy of PartyPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartyPresenceEventCopyWith<_PartyPresenceEvent> get copyWith => __$PartyPresenceEventCopyWithImpl<_PartyPresenceEvent>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartyPresenceEvent&&(identical(other.partyId, partyId) || other.partyId == partyId)&&const DeepCollectionEquality().equals(other._joins, _joins)&&const DeepCollectionEquality().equals(other._leaves, _leaves));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,const DeepCollectionEquality().hash(_joins),const DeepCollectionEquality().hash(_leaves));
+
+@override
+String toString() {
+  return 'PartyPresenceEvent(partyId: $partyId, joins: $joins, leaves: $leaves)';
+}
+
+
 }
 
 /// @nodoc
-class __$$PartyPresenceEventImplCopyWithImpl<$Res>
-    extends _$PartyPresenceEventCopyWithImpl<$Res, _$PartyPresenceEventImpl>
-    implements _$$PartyPresenceEventImplCopyWith<$Res> {
-  __$$PartyPresenceEventImplCopyWithImpl(_$PartyPresenceEventImpl _value,
-      $Res Function(_$PartyPresenceEventImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$PartyPresenceEventCopyWith<$Res> implements $PartyPresenceEventCopyWith<$Res> {
+  factory _$PartyPresenceEventCopyWith(_PartyPresenceEvent value, $Res Function(_PartyPresenceEvent) _then) = __$PartyPresenceEventCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'joins') List<UserPresence>? joins,@JsonKey(name: 'leaves') List<UserPresence>? leaves
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? joins = freezed,
-    Object? leaves = freezed,
-  }) {
-    return _then(_$PartyPresenceEventImpl(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      joins: freezed == joins
-          ? _value._joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>?,
-      leaves: freezed == leaves
-          ? _value._leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>?,
-    ));
-  }
+
+
+
 }
-
 /// @nodoc
+class __$PartyPresenceEventCopyWithImpl<$Res>
+    implements _$PartyPresenceEventCopyWith<$Res> {
+  __$PartyPresenceEventCopyWithImpl(this._self, this._then);
 
-class _$PartyPresenceEventImpl extends _PartyPresenceEvent {
-  const _$PartyPresenceEventImpl(
-      {@JsonKey(name: 'party_id') required this.partyId,
-      @JsonKey(name: 'joins') final List<UserPresence>? joins,
-      @JsonKey(name: 'leaves') final List<UserPresence>? leaves})
-      : _joins = joins,
-        _leaves = leaves,
-        super._();
+  final _PartyPresenceEvent _self;
+  final $Res Function(_PartyPresenceEvent) _then;
 
-  /// The party unique ID.
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-
-  /// Presences that have joined the party.
-  final List<UserPresence>? _joins;
-
-  /// Presences that have joined the party.
-  @override
-  @JsonKey(name: 'joins')
-  List<UserPresence>? get joins {
-    final value = _joins;
-    if (value == null) return null;
-    if (_joins is EqualUnmodifiableListView) return _joins;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  /// Presences that have left the party.
-  final List<UserPresence>? _leaves;
-
-  /// Presences that have left the party.
-  @override
-  @JsonKey(name: 'leaves')
-  List<UserPresence>? get leaves {
-    final value = _leaves;
-    if (value == null) return null;
-    if (_leaves is EqualUnmodifiableListView) return _leaves;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'PartyPresenceEvent(partyId: $partyId, joins: $joins, leaves: $leaves)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$PartyPresenceEventImpl &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            const DeepCollectionEquality().equals(other._joins, _joins) &&
-            const DeepCollectionEquality().equals(other._leaves, _leaves));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      partyId,
-      const DeepCollectionEquality().hash(_joins),
-      const DeepCollectionEquality().hash(_leaves));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$PartyPresenceEventImplCopyWith<_$PartyPresenceEventImpl> get copyWith =>
-      __$$PartyPresenceEventImplCopyWithImpl<_$PartyPresenceEventImpl>(
-          this, _$identity);
+/// Create a copy of PartyPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,Object? joins = freezed,Object? leaves = freezed,}) {
+  return _then(_PartyPresenceEvent(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,joins: freezed == joins ? _self._joins : joins // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>?,leaves: freezed == leaves ? _self._leaves : leaves // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>?,
+  ));
 }
 
-abstract class _PartyPresenceEvent extends PartyPresenceEvent {
-  const factory _PartyPresenceEvent(
-          {@JsonKey(name: 'party_id') required final String partyId,
-          @JsonKey(name: 'joins') final List<UserPresence>? joins,
-          @JsonKey(name: 'leaves') final List<UserPresence>? leaves}) =
-      _$PartyPresenceEventImpl;
-  const _PartyPresenceEvent._() : super._();
 
-  @override
-
-  /// The party unique ID.
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  @override
-
-  /// Presences that have joined the party.
-  @JsonKey(name: 'joins')
-  List<UserPresence>? get joins;
-  @override
-
-  /// Presences that have left the party.
-  @JsonKey(name: 'leaves')
-  List<UserPresence>? get leaves;
-  @override
-  @JsonKey(ignore: true)
-  _$$PartyPresenceEventImplCopyWith<_$PartyPresenceEventImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 mixin _$PartyLeader {
-  /// The ID of the party to announce the new leader for.
-  @JsonKey(name: 'party_id')
-  String get partyId => throw _privateConstructorUsedError;
 
-  /// The presence of the new party leader.
-  @JsonKey(name: 'presence')
-  UserPresence? get newLeader => throw _privateConstructorUsedError;
+/// The ID of the party to announce the new leader for.
+@JsonKey(name: 'party_id') String get partyId;/// The presence of the new party leader.
+@JsonKey(name: 'presence') UserPresence? get newLeader;
+/// Create a copy of PartyLeader
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartyLeaderCopyWith<PartyLeader> get copyWith => _$PartyLeaderCopyWithImpl<PartyLeader>(this as PartyLeader, _$identity);
 
-  @JsonKey(ignore: true)
-  $PartyLeaderCopyWith<PartyLeader> get copyWith =>
-      throw _privateConstructorUsedError;
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartyLeader&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.newLeader, newLeader) || other.newLeader == newLeader));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,newLeader);
+
+@override
+String toString() {
+  return 'PartyLeader(partyId: $partyId, newLeader: $newLeader)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $PartyLeaderCopyWith<$Res> {
-  factory $PartyLeaderCopyWith(
-          PartyLeader value, $Res Function(PartyLeader) then) =
-      _$PartyLeaderCopyWithImpl<$Res, PartyLeader>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'presence') UserPresence? newLeader});
+abstract mixin class $PartyLeaderCopyWith<$Res>  {
+  factory $PartyLeaderCopyWith(PartyLeader value, $Res Function(PartyLeader) _then) = _$PartyLeaderCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'presence') UserPresence? newLeader
+});
 
-  $UserPresenceCopyWith<$Res>? get newLeader;
+
+$UserPresenceCopyWith<$Res>? get newLeader;
+
 }
-
 /// @nodoc
-class _$PartyLeaderCopyWithImpl<$Res, $Val extends PartyLeader>
+class _$PartyLeaderCopyWithImpl<$Res>
     implements $PartyLeaderCopyWith<$Res> {
-  _$PartyLeaderCopyWithImpl(this._value, this._then);
+  _$PartyLeaderCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final PartyLeader _self;
+  final $Res Function(PartyLeader) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? newLeader = freezed,
-  }) {
-    return _then(_value.copyWith(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      newLeader: freezed == newLeader
-          ? _value.newLeader
-          : newLeader // ignore: cast_nullable_to_non_nullable
-              as UserPresence?,
-    ) as $Val);
+/// Create a copy of PartyLeader
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,Object? newLeader = freezed,}) {
+  return _then(_self.copyWith(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,newLeader: freezed == newLeader ? _self.newLeader : newLeader // ignore: cast_nullable_to_non_nullable
+as UserPresence?,
+  ));
+}
+/// Create a copy of PartyLeader
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res>? get newLeader {
+    if (_self.newLeader == null) {
+    return null;
   }
 
-  @override
-  @pragma('vm:prefer-inline')
-  $UserPresenceCopyWith<$Res>? get newLeader {
-    if (_value.newLeader == null) {
-      return null;
-    }
+  return $UserPresenceCopyWith<$Res>(_self.newLeader!, (value) {
+    return _then(_self.copyWith(newLeader: value));
+  });
+}
+}
 
-    return $UserPresenceCopyWith<$Res>(_value.newLeader!, (value) {
-      return _then(_value.copyWith(newLeader: value) as $Val);
-    });
-  }
+
+/// Adds pattern-matching-related methods to [PartyLeader].
+extension PartyLeaderPatterns on PartyLeader {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PartyLeader value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PartyLeader() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PartyLeader value)  $default,){
+final _that = this;
+switch (_that) {
+case _PartyLeader():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PartyLeader value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PartyLeader() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presence')  UserPresence? newLeader)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PartyLeader() when $default != null:
+return $default(_that.partyId,_that.newLeader);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presence')  UserPresence? newLeader)  $default,) {final _that = this;
+switch (_that) {
+case _PartyLeader():
+return $default(_that.partyId,_that.newLeader);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presence')  UserPresence? newLeader)?  $default,) {final _that = this;
+switch (_that) {
+case _PartyLeader() when $default != null:
+return $default(_that.partyId,_that.newLeader);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$PartyLeaderImplCopyWith<$Res>
-    implements $PartyLeaderCopyWith<$Res> {
-  factory _$$PartyLeaderImplCopyWith(
-          _$PartyLeaderImpl value, $Res Function(_$PartyLeaderImpl) then) =
-      __$$PartyLeaderImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'presence') UserPresence? newLeader});
 
-  @override
-  $UserPresenceCopyWith<$Res>? get newLeader;
+
+class _PartyLeader extends PartyLeader {
+  const _PartyLeader({@JsonKey(name: 'party_id') required this.partyId, @JsonKey(name: 'presence') this.newLeader}): super._();
+  
+
+/// The ID of the party to announce the new leader for.
+@override@JsonKey(name: 'party_id') final  String partyId;
+/// The presence of the new party leader.
+@override@JsonKey(name: 'presence') final  UserPresence? newLeader;
+
+/// Create a copy of PartyLeader
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartyLeaderCopyWith<_PartyLeader> get copyWith => __$PartyLeaderCopyWithImpl<_PartyLeader>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartyLeader&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.newLeader, newLeader) || other.newLeader == newLeader));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,newLeader);
+
+@override
+String toString() {
+  return 'PartyLeader(partyId: $partyId, newLeader: $newLeader)';
+}
+
+
 }
 
 /// @nodoc
-class __$$PartyLeaderImplCopyWithImpl<$Res>
-    extends _$PartyLeaderCopyWithImpl<$Res, _$PartyLeaderImpl>
-    implements _$$PartyLeaderImplCopyWith<$Res> {
-  __$$PartyLeaderImplCopyWithImpl(
-      _$PartyLeaderImpl _value, $Res Function(_$PartyLeaderImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$PartyLeaderCopyWith<$Res> implements $PartyLeaderCopyWith<$Res> {
+  factory _$PartyLeaderCopyWith(_PartyLeader value, $Res Function(_PartyLeader) _then) = __$PartyLeaderCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'presence') UserPresence? newLeader
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? partyId = null,
-    Object? newLeader = freezed,
-  }) {
-    return _then(_$PartyLeaderImpl(
-      partyId: null == partyId
-          ? _value.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      newLeader: freezed == newLeader
-          ? _value.newLeader
-          : newLeader // ignore: cast_nullable_to_non_nullable
-              as UserPresence?,
-    ));
-  }
+
+@override $UserPresenceCopyWith<$Res>? get newLeader;
+
 }
-
 /// @nodoc
+class __$PartyLeaderCopyWithImpl<$Res>
+    implements _$PartyLeaderCopyWith<$Res> {
+  __$PartyLeaderCopyWithImpl(this._self, this._then);
 
-class _$PartyLeaderImpl extends _PartyLeader {
-  const _$PartyLeaderImpl(
-      {@JsonKey(name: 'party_id') required this.partyId,
-      @JsonKey(name: 'presence') this.newLeader})
-      : super._();
+  final _PartyLeader _self;
+  final $Res Function(_PartyLeader) _then;
 
-  /// The ID of the party to announce the new leader for.
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-
-  /// The presence of the new party leader.
-  @override
-  @JsonKey(name: 'presence')
-  final UserPresence? newLeader;
-
-  @override
-  String toString() {
-    return 'PartyLeader(partyId: $partyId, newLeader: $newLeader)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$PartyLeaderImpl &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.newLeader, newLeader) ||
-                other.newLeader == newLeader));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, partyId, newLeader);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$PartyLeaderImplCopyWith<_$PartyLeaderImpl> get copyWith =>
-      __$$PartyLeaderImplCopyWithImpl<_$PartyLeaderImpl>(this, _$identity);
+/// Create a copy of PartyLeader
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,Object? newLeader = freezed,}) {
+  return _then(_PartyLeader(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,newLeader: freezed == newLeader ? _self.newLeader : newLeader // ignore: cast_nullable_to_non_nullable
+as UserPresence?,
+  ));
 }
 
-abstract class _PartyLeader extends PartyLeader {
-  const factory _PartyLeader(
-          {@JsonKey(name: 'party_id') required final String partyId,
-          @JsonKey(name: 'presence') final UserPresence? newLeader}) =
-      _$PartyLeaderImpl;
-  const _PartyLeader._() : super._();
+/// Create a copy of PartyLeader
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res>? get newLeader {
+    if (_self.newLeader == null) {
+    return null;
+  }
 
-  @override
-
-  /// The ID of the party to announce the new leader for.
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  @override
-
-  /// The presence of the new party leader.
-  @JsonKey(name: 'presence')
-  UserPresence? get newLeader;
-  @override
-  @JsonKey(ignore: true)
-  _$$PartyLeaderImplCopyWith<_$PartyLeaderImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  return $UserPresenceCopyWith<$Res>(_self.newLeader!, (value) {
+    return _then(_self.copyWith(newLeader: value));
+  });
 }
+}
+
+// dart format on

--- a/nakama/lib/src/models/response_error.g.dart
+++ b/nakama/lib/src/models/response_error.g.dart
@@ -8,12 +8,9 @@ part of 'response_error.dart';
 
 ResponseError _$ResponseErrorFromJson(Map<String, dynamic> json) =>
     ResponseError(
-      code: json['code'] as int?,
+      code: (json['code'] as num?)?.toInt(),
       message: json['message'] as String?,
     );
 
 Map<String, dynamic> _$ResponseErrorToJson(ResponseError instance) =>
-    <String, dynamic>{
-      'code': instance.code,
-      'message': instance.message,
-    };
+    <String, dynamic>{'code': instance.code, 'message': instance.message};

--- a/nakama/lib/src/models/rpc.dart
+++ b/nakama/lib/src/models/rpc.dart
@@ -4,7 +4,7 @@ import 'package:nakama/src/api/api.dart' as api;
 part 'rpc.freezed.dart';
 
 @freezed
-class Rpc with _$Rpc {
+sealed class Rpc with _$Rpc {
   const Rpc._();
 
   const factory Rpc({

--- a/nakama/lib/src/models/rpc.freezed.dart
+++ b/nakama/lib/src/models/rpc.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,118 +9,257 @@ part of 'rpc.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
 /// @nodoc
 mixin _$Rpc {
-  String get payload => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $RpcCopyWith<Rpc> get copyWith => throw _privateConstructorUsedError;
+ String get payload;
+/// Create a copy of Rpc
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RpcCopyWith<Rpc> get copyWith => _$RpcCopyWithImpl<Rpc>(this as Rpc, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Rpc&&(identical(other.payload, payload) || other.payload == payload));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,payload);
+
+@override
+String toString() {
+  return 'Rpc(payload: $payload)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $RpcCopyWith<$Res> {
-  factory $RpcCopyWith(Rpc value, $Res Function(Rpc) then) =
-      _$RpcCopyWithImpl<$Res, Rpc>;
-  @useResult
-  $Res call({String payload});
+abstract mixin class $RpcCopyWith<$Res>  {
+  factory $RpcCopyWith(Rpc value, $Res Function(Rpc) _then) = _$RpcCopyWithImpl;
+@useResult
+$Res call({
+ String payload
+});
+
+
+
+
+}
+/// @nodoc
+class _$RpcCopyWithImpl<$Res>
+    implements $RpcCopyWith<$Res> {
+  _$RpcCopyWithImpl(this._self, this._then);
+
+  final Rpc _self;
+  final $Res Function(Rpc) _then;
+
+/// Create a copy of Rpc
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? payload = null,}) {
+  return _then(_self.copyWith(
+payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Rpc].
+extension RpcPatterns on Rpc {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Rpc value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Rpc() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Rpc value)  $default,){
+final _that = this;
+switch (_that) {
+case _Rpc():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Rpc value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Rpc() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String payload)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Rpc() when $default != null:
+return $default(_that.payload);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String payload)  $default,) {final _that = this;
+switch (_that) {
+case _Rpc():
+return $default(_that.payload);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String payload)?  $default,) {final _that = this;
+switch (_that) {
+case _Rpc() when $default != null:
+return $default(_that.payload);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-class _$RpcCopyWithImpl<$Res, $Val extends Rpc> implements $RpcCopyWith<$Res> {
-  _$RpcCopyWithImpl(this._value, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? payload = null,
-  }) {
-    return _then(_value.copyWith(
-      payload: null == payload
-          ? _value.payload
-          : payload // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
+class _Rpc extends Rpc {
+  const _Rpc({required this.payload}): super._();
+  
+
+@override final  String payload;
+
+/// Create a copy of Rpc
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RpcCopyWith<_Rpc> get copyWith => __$RpcCopyWithImpl<_Rpc>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Rpc&&(identical(other.payload, payload) || other.payload == payload));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,payload);
+
+@override
+String toString() {
+  return 'Rpc(payload: $payload)';
+}
+
+
 }
 
 /// @nodoc
-abstract class _$$RpcImplCopyWith<$Res> implements $RpcCopyWith<$Res> {
-  factory _$$RpcImplCopyWith(_$RpcImpl value, $Res Function(_$RpcImpl) then) =
-      __$$RpcImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String payload});
-}
+abstract mixin class _$RpcCopyWith<$Res> implements $RpcCopyWith<$Res> {
+  factory _$RpcCopyWith(_Rpc value, $Res Function(_Rpc) _then) = __$RpcCopyWithImpl;
+@override @useResult
+$Res call({
+ String payload
+});
 
+
+
+
+}
 /// @nodoc
-class __$$RpcImplCopyWithImpl<$Res> extends _$RpcCopyWithImpl<$Res, _$RpcImpl>
-    implements _$$RpcImplCopyWith<$Res> {
-  __$$RpcImplCopyWithImpl(_$RpcImpl _value, $Res Function(_$RpcImpl) _then)
-      : super(_value, _then);
+class __$RpcCopyWithImpl<$Res>
+    implements _$RpcCopyWith<$Res> {
+  __$RpcCopyWithImpl(this._self, this._then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? payload = null,
-  }) {
-    return _then(_$RpcImpl(
-      payload: null == payload
-          ? _value.payload
-          : payload // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+  final _Rpc _self;
+  final $Res Function(_Rpc) _then;
+
+/// Create a copy of Rpc
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? payload = null,}) {
+  return _then(_Rpc(
+payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
 
-/// @nodoc
 
-class _$RpcImpl extends _Rpc {
-  const _$RpcImpl({required this.payload}) : super._();
-
-  @override
-  final String payload;
-
-  @override
-  String toString() {
-    return 'Rpc(payload: $payload)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$RpcImpl &&
-            (identical(other.payload, payload) || other.payload == payload));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, payload);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$RpcImplCopyWith<_$RpcImpl> get copyWith =>
-      __$$RpcImplCopyWithImpl<_$RpcImpl>(this, _$identity);
 }
 
-abstract class _Rpc extends Rpc {
-  const factory _Rpc({required final String payload}) = _$RpcImpl;
-  const _Rpc._() : super._();
-
-  @override
-  String get payload;
-  @override
-  @JsonKey(ignore: true)
-  _$$RpcImplCopyWith<_$RpcImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/nakama/lib/src/models/session.dart
+++ b/nakama/lib/src/models/session.dart
@@ -6,7 +6,7 @@ import 'package:nakama/src/rest/api_client.gen.dart';
 part 'session.freezed.dart';
 
 @freezed
-class Session with _$Session {
+sealed class Session with _$Session {
   const Session._();
 
   factory Session({

--- a/nakama/lib/src/models/session.freezed.dart
+++ b/nakama/lib/src/models/session.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,267 +9,283 @@ part of 'session.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
 /// @nodoc
 mixin _$Session {
-  String get token => throw _privateConstructorUsedError;
-  String? get refreshToken => throw _privateConstructorUsedError;
-  bool get created => throw _privateConstructorUsedError;
-  Map<String, String>? get vars => throw _privateConstructorUsedError;
-  String get userId => throw _privateConstructorUsedError;
-  DateTime get expiresAt => throw _privateConstructorUsedError;
-  DateTime get refreshExpiresAt => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $SessionCopyWith<Session> get copyWith => throw _privateConstructorUsedError;
+ String get token; String? get refreshToken; bool get created; Map<String, String>? get vars; String get userId; DateTime get expiresAt; DateTime get refreshExpiresAt;
+/// Create a copy of Session
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SessionCopyWith<Session> get copyWith => _$SessionCopyWithImpl<Session>(this as Session, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Session&&(identical(other.token, token) || other.token == token)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken)&&(identical(other.created, created) || other.created == created)&&const DeepCollectionEquality().equals(other.vars, vars)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.refreshExpiresAt, refreshExpiresAt) || other.refreshExpiresAt == refreshExpiresAt));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,token,refreshToken,created,const DeepCollectionEquality().hash(vars),userId,expiresAt,refreshExpiresAt);
+
+@override
+String toString() {
+  return 'Session(token: $token, refreshToken: $refreshToken, created: $created, vars: $vars, userId: $userId, expiresAt: $expiresAt, refreshExpiresAt: $refreshExpiresAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $SessionCopyWith<$Res> {
-  factory $SessionCopyWith(Session value, $Res Function(Session) then) =
-      _$SessionCopyWithImpl<$Res, Session>;
-  @useResult
-  $Res call(
-      {String token,
-      String? refreshToken,
-      bool created,
-      Map<String, String>? vars,
-      String userId,
-      DateTime expiresAt,
-      DateTime refreshExpiresAt});
-}
+abstract mixin class $SessionCopyWith<$Res>  {
+  factory $SessionCopyWith(Session value, $Res Function(Session) _then) = _$SessionCopyWithImpl;
+@useResult
+$Res call({
+ String token, String? refreshToken, bool created, Map<String, String>? vars, String userId, DateTime expiresAt, DateTime refreshExpiresAt
+});
 
+
+
+
+}
 /// @nodoc
-class _$SessionCopyWithImpl<$Res, $Val extends Session>
+class _$SessionCopyWithImpl<$Res>
     implements $SessionCopyWith<$Res> {
-  _$SessionCopyWithImpl(this._value, this._then);
+  _$SessionCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Session _self;
+  final $Res Function(Session) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? token = null,
-    Object? refreshToken = freezed,
-    Object? created = null,
-    Object? vars = freezed,
-    Object? userId = null,
-    Object? expiresAt = null,
-    Object? refreshExpiresAt = null,
-  }) {
-    return _then(_value.copyWith(
-      token: null == token
-          ? _value.token
-          : token // ignore: cast_nullable_to_non_nullable
-              as String,
-      refreshToken: freezed == refreshToken
-          ? _value.refreshToken
-          : refreshToken // ignore: cast_nullable_to_non_nullable
-              as String?,
-      created: null == created
-          ? _value.created
-          : created // ignore: cast_nullable_to_non_nullable
-              as bool,
-      vars: freezed == vars
-          ? _value.vars
-          : vars // ignore: cast_nullable_to_non_nullable
-              as Map<String, String>?,
-      userId: null == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      expiresAt: null == expiresAt
-          ? _value.expiresAt
-          : expiresAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      refreshExpiresAt: null == refreshExpiresAt
-          ? _value.refreshExpiresAt
-          : refreshExpiresAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ) as $Val);
-  }
+/// Create a copy of Session
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? token = null,Object? refreshToken = freezed,Object? created = null,Object? vars = freezed,Object? userId = null,Object? expiresAt = null,Object? refreshExpiresAt = null,}) {
+  return _then(_self.copyWith(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,refreshToken: freezed == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String?,created: null == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
+as bool,vars: freezed == vars ? _self.vars : vars // ignore: cast_nullable_to_non_nullable
+as Map<String, String>?,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,expiresAt: null == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,refreshExpiresAt: null == refreshExpiresAt ? _self.refreshExpiresAt : refreshExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Session].
+extension SessionPatterns on Session {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Session value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Session() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Session value)  $default,){
+final _that = this;
+switch (_that) {
+case _Session():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Session value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Session() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String token,  String? refreshToken,  bool created,  Map<String, String>? vars,  String userId,  DateTime expiresAt,  DateTime refreshExpiresAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Session() when $default != null:
+return $default(_that.token,_that.refreshToken,_that.created,_that.vars,_that.userId,_that.expiresAt,_that.refreshExpiresAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String token,  String? refreshToken,  bool created,  Map<String, String>? vars,  String userId,  DateTime expiresAt,  DateTime refreshExpiresAt)  $default,) {final _that = this;
+switch (_that) {
+case _Session():
+return $default(_that.token,_that.refreshToken,_that.created,_that.vars,_that.userId,_that.expiresAt,_that.refreshExpiresAt);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String token,  String? refreshToken,  bool created,  Map<String, String>? vars,  String userId,  DateTime expiresAt,  DateTime refreshExpiresAt)?  $default,) {final _that = this;
+switch (_that) {
+case _Session() when $default != null:
+return $default(_that.token,_that.refreshToken,_that.created,_that.vars,_that.userId,_that.expiresAt,_that.refreshExpiresAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$SessionImplCopyWith<$Res> implements $SessionCopyWith<$Res> {
-  factory _$$SessionImplCopyWith(
-          _$SessionImpl value, $Res Function(_$SessionImpl) then) =
-      __$$SessionImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String token,
-      String? refreshToken,
-      bool created,
-      Map<String, String>? vars,
-      String userId,
-      DateTime expiresAt,
-      DateTime refreshExpiresAt});
+
+
+class _Session extends Session {
+   _Session({required this.token, required this.refreshToken, required this.created, required final  Map<String, String>? vars, required this.userId, required this.expiresAt, required this.refreshExpiresAt}): _vars = vars,super._();
+  
+
+@override final  String token;
+@override final  String? refreshToken;
+@override final  bool created;
+ final  Map<String, String>? _vars;
+@override Map<String, String>? get vars {
+  final value = _vars;
+  if (value == null) return null;
+  if (_vars is EqualUnmodifiableMapView) return _vars;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+@override final  String userId;
+@override final  DateTime expiresAt;
+@override final  DateTime refreshExpiresAt;
+
+/// Create a copy of Session
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SessionCopyWith<_Session> get copyWith => __$SessionCopyWithImpl<_Session>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Session&&(identical(other.token, token) || other.token == token)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken)&&(identical(other.created, created) || other.created == created)&&const DeepCollectionEquality().equals(other._vars, _vars)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.refreshExpiresAt, refreshExpiresAt) || other.refreshExpiresAt == refreshExpiresAt));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,token,refreshToken,created,const DeepCollectionEquality().hash(_vars),userId,expiresAt,refreshExpiresAt);
+
+@override
+String toString() {
+  return 'Session(token: $token, refreshToken: $refreshToken, created: $created, vars: $vars, userId: $userId, expiresAt: $expiresAt, refreshExpiresAt: $refreshExpiresAt)';
+}
+
+
 }
 
 /// @nodoc
-class __$$SessionImplCopyWithImpl<$Res>
-    extends _$SessionCopyWithImpl<$Res, _$SessionImpl>
-    implements _$$SessionImplCopyWith<$Res> {
-  __$$SessionImplCopyWithImpl(
-      _$SessionImpl _value, $Res Function(_$SessionImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$SessionCopyWith<$Res> implements $SessionCopyWith<$Res> {
+  factory _$SessionCopyWith(_Session value, $Res Function(_Session) _then) = __$SessionCopyWithImpl;
+@override @useResult
+$Res call({
+ String token, String? refreshToken, bool created, Map<String, String>? vars, String userId, DateTime expiresAt, DateTime refreshExpiresAt
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? token = null,
-    Object? refreshToken = freezed,
-    Object? created = null,
-    Object? vars = freezed,
-    Object? userId = null,
-    Object? expiresAt = null,
-    Object? refreshExpiresAt = null,
-  }) {
-    return _then(_$SessionImpl(
-      token: null == token
-          ? _value.token
-          : token // ignore: cast_nullable_to_non_nullable
-              as String,
-      refreshToken: freezed == refreshToken
-          ? _value.refreshToken
-          : refreshToken // ignore: cast_nullable_to_non_nullable
-              as String?,
-      created: null == created
-          ? _value.created
-          : created // ignore: cast_nullable_to_non_nullable
-              as bool,
-      vars: freezed == vars
-          ? _value._vars
-          : vars // ignore: cast_nullable_to_non_nullable
-              as Map<String, String>?,
-      userId: null == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      expiresAt: null == expiresAt
-          ? _value.expiresAt
-          : expiresAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      refreshExpiresAt: null == refreshExpiresAt
-          ? _value.refreshExpiresAt
-          : refreshExpiresAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ));
-  }
+
+
+
 }
-
 /// @nodoc
+class __$SessionCopyWithImpl<$Res>
+    implements _$SessionCopyWith<$Res> {
+  __$SessionCopyWithImpl(this._self, this._then);
 
-class _$SessionImpl extends _Session {
-  _$SessionImpl(
-      {required this.token,
-      required this.refreshToken,
-      required this.created,
-      required final Map<String, String>? vars,
-      required this.userId,
-      required this.expiresAt,
-      required this.refreshExpiresAt})
-      : _vars = vars,
-        super._();
+  final _Session _self;
+  final $Res Function(_Session) _then;
 
-  @override
-  final String token;
-  @override
-  final String? refreshToken;
-  @override
-  final bool created;
-  final Map<String, String>? _vars;
-  @override
-  Map<String, String>? get vars {
-    final value = _vars;
-    if (value == null) return null;
-    if (_vars is EqualUnmodifiableMapView) return _vars;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
-
-  @override
-  final String userId;
-  @override
-  final DateTime expiresAt;
-  @override
-  final DateTime refreshExpiresAt;
-
-  @override
-  String toString() {
-    return 'Session(token: $token, refreshToken: $refreshToken, created: $created, vars: $vars, userId: $userId, expiresAt: $expiresAt, refreshExpiresAt: $refreshExpiresAt)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$SessionImpl &&
-            (identical(other.token, token) || other.token == token) &&
-            (identical(other.refreshToken, refreshToken) ||
-                other.refreshToken == refreshToken) &&
-            (identical(other.created, created) || other.created == created) &&
-            const DeepCollectionEquality().equals(other._vars, _vars) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.expiresAt, expiresAt) ||
-                other.expiresAt == expiresAt) &&
-            (identical(other.refreshExpiresAt, refreshExpiresAt) ||
-                other.refreshExpiresAt == refreshExpiresAt));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      token,
-      refreshToken,
-      created,
-      const DeepCollectionEquality().hash(_vars),
-      userId,
-      expiresAt,
-      refreshExpiresAt);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$SessionImplCopyWith<_$SessionImpl> get copyWith =>
-      __$$SessionImplCopyWithImpl<_$SessionImpl>(this, _$identity);
+/// Create a copy of Session
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? token = null,Object? refreshToken = freezed,Object? created = null,Object? vars = freezed,Object? userId = null,Object? expiresAt = null,Object? refreshExpiresAt = null,}) {
+  return _then(_Session(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,refreshToken: freezed == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String?,created: null == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
+as bool,vars: freezed == vars ? _self._vars : vars // ignore: cast_nullable_to_non_nullable
+as Map<String, String>?,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,expiresAt: null == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,refreshExpiresAt: null == refreshExpiresAt ? _self.refreshExpiresAt : refreshExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
 }
 
-abstract class _Session extends Session {
-  factory _Session(
-      {required final String token,
-      required final String? refreshToken,
-      required final bool created,
-      required final Map<String, String>? vars,
-      required final String userId,
-      required final DateTime expiresAt,
-      required final DateTime refreshExpiresAt}) = _$SessionImpl;
-  _Session._() : super._();
 
-  @override
-  String get token;
-  @override
-  String? get refreshToken;
-  @override
-  bool get created;
-  @override
-  Map<String, String>? get vars;
-  @override
-  String get userId;
-  @override
-  DateTime get expiresAt;
-  @override
-  DateTime get refreshExpiresAt;
-  @override
-  @JsonKey(ignore: true)
-  _$$SessionImplCopyWith<_$SessionImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
+
+// dart format on

--- a/nakama/lib/src/models/status.dart
+++ b/nakama/lib/src/models/status.dart
@@ -5,7 +5,7 @@ part 'status.freezed.dart';
 part 'status.g.dart';
 
 @freezed
-class UserPresence with _$UserPresence {
+sealed class UserPresence with _$UserPresence {
   const UserPresence._();
 
   const factory UserPresence({
@@ -39,7 +39,7 @@ class UserPresence with _$UserPresence {
 }
 
 @freezed
-class StatusPresenceEvent with _$StatusPresenceEvent {
+sealed class StatusPresenceEvent with _$StatusPresenceEvent {
   const StatusPresenceEvent._();
 
   const factory StatusPresenceEvent({
@@ -57,7 +57,7 @@ class StatusPresenceEvent with _$StatusPresenceEvent {
 }
 
 @freezed
-class RealtimeStream with _$RealtimeStream {
+sealed class RealtimeStream with _$RealtimeStream {
   const RealtimeStream._();
 
   const factory RealtimeStream({
@@ -83,7 +83,7 @@ class RealtimeStream with _$RealtimeStream {
 }
 
 @freezed
-class RealtimeStreamData with _$RealtimeStreamData {
+sealed class RealtimeStreamData with _$RealtimeStreamData {
   const RealtimeStreamData._();
 
   const factory RealtimeStreamData({
@@ -109,7 +109,7 @@ class RealtimeStreamData with _$RealtimeStreamData {
 }
 
 @freezed
-class StreamPresenceEvent with _$StreamPresenceEvent {
+sealed class StreamPresenceEvent with _$StreamPresenceEvent {
   const StreamPresenceEvent._();
 
   const factory StreamPresenceEvent({

--- a/nakama/lib/src/models/status.freezed.dart
+++ b/nakama/lib/src/models/status.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,1089 +9,1428 @@ part of 'status.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-UserPresence _$UserPresenceFromJson(Map<String, dynamic> json) {
-  return _UserPresence.fromJson(json);
-}
 
 /// @nodoc
 mixin _$UserPresence {
-  /// The user this presence belongs to.
-  @JsonKey(name: 'user_id')
-  String get userId => throw _privateConstructorUsedError;
 
-  /// A unique session ID identifying the particular connection, because the
-  /// user may have many.
-  @JsonKey(name: 'session_id')
-  String get sessionId => throw _privateConstructorUsedError;
+/// The user this presence belongs to.
+@JsonKey(name: 'user_id') String get userId;/// A unique session ID identifying the particular connection, because the
+/// user may have many.
+@JsonKey(name: 'session_id') String get sessionId;/// The username for display purposes.
+@JsonKey(name: 'username') String get username;/// Whether this presence generates persistent data/messages, if applicable
+/// for the stream type.
+@JsonKey(name: 'persistence') bool get persistence;/// A user-set status message for this stream, if applicable.
+@JsonKey(name: 'status') String? get status;
+/// Create a copy of UserPresence
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<UserPresence> get copyWith => _$UserPresenceCopyWithImpl<UserPresence>(this as UserPresence, _$identity);
 
-  /// The username for display purposes.
-  @JsonKey(name: 'username')
-  String get username => throw _privateConstructorUsedError;
+  /// Serializes this UserPresence to a JSON map.
+  Map<String, dynamic> toJson();
 
-  /// Whether this presence generates persistent data/messages, if applicable
-  /// for the stream type.
-  @JsonKey(name: 'persistence')
-  bool get persistence => throw _privateConstructorUsedError;
 
-  /// A user-set status message for this stream, if applicable.
-  @JsonKey(name: 'status')
-  String? get status => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserPresence&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.username, username) || other.username == username)&&(identical(other.persistence, persistence) || other.persistence == persistence)&&(identical(other.status, status) || other.status == status));
+}
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $UserPresenceCopyWith<UserPresence> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,userId,sessionId,username,persistence,status);
+
+@override
+String toString() {
+  return 'UserPresence(userId: $userId, sessionId: $sessionId, username: $username, persistence: $persistence, status: $status)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $UserPresenceCopyWith<$Res> {
-  factory $UserPresenceCopyWith(
-          UserPresence value, $Res Function(UserPresence) then) =
-      _$UserPresenceCopyWithImpl<$Res, UserPresence>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'session_id') String sessionId,
-      @JsonKey(name: 'username') String username,
-      @JsonKey(name: 'persistence') bool persistence,
-      @JsonKey(name: 'status') String? status});
-}
+abstract mixin class $UserPresenceCopyWith<$Res>  {
+  factory $UserPresenceCopyWith(UserPresence value, $Res Function(UserPresence) _then) = _$UserPresenceCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'session_id') String sessionId,@JsonKey(name: 'username') String username,@JsonKey(name: 'persistence') bool persistence,@JsonKey(name: 'status') String? status
+});
 
+
+
+
+}
 /// @nodoc
-class _$UserPresenceCopyWithImpl<$Res, $Val extends UserPresence>
+class _$UserPresenceCopyWithImpl<$Res>
     implements $UserPresenceCopyWith<$Res> {
-  _$UserPresenceCopyWithImpl(this._value, this._then);
+  _$UserPresenceCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final UserPresence _self;
+  final $Res Function(UserPresence) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? userId = null,
-    Object? sessionId = null,
-    Object? username = null,
-    Object? persistence = null,
-    Object? status = freezed,
-  }) {
-    return _then(_value.copyWith(
-      userId: null == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      sessionId: null == sessionId
-          ? _value.sessionId
-          : sessionId // ignore: cast_nullable_to_non_nullable
-              as String,
-      username: null == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String,
-      persistence: null == persistence
-          ? _value.persistence
-          : persistence // ignore: cast_nullable_to_non_nullable
-              as bool,
-      status: freezed == status
-          ? _value.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of UserPresence
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? userId = null,Object? sessionId = null,Object? username = null,Object? persistence = null,Object? status = freezed,}) {
+  return _then(_self.copyWith(
+userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,persistence: null == persistence ? _self.persistence : persistence // ignore: cast_nullable_to_non_nullable
+as bool,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$UserPresenceImplCopyWith<$Res>
-    implements $UserPresenceCopyWith<$Res> {
-  factory _$$UserPresenceImplCopyWith(
-          _$UserPresenceImpl value, $Res Function(_$UserPresenceImpl) then) =
-      __$$UserPresenceImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'session_id') String sessionId,
-      @JsonKey(name: 'username') String username,
-      @JsonKey(name: 'persistence') bool persistence,
-      @JsonKey(name: 'status') String? status});
 }
 
-/// @nodoc
-class __$$UserPresenceImplCopyWithImpl<$Res>
-    extends _$UserPresenceCopyWithImpl<$Res, _$UserPresenceImpl>
-    implements _$$UserPresenceImplCopyWith<$Res> {
-  __$$UserPresenceImplCopyWithImpl(
-      _$UserPresenceImpl _value, $Res Function(_$UserPresenceImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? userId = null,
-    Object? sessionId = null,
-    Object? username = null,
-    Object? persistence = null,
-    Object? status = freezed,
-  }) {
-    return _then(_$UserPresenceImpl(
-      userId: null == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      sessionId: null == sessionId
-          ? _value.sessionId
-          : sessionId // ignore: cast_nullable_to_non_nullable
-              as String,
-      username: null == username
-          ? _value.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String,
-      persistence: null == persistence
-          ? _value.persistence
-          : persistence // ignore: cast_nullable_to_non_nullable
-              as bool,
-      status: freezed == status
-          ? _value.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [UserPresence].
+extension UserPresencePatterns on UserPresence {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserPresence value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserPresence() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserPresence value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserPresence():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserPresence value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserPresence() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'session_id')  String sessionId, @JsonKey(name: 'username')  String username, @JsonKey(name: 'persistence')  bool persistence, @JsonKey(name: 'status')  String? status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserPresence() when $default != null:
+return $default(_that.userId,_that.sessionId,_that.username,_that.persistence,_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'session_id')  String sessionId, @JsonKey(name: 'username')  String username, @JsonKey(name: 'persistence')  bool persistence, @JsonKey(name: 'status')  String? status)  $default,) {final _that = this;
+switch (_that) {
+case _UserPresence():
+return $default(_that.userId,_that.sessionId,_that.username,_that.persistence,_that.status);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'session_id')  String sessionId, @JsonKey(name: 'username')  String username, @JsonKey(name: 'persistence')  bool persistence, @JsonKey(name: 'status')  String? status)?  $default,) {final _that = this;
+switch (_that) {
+case _UserPresence() when $default != null:
+return $default(_that.userId,_that.sessionId,_that.username,_that.persistence,_that.status);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$UserPresenceImpl extends _UserPresence {
-  const _$UserPresenceImpl(
-      {@JsonKey(name: 'user_id') required this.userId,
-      @JsonKey(name: 'session_id') required this.sessionId,
-      @JsonKey(name: 'username') required this.username,
-      @JsonKey(name: 'persistence') required this.persistence,
-      @JsonKey(name: 'status') this.status})
-      : super._();
 
-  factory _$UserPresenceImpl.fromJson(Map<String, dynamic> json) =>
-      _$$UserPresenceImplFromJson(json);
+class _UserPresence extends UserPresence {
+  const _UserPresence({@JsonKey(name: 'user_id') required this.userId, @JsonKey(name: 'session_id') required this.sessionId, @JsonKey(name: 'username') required this.username, @JsonKey(name: 'persistence') required this.persistence, @JsonKey(name: 'status') this.status}): super._();
+  factory _UserPresence.fromJson(Map<String, dynamic> json) => _$UserPresenceFromJson(json);
 
-  /// The user this presence belongs to.
-  @override
-  @JsonKey(name: 'user_id')
-  final String userId;
+/// The user this presence belongs to.
+@override@JsonKey(name: 'user_id') final  String userId;
+/// A unique session ID identifying the particular connection, because the
+/// user may have many.
+@override@JsonKey(name: 'session_id') final  String sessionId;
+/// The username for display purposes.
+@override@JsonKey(name: 'username') final  String username;
+/// Whether this presence generates persistent data/messages, if applicable
+/// for the stream type.
+@override@JsonKey(name: 'persistence') final  bool persistence;
+/// A user-set status message for this stream, if applicable.
+@override@JsonKey(name: 'status') final  String? status;
 
-  /// A unique session ID identifying the particular connection, because the
-  /// user may have many.
-  @override
-  @JsonKey(name: 'session_id')
-  final String sessionId;
+/// Create a copy of UserPresence
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserPresenceCopyWith<_UserPresence> get copyWith => __$UserPresenceCopyWithImpl<_UserPresence>(this, _$identity);
 
-  /// The username for display purposes.
-  @override
-  @JsonKey(name: 'username')
-  final String username;
-
-  /// Whether this presence generates persistent data/messages, if applicable
-  /// for the stream type.
-  @override
-  @JsonKey(name: 'persistence')
-  final bool persistence;
-
-  /// A user-set status message for this stream, if applicable.
-  @override
-  @JsonKey(name: 'status')
-  final String? status;
-
-  @override
-  String toString() {
-    return 'UserPresence(userId: $userId, sessionId: $sessionId, username: $username, persistence: $persistence, status: $status)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$UserPresenceImpl &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.sessionId, sessionId) ||
-                other.sessionId == sessionId) &&
-            (identical(other.username, username) ||
-                other.username == username) &&
-            (identical(other.persistence, persistence) ||
-                other.persistence == persistence) &&
-            (identical(other.status, status) || other.status == status));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, userId, sessionId, username, persistence, status);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$UserPresenceImplCopyWith<_$UserPresenceImpl> get copyWith =>
-      __$$UserPresenceImplCopyWithImpl<_$UserPresenceImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$UserPresenceImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$UserPresenceToJson(this, );
 }
 
-abstract class _UserPresence extends UserPresence {
-  const factory _UserPresence(
-      {@JsonKey(name: 'user_id') required final String userId,
-      @JsonKey(name: 'session_id') required final String sessionId,
-      @JsonKey(name: 'username') required final String username,
-      @JsonKey(name: 'persistence') required final bool persistence,
-      @JsonKey(name: 'status') final String? status}) = _$UserPresenceImpl;
-  const _UserPresence._() : super._();
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserPresence&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.username, username) || other.username == username)&&(identical(other.persistence, persistence) || other.persistence == persistence)&&(identical(other.status, status) || other.status == status));
+}
 
-  factory _UserPresence.fromJson(Map<String, dynamic> json) =
-      _$UserPresenceImpl.fromJson;
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,userId,sessionId,username,persistence,status);
 
-  @override
+@override
+String toString() {
+  return 'UserPresence(userId: $userId, sessionId: $sessionId, username: $username, persistence: $persistence, status: $status)';
+}
 
-  /// The user this presence belongs to.
-  @JsonKey(name: 'user_id')
-  String get userId;
-  @override
 
-  /// A unique session ID identifying the particular connection, because the
-  /// user may have many.
-  @JsonKey(name: 'session_id')
-  String get sessionId;
-  @override
+}
 
-  /// The username for display purposes.
-  @JsonKey(name: 'username')
-  String get username;
-  @override
+/// @nodoc
+abstract mixin class _$UserPresenceCopyWith<$Res> implements $UserPresenceCopyWith<$Res> {
+  factory _$UserPresenceCopyWith(_UserPresence value, $Res Function(_UserPresence) _then) = __$UserPresenceCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'session_id') String sessionId,@JsonKey(name: 'username') String username,@JsonKey(name: 'persistence') bool persistence,@JsonKey(name: 'status') String? status
+});
 
-  /// Whether this presence generates persistent data/messages, if applicable
-  /// for the stream type.
-  @JsonKey(name: 'persistence')
-  bool get persistence;
-  @override
 
-  /// A user-set status message for this stream, if applicable.
-  @JsonKey(name: 'status')
-  String? get status;
-  @override
-  @JsonKey(ignore: true)
-  _$$UserPresenceImplCopyWith<_$UserPresenceImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+
+
+}
+/// @nodoc
+class __$UserPresenceCopyWithImpl<$Res>
+    implements _$UserPresenceCopyWith<$Res> {
+  __$UserPresenceCopyWithImpl(this._self, this._then);
+
+  final _UserPresence _self;
+  final $Res Function(_UserPresence) _then;
+
+/// Create a copy of UserPresence
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? userId = null,Object? sessionId = null,Object? username = null,Object? persistence = null,Object? status = freezed,}) {
+  return _then(_UserPresence(
+userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,persistence: null == persistence ? _self.persistence : persistence // ignore: cast_nullable_to_non_nullable
+as bool,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 /// @nodoc
 mixin _$StatusPresenceEvent {
-  /// New statuses for the user.
-  List<UserPresence> get joins => throw _privateConstructorUsedError;
 
-  /// Previous statuses for the user.
-  List<UserPresence> get leaves => throw _privateConstructorUsedError;
+/// New statuses for the user.
+ List<UserPresence> get joins;/// Previous statuses for the user.
+ List<UserPresence> get leaves;
+/// Create a copy of StatusPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StatusPresenceEventCopyWith<StatusPresenceEvent> get copyWith => _$StatusPresenceEventCopyWithImpl<StatusPresenceEvent>(this as StatusPresenceEvent, _$identity);
 
-  @JsonKey(ignore: true)
-  $StatusPresenceEventCopyWith<StatusPresenceEvent> get copyWith =>
-      throw _privateConstructorUsedError;
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StatusPresenceEvent&&const DeepCollectionEquality().equals(other.joins, joins)&&const DeepCollectionEquality().equals(other.leaves, leaves));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(joins),const DeepCollectionEquality().hash(leaves));
+
+@override
+String toString() {
+  return 'StatusPresenceEvent(joins: $joins, leaves: $leaves)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $StatusPresenceEventCopyWith<$Res> {
-  factory $StatusPresenceEventCopyWith(
-          StatusPresenceEvent value, $Res Function(StatusPresenceEvent) then) =
-      _$StatusPresenceEventCopyWithImpl<$Res, StatusPresenceEvent>;
-  @useResult
-  $Res call({List<UserPresence> joins, List<UserPresence> leaves});
-}
+abstract mixin class $StatusPresenceEventCopyWith<$Res>  {
+  factory $StatusPresenceEventCopyWith(StatusPresenceEvent value, $Res Function(StatusPresenceEvent) _then) = _$StatusPresenceEventCopyWithImpl;
+@useResult
+$Res call({
+ List<UserPresence> joins, List<UserPresence> leaves
+});
 
+
+
+
+}
 /// @nodoc
-class _$StatusPresenceEventCopyWithImpl<$Res, $Val extends StatusPresenceEvent>
+class _$StatusPresenceEventCopyWithImpl<$Res>
     implements $StatusPresenceEventCopyWith<$Res> {
-  _$StatusPresenceEventCopyWithImpl(this._value, this._then);
+  _$StatusPresenceEventCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final StatusPresenceEvent _self;
+  final $Res Function(StatusPresenceEvent) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? joins = null,
-    Object? leaves = null,
-  }) {
-    return _then(_value.copyWith(
-      joins: null == joins
-          ? _value.joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-      leaves: null == leaves
-          ? _value.leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ) as $Val);
-  }
+/// Create a copy of StatusPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? joins = null,Object? leaves = null,}) {
+  return _then(_self.copyWith(
+joins: null == joins ? _self.joins : joins // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,leaves: null == leaves ? _self.leaves : leaves // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [StatusPresenceEvent].
+extension StatusPresenceEventPatterns on StatusPresenceEvent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _StatusPresenceEvent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _StatusPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _StatusPresenceEvent value)  $default,){
+final _that = this;
+switch (_that) {
+case _StatusPresenceEvent():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _StatusPresenceEvent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _StatusPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<UserPresence> joins,  List<UserPresence> leaves)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _StatusPresenceEvent() when $default != null:
+return $default(_that.joins,_that.leaves);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<UserPresence> joins,  List<UserPresence> leaves)  $default,) {final _that = this;
+switch (_that) {
+case _StatusPresenceEvent():
+return $default(_that.joins,_that.leaves);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<UserPresence> joins,  List<UserPresence> leaves)?  $default,) {final _that = this;
+switch (_that) {
+case _StatusPresenceEvent() when $default != null:
+return $default(_that.joins,_that.leaves);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$StatusPresenceEventImplCopyWith<$Res>
-    implements $StatusPresenceEventCopyWith<$Res> {
-  factory _$$StatusPresenceEventImplCopyWith(_$StatusPresenceEventImpl value,
-          $Res Function(_$StatusPresenceEventImpl) then) =
-      __$$StatusPresenceEventImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({List<UserPresence> joins, List<UserPresence> leaves});
+
+
+class _StatusPresenceEvent extends StatusPresenceEvent {
+  const _StatusPresenceEvent({required final  List<UserPresence> joins, required final  List<UserPresence> leaves}): _joins = joins,_leaves = leaves,super._();
+  
+
+/// New statuses for the user.
+ final  List<UserPresence> _joins;
+/// New statuses for the user.
+@override List<UserPresence> get joins {
+  if (_joins is EqualUnmodifiableListView) return _joins;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_joins);
+}
+
+/// Previous statuses for the user.
+ final  List<UserPresence> _leaves;
+/// Previous statuses for the user.
+@override List<UserPresence> get leaves {
+  if (_leaves is EqualUnmodifiableListView) return _leaves;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_leaves);
+}
+
+
+/// Create a copy of StatusPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$StatusPresenceEventCopyWith<_StatusPresenceEvent> get copyWith => __$StatusPresenceEventCopyWithImpl<_StatusPresenceEvent>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StatusPresenceEvent&&const DeepCollectionEquality().equals(other._joins, _joins)&&const DeepCollectionEquality().equals(other._leaves, _leaves));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_joins),const DeepCollectionEquality().hash(_leaves));
+
+@override
+String toString() {
+  return 'StatusPresenceEvent(joins: $joins, leaves: $leaves)';
+}
+
+
 }
 
 /// @nodoc
-class __$$StatusPresenceEventImplCopyWithImpl<$Res>
-    extends _$StatusPresenceEventCopyWithImpl<$Res, _$StatusPresenceEventImpl>
-    implements _$$StatusPresenceEventImplCopyWith<$Res> {
-  __$$StatusPresenceEventImplCopyWithImpl(_$StatusPresenceEventImpl _value,
-      $Res Function(_$StatusPresenceEventImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$StatusPresenceEventCopyWith<$Res> implements $StatusPresenceEventCopyWith<$Res> {
+  factory _$StatusPresenceEventCopyWith(_StatusPresenceEvent value, $Res Function(_StatusPresenceEvent) _then) = __$StatusPresenceEventCopyWithImpl;
+@override @useResult
+$Res call({
+ List<UserPresence> joins, List<UserPresence> leaves
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? joins = null,
-    Object? leaves = null,
-  }) {
-    return _then(_$StatusPresenceEventImpl(
-      joins: null == joins
-          ? _value._joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-      leaves: null == leaves
-          ? _value._leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ));
-  }
+
+
+
 }
-
 /// @nodoc
+class __$StatusPresenceEventCopyWithImpl<$Res>
+    implements _$StatusPresenceEventCopyWith<$Res> {
+  __$StatusPresenceEventCopyWithImpl(this._self, this._then);
 
-class _$StatusPresenceEventImpl extends _StatusPresenceEvent {
-  const _$StatusPresenceEventImpl(
-      {required final List<UserPresence> joins,
-      required final List<UserPresence> leaves})
-      : _joins = joins,
-        _leaves = leaves,
-        super._();
+  final _StatusPresenceEvent _self;
+  final $Res Function(_StatusPresenceEvent) _then;
 
-  /// New statuses for the user.
-  final List<UserPresence> _joins;
-
-  /// New statuses for the user.
-  @override
-  List<UserPresence> get joins {
-    if (_joins is EqualUnmodifiableListView) return _joins;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_joins);
-  }
-
-  /// Previous statuses for the user.
-  final List<UserPresence> _leaves;
-
-  /// Previous statuses for the user.
-  @override
-  List<UserPresence> get leaves {
-    if (_leaves is EqualUnmodifiableListView) return _leaves;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_leaves);
-  }
-
-  @override
-  String toString() {
-    return 'StatusPresenceEvent(joins: $joins, leaves: $leaves)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$StatusPresenceEventImpl &&
-            const DeepCollectionEquality().equals(other._joins, _joins) &&
-            const DeepCollectionEquality().equals(other._leaves, _leaves));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(_joins),
-      const DeepCollectionEquality().hash(_leaves));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$StatusPresenceEventImplCopyWith<_$StatusPresenceEventImpl> get copyWith =>
-      __$$StatusPresenceEventImplCopyWithImpl<_$StatusPresenceEventImpl>(
-          this, _$identity);
+/// Create a copy of StatusPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? joins = null,Object? leaves = null,}) {
+  return _then(_StatusPresenceEvent(
+joins: null == joins ? _self._joins : joins // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,leaves: null == leaves ? _self._leaves : leaves // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
 }
 
-abstract class _StatusPresenceEvent extends StatusPresenceEvent {
-  const factory _StatusPresenceEvent(
-      {required final List<UserPresence> joins,
-      required final List<UserPresence> leaves}) = _$StatusPresenceEventImpl;
-  const _StatusPresenceEvent._() : super._();
 
-  @override
-
-  /// New statuses for the user.
-  List<UserPresence> get joins;
-  @override
-
-  /// Previous statuses for the user.
-  List<UserPresence> get leaves;
-  @override
-  @JsonKey(ignore: true)
-  _$$StatusPresenceEventImplCopyWith<_$StatusPresenceEventImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 mixin _$RealtimeStream {
-  /// Mode identifies the type of stream.
-  int get mode => throw _privateConstructorUsedError;
 
-  /// Subject is the primary identifier, if any.
-  String get subject => throw _privateConstructorUsedError;
+/// Mode identifies the type of stream.
+ int get mode;/// Subject is the primary identifier, if any.
+ String get subject;/// Subcontext is a secondary identifier, if any.
+ String get subcontext;/// The label is an arbitrary identifying string, if the stream has one.
+ String get label;
+/// Create a copy of RealtimeStream
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RealtimeStreamCopyWith<RealtimeStream> get copyWith => _$RealtimeStreamCopyWithImpl<RealtimeStream>(this as RealtimeStream, _$identity);
 
-  /// Subcontext is a secondary identifier, if any.
-  String get subcontext => throw _privateConstructorUsedError;
 
-  /// The label is an arbitrary identifying string, if the stream has one.
-  String get label => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $RealtimeStreamCopyWith<RealtimeStream> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RealtimeStream&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.subject, subject) || other.subject == subject)&&(identical(other.subcontext, subcontext) || other.subcontext == subcontext)&&(identical(other.label, label) || other.label == label));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,mode,subject,subcontext,label);
+
+@override
+String toString() {
+  return 'RealtimeStream(mode: $mode, subject: $subject, subcontext: $subcontext, label: $label)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $RealtimeStreamCopyWith<$Res> {
-  factory $RealtimeStreamCopyWith(
-          RealtimeStream value, $Res Function(RealtimeStream) then) =
-      _$RealtimeStreamCopyWithImpl<$Res, RealtimeStream>;
-  @useResult
-  $Res call({int mode, String subject, String subcontext, String label});
-}
+abstract mixin class $RealtimeStreamCopyWith<$Res>  {
+  factory $RealtimeStreamCopyWith(RealtimeStream value, $Res Function(RealtimeStream) _then) = _$RealtimeStreamCopyWithImpl;
+@useResult
+$Res call({
+ int mode, String subject, String subcontext, String label
+});
 
+
+
+
+}
 /// @nodoc
-class _$RealtimeStreamCopyWithImpl<$Res, $Val extends RealtimeStream>
+class _$RealtimeStreamCopyWithImpl<$Res>
     implements $RealtimeStreamCopyWith<$Res> {
-  _$RealtimeStreamCopyWithImpl(this._value, this._then);
+  _$RealtimeStreamCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final RealtimeStream _self;
+  final $Res Function(RealtimeStream) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? mode = null,
-    Object? subject = null,
-    Object? subcontext = null,
-    Object? label = null,
-  }) {
-    return _then(_value.copyWith(
-      mode: null == mode
-          ? _value.mode
-          : mode // ignore: cast_nullable_to_non_nullable
-              as int,
-      subject: null == subject
-          ? _value.subject
-          : subject // ignore: cast_nullable_to_non_nullable
-              as String,
-      subcontext: null == subcontext
-          ? _value.subcontext
-          : subcontext // ignore: cast_nullable_to_non_nullable
-              as String,
-      label: null == label
-          ? _value.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
+/// Create a copy of RealtimeStream
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? mode = null,Object? subject = null,Object? subcontext = null,Object? label = null,}) {
+  return _then(_self.copyWith(
+mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
+as int,subject: null == subject ? _self.subject : subject // ignore: cast_nullable_to_non_nullable
+as String,subcontext: null == subcontext ? _self.subcontext : subcontext // ignore: cast_nullable_to_non_nullable
+as String,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RealtimeStream].
+extension RealtimeStreamPatterns on RealtimeStream {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RealtimeStream value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RealtimeStream() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RealtimeStream value)  $default,){
+final _that = this;
+switch (_that) {
+case _RealtimeStream():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RealtimeStream value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RealtimeStream() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int mode,  String subject,  String subcontext,  String label)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RealtimeStream() when $default != null:
+return $default(_that.mode,_that.subject,_that.subcontext,_that.label);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int mode,  String subject,  String subcontext,  String label)  $default,) {final _that = this;
+switch (_that) {
+case _RealtimeStream():
+return $default(_that.mode,_that.subject,_that.subcontext,_that.label);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int mode,  String subject,  String subcontext,  String label)?  $default,) {final _that = this;
+switch (_that) {
+case _RealtimeStream() when $default != null:
+return $default(_that.mode,_that.subject,_that.subcontext,_that.label);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$RealtimeStreamImplCopyWith<$Res>
-    implements $RealtimeStreamCopyWith<$Res> {
-  factory _$$RealtimeStreamImplCopyWith(_$RealtimeStreamImpl value,
-          $Res Function(_$RealtimeStreamImpl) then) =
-      __$$RealtimeStreamImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({int mode, String subject, String subcontext, String label});
+
+
+class _RealtimeStream extends RealtimeStream {
+  const _RealtimeStream({required this.mode, required this.subject, required this.subcontext, required this.label}): super._();
+  
+
+/// Mode identifies the type of stream.
+@override final  int mode;
+/// Subject is the primary identifier, if any.
+@override final  String subject;
+/// Subcontext is a secondary identifier, if any.
+@override final  String subcontext;
+/// The label is an arbitrary identifying string, if the stream has one.
+@override final  String label;
+
+/// Create a copy of RealtimeStream
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RealtimeStreamCopyWith<_RealtimeStream> get copyWith => __$RealtimeStreamCopyWithImpl<_RealtimeStream>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RealtimeStream&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.subject, subject) || other.subject == subject)&&(identical(other.subcontext, subcontext) || other.subcontext == subcontext)&&(identical(other.label, label) || other.label == label));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,mode,subject,subcontext,label);
+
+@override
+String toString() {
+  return 'RealtimeStream(mode: $mode, subject: $subject, subcontext: $subcontext, label: $label)';
+}
+
+
 }
 
 /// @nodoc
-class __$$RealtimeStreamImplCopyWithImpl<$Res>
-    extends _$RealtimeStreamCopyWithImpl<$Res, _$RealtimeStreamImpl>
-    implements _$$RealtimeStreamImplCopyWith<$Res> {
-  __$$RealtimeStreamImplCopyWithImpl(
-      _$RealtimeStreamImpl _value, $Res Function(_$RealtimeStreamImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$RealtimeStreamCopyWith<$Res> implements $RealtimeStreamCopyWith<$Res> {
+  factory _$RealtimeStreamCopyWith(_RealtimeStream value, $Res Function(_RealtimeStream) _then) = __$RealtimeStreamCopyWithImpl;
+@override @useResult
+$Res call({
+ int mode, String subject, String subcontext, String label
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? mode = null,
-    Object? subject = null,
-    Object? subcontext = null,
-    Object? label = null,
-  }) {
-    return _then(_$RealtimeStreamImpl(
-      mode: null == mode
-          ? _value.mode
-          : mode // ignore: cast_nullable_to_non_nullable
-              as int,
-      subject: null == subject
-          ? _value.subject
-          : subject // ignore: cast_nullable_to_non_nullable
-              as String,
-      subcontext: null == subcontext
-          ? _value.subcontext
-          : subcontext // ignore: cast_nullable_to_non_nullable
-              as String,
-      label: null == label
-          ? _value.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+
+
+
 }
-
 /// @nodoc
+class __$RealtimeStreamCopyWithImpl<$Res>
+    implements _$RealtimeStreamCopyWith<$Res> {
+  __$RealtimeStreamCopyWithImpl(this._self, this._then);
 
-class _$RealtimeStreamImpl extends _RealtimeStream {
-  const _$RealtimeStreamImpl(
-      {required this.mode,
-      required this.subject,
-      required this.subcontext,
-      required this.label})
-      : super._();
+  final _RealtimeStream _self;
+  final $Res Function(_RealtimeStream) _then;
 
-  /// Mode identifies the type of stream.
-  @override
-  final int mode;
-
-  /// Subject is the primary identifier, if any.
-  @override
-  final String subject;
-
-  /// Subcontext is a secondary identifier, if any.
-  @override
-  final String subcontext;
-
-  /// The label is an arbitrary identifying string, if the stream has one.
-  @override
-  final String label;
-
-  @override
-  String toString() {
-    return 'RealtimeStream(mode: $mode, subject: $subject, subcontext: $subcontext, label: $label)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$RealtimeStreamImpl &&
-            (identical(other.mode, mode) || other.mode == mode) &&
-            (identical(other.subject, subject) || other.subject == subject) &&
-            (identical(other.subcontext, subcontext) ||
-                other.subcontext == subcontext) &&
-            (identical(other.label, label) || other.label == label));
-  }
-
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, mode, subject, subcontext, label);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$RealtimeStreamImplCopyWith<_$RealtimeStreamImpl> get copyWith =>
-      __$$RealtimeStreamImplCopyWithImpl<_$RealtimeStreamImpl>(
-          this, _$identity);
+/// Create a copy of RealtimeStream
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? mode = null,Object? subject = null,Object? subcontext = null,Object? label = null,}) {
+  return _then(_RealtimeStream(
+mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
+as int,subject: null == subject ? _self.subject : subject // ignore: cast_nullable_to_non_nullable
+as String,subcontext: null == subcontext ? _self.subcontext : subcontext // ignore: cast_nullable_to_non_nullable
+as String,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
 
-abstract class _RealtimeStream extends RealtimeStream {
-  const factory _RealtimeStream(
-      {required final int mode,
-      required final String subject,
-      required final String subcontext,
-      required final String label}) = _$RealtimeStreamImpl;
-  const _RealtimeStream._() : super._();
 
-  @override
-
-  /// Mode identifies the type of stream.
-  int get mode;
-  @override
-
-  /// Subject is the primary identifier, if any.
-  String get subject;
-  @override
-
-  /// Subcontext is a secondary identifier, if any.
-  String get subcontext;
-  @override
-
-  /// The label is an arbitrary identifying string, if the stream has one.
-  String get label;
-  @override
-  @JsonKey(ignore: true)
-  _$$RealtimeStreamImplCopyWith<_$RealtimeStreamImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 mixin _$RealtimeStreamData {
-  /// The stream this data message relates to.
-  RealtimeStream get stream => throw _privateConstructorUsedError;
 
-  /// The sender, if any.
-  UserPresence get sender => throw _privateConstructorUsedError;
+/// The stream this data message relates to.
+ RealtimeStream get stream;/// The sender, if any.
+ UserPresence get sender;/// Arbitrary contents of the data message.
+ String get data;/// True if this data was delivered reliably, false otherwise.
+ bool get reliable;
+/// Create a copy of RealtimeStreamData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RealtimeStreamDataCopyWith<RealtimeStreamData> get copyWith => _$RealtimeStreamDataCopyWithImpl<RealtimeStreamData>(this as RealtimeStreamData, _$identity);
 
-  /// Arbitrary contents of the data message.
-  String get data => throw _privateConstructorUsedError;
 
-  /// True if this data was delivered reliably, false otherwise.
-  bool get reliable => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $RealtimeStreamDataCopyWith<RealtimeStreamData> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RealtimeStreamData&&(identical(other.stream, stream) || other.stream == stream)&&(identical(other.sender, sender) || other.sender == sender)&&(identical(other.data, data) || other.data == data)&&(identical(other.reliable, reliable) || other.reliable == reliable));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,stream,sender,data,reliable);
+
+@override
+String toString() {
+  return 'RealtimeStreamData(stream: $stream, sender: $sender, data: $data, reliable: $reliable)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $RealtimeStreamDataCopyWith<$Res> {
-  factory $RealtimeStreamDataCopyWith(
-          RealtimeStreamData value, $Res Function(RealtimeStreamData) then) =
-      _$RealtimeStreamDataCopyWithImpl<$Res, RealtimeStreamData>;
-  @useResult
-  $Res call(
-      {RealtimeStream stream, UserPresence sender, String data, bool reliable});
+abstract mixin class $RealtimeStreamDataCopyWith<$Res>  {
+  factory $RealtimeStreamDataCopyWith(RealtimeStreamData value, $Res Function(RealtimeStreamData) _then) = _$RealtimeStreamDataCopyWithImpl;
+@useResult
+$Res call({
+ RealtimeStream stream, UserPresence sender, String data, bool reliable
+});
 
-  $RealtimeStreamCopyWith<$Res> get stream;
-  $UserPresenceCopyWith<$Res> get sender;
+
+$RealtimeStreamCopyWith<$Res> get stream;$UserPresenceCopyWith<$Res> get sender;
+
 }
-
 /// @nodoc
-class _$RealtimeStreamDataCopyWithImpl<$Res, $Val extends RealtimeStreamData>
+class _$RealtimeStreamDataCopyWithImpl<$Res>
     implements $RealtimeStreamDataCopyWith<$Res> {
-  _$RealtimeStreamDataCopyWithImpl(this._value, this._then);
+  _$RealtimeStreamDataCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final RealtimeStreamData _self;
+  final $Res Function(RealtimeStreamData) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? stream = null,
-    Object? sender = null,
-    Object? data = null,
-    Object? reliable = null,
-  }) {
-    return _then(_value.copyWith(
-      stream: null == stream
-          ? _value.stream
-          : stream // ignore: cast_nullable_to_non_nullable
-              as RealtimeStream,
-      sender: null == sender
-          ? _value.sender
-          : sender // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      data: null == data
-          ? _value.data
-          : data // ignore: cast_nullable_to_non_nullable
-              as String,
-      reliable: null == reliable
-          ? _value.reliable
-          : reliable // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
-  }
+/// Create a copy of RealtimeStreamData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? stream = null,Object? sender = null,Object? data = null,Object? reliable = null,}) {
+  return _then(_self.copyWith(
+stream: null == stream ? _self.stream : stream // ignore: cast_nullable_to_non_nullable
+as RealtimeStream,sender: null == sender ? _self.sender : sender // ignore: cast_nullable_to_non_nullable
+as UserPresence,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as String,reliable: null == reliable ? _self.reliable : reliable // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+/// Create a copy of RealtimeStreamData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RealtimeStreamCopyWith<$Res> get stream {
+  
+  return $RealtimeStreamCopyWith<$Res>(_self.stream, (value) {
+    return _then(_self.copyWith(stream: value));
+  });
+}/// Create a copy of RealtimeStreamData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get sender {
+  
+  return $UserPresenceCopyWith<$Res>(_self.sender, (value) {
+    return _then(_self.copyWith(sender: value));
+  });
+}
+}
 
-  @override
-  @pragma('vm:prefer-inline')
-  $RealtimeStreamCopyWith<$Res> get stream {
-    return $RealtimeStreamCopyWith<$Res>(_value.stream, (value) {
-      return _then(_value.copyWith(stream: value) as $Val);
-    });
-  }
 
-  @override
-  @pragma('vm:prefer-inline')
-  $UserPresenceCopyWith<$Res> get sender {
-    return $UserPresenceCopyWith<$Res>(_value.sender, (value) {
-      return _then(_value.copyWith(sender: value) as $Val);
-    });
-  }
+/// Adds pattern-matching-related methods to [RealtimeStreamData].
+extension RealtimeStreamDataPatterns on RealtimeStreamData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RealtimeStreamData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RealtimeStreamData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RealtimeStreamData value)  $default,){
+final _that = this;
+switch (_that) {
+case _RealtimeStreamData():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RealtimeStreamData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RealtimeStreamData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( RealtimeStream stream,  UserPresence sender,  String data,  bool reliable)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RealtimeStreamData() when $default != null:
+return $default(_that.stream,_that.sender,_that.data,_that.reliable);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( RealtimeStream stream,  UserPresence sender,  String data,  bool reliable)  $default,) {final _that = this;
+switch (_that) {
+case _RealtimeStreamData():
+return $default(_that.stream,_that.sender,_that.data,_that.reliable);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( RealtimeStream stream,  UserPresence sender,  String data,  bool reliable)?  $default,) {final _that = this;
+switch (_that) {
+case _RealtimeStreamData() when $default != null:
+return $default(_that.stream,_that.sender,_that.data,_that.reliable);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$RealtimeStreamDataImplCopyWith<$Res>
-    implements $RealtimeStreamDataCopyWith<$Res> {
-  factory _$$RealtimeStreamDataImplCopyWith(_$RealtimeStreamDataImpl value,
-          $Res Function(_$RealtimeStreamDataImpl) then) =
-      __$$RealtimeStreamDataImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {RealtimeStream stream, UserPresence sender, String data, bool reliable});
 
-  @override
-  $RealtimeStreamCopyWith<$Res> get stream;
-  @override
-  $UserPresenceCopyWith<$Res> get sender;
+
+class _RealtimeStreamData extends RealtimeStreamData {
+  const _RealtimeStreamData({required this.stream, required this.sender, required this.data, required this.reliable}): super._();
+  
+
+/// The stream this data message relates to.
+@override final  RealtimeStream stream;
+/// The sender, if any.
+@override final  UserPresence sender;
+/// Arbitrary contents of the data message.
+@override final  String data;
+/// True if this data was delivered reliably, false otherwise.
+@override final  bool reliable;
+
+/// Create a copy of RealtimeStreamData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RealtimeStreamDataCopyWith<_RealtimeStreamData> get copyWith => __$RealtimeStreamDataCopyWithImpl<_RealtimeStreamData>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RealtimeStreamData&&(identical(other.stream, stream) || other.stream == stream)&&(identical(other.sender, sender) || other.sender == sender)&&(identical(other.data, data) || other.data == data)&&(identical(other.reliable, reliable) || other.reliable == reliable));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,stream,sender,data,reliable);
+
+@override
+String toString() {
+  return 'RealtimeStreamData(stream: $stream, sender: $sender, data: $data, reliable: $reliable)';
+}
+
+
 }
 
 /// @nodoc
-class __$$RealtimeStreamDataImplCopyWithImpl<$Res>
-    extends _$RealtimeStreamDataCopyWithImpl<$Res, _$RealtimeStreamDataImpl>
-    implements _$$RealtimeStreamDataImplCopyWith<$Res> {
-  __$$RealtimeStreamDataImplCopyWithImpl(_$RealtimeStreamDataImpl _value,
-      $Res Function(_$RealtimeStreamDataImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$RealtimeStreamDataCopyWith<$Res> implements $RealtimeStreamDataCopyWith<$Res> {
+  factory _$RealtimeStreamDataCopyWith(_RealtimeStreamData value, $Res Function(_RealtimeStreamData) _then) = __$RealtimeStreamDataCopyWithImpl;
+@override @useResult
+$Res call({
+ RealtimeStream stream, UserPresence sender, String data, bool reliable
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? stream = null,
-    Object? sender = null,
-    Object? data = null,
-    Object? reliable = null,
-  }) {
-    return _then(_$RealtimeStreamDataImpl(
-      stream: null == stream
-          ? _value.stream
-          : stream // ignore: cast_nullable_to_non_nullable
-              as RealtimeStream,
-      sender: null == sender
-          ? _value.sender
-          : sender // ignore: cast_nullable_to_non_nullable
-              as UserPresence,
-      data: null == data
-          ? _value.data
-          : data // ignore: cast_nullable_to_non_nullable
-              as String,
-      reliable: null == reliable
-          ? _value.reliable
-          : reliable // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+
+@override $RealtimeStreamCopyWith<$Res> get stream;@override $UserPresenceCopyWith<$Res> get sender;
+
 }
-
 /// @nodoc
+class __$RealtimeStreamDataCopyWithImpl<$Res>
+    implements _$RealtimeStreamDataCopyWith<$Res> {
+  __$RealtimeStreamDataCopyWithImpl(this._self, this._then);
 
-class _$RealtimeStreamDataImpl extends _RealtimeStreamData {
-  const _$RealtimeStreamDataImpl(
-      {required this.stream,
-      required this.sender,
-      required this.data,
-      required this.reliable})
-      : super._();
+  final _RealtimeStreamData _self;
+  final $Res Function(_RealtimeStreamData) _then;
 
-  /// The stream this data message relates to.
-  @override
-  final RealtimeStream stream;
-
-  /// The sender, if any.
-  @override
-  final UserPresence sender;
-
-  /// Arbitrary contents of the data message.
-  @override
-  final String data;
-
-  /// True if this data was delivered reliably, false otherwise.
-  @override
-  final bool reliable;
-
-  @override
-  String toString() {
-    return 'RealtimeStreamData(stream: $stream, sender: $sender, data: $data, reliable: $reliable)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$RealtimeStreamDataImpl &&
-            (identical(other.stream, stream) || other.stream == stream) &&
-            (identical(other.sender, sender) || other.sender == sender) &&
-            (identical(other.data, data) || other.data == data) &&
-            (identical(other.reliable, reliable) ||
-                other.reliable == reliable));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, stream, sender, data, reliable);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$RealtimeStreamDataImplCopyWith<_$RealtimeStreamDataImpl> get copyWith =>
-      __$$RealtimeStreamDataImplCopyWithImpl<_$RealtimeStreamDataImpl>(
-          this, _$identity);
+/// Create a copy of RealtimeStreamData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? stream = null,Object? sender = null,Object? data = null,Object? reliable = null,}) {
+  return _then(_RealtimeStreamData(
+stream: null == stream ? _self.stream : stream // ignore: cast_nullable_to_non_nullable
+as RealtimeStream,sender: null == sender ? _self.sender : sender // ignore: cast_nullable_to_non_nullable
+as UserPresence,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as String,reliable: null == reliable ? _self.reliable : reliable // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
 
-abstract class _RealtimeStreamData extends RealtimeStreamData {
-  const factory _RealtimeStreamData(
-      {required final RealtimeStream stream,
-      required final UserPresence sender,
-      required final String data,
-      required final bool reliable}) = _$RealtimeStreamDataImpl;
-  const _RealtimeStreamData._() : super._();
-
-  @override
-
-  /// The stream this data message relates to.
-  RealtimeStream get stream;
-  @override
-
-  /// The sender, if any.
-  UserPresence get sender;
-  @override
-
-  /// Arbitrary contents of the data message.
-  String get data;
-  @override
-
-  /// True if this data was delivered reliably, false otherwise.
-  bool get reliable;
-  @override
-  @JsonKey(ignore: true)
-  _$$RealtimeStreamDataImplCopyWith<_$RealtimeStreamDataImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+/// Create a copy of RealtimeStreamData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RealtimeStreamCopyWith<$Res> get stream {
+  
+  return $RealtimeStreamCopyWith<$Res>(_self.stream, (value) {
+    return _then(_self.copyWith(stream: value));
+  });
+}/// Create a copy of RealtimeStreamData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserPresenceCopyWith<$Res> get sender {
+  
+  return $UserPresenceCopyWith<$Res>(_self.sender, (value) {
+    return _then(_self.copyWith(sender: value));
+  });
+}
 }
 
 /// @nodoc
 mixin _$StreamPresenceEvent {
-  /// The stream this presence event is for.
-  RealtimeStream get stream => throw _privateConstructorUsedError;
 
-  /// The user presence that joined the stream.
-  List<UserPresence> get joins => throw _privateConstructorUsedError;
+/// The stream this presence event is for.
+ RealtimeStream get stream;/// The user presence that joined the stream.
+ List<UserPresence> get joins;/// The user presence that left the stream.
+ List<UserPresence> get leaves;
+/// Create a copy of StreamPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StreamPresenceEventCopyWith<StreamPresenceEvent> get copyWith => _$StreamPresenceEventCopyWithImpl<StreamPresenceEvent>(this as StreamPresenceEvent, _$identity);
 
-  /// The user presence that left the stream.
-  List<UserPresence> get leaves => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
-  $StreamPresenceEventCopyWith<StreamPresenceEvent> get copyWith =>
-      throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StreamPresenceEvent&&(identical(other.stream, stream) || other.stream == stream)&&const DeepCollectionEquality().equals(other.joins, joins)&&const DeepCollectionEquality().equals(other.leaves, leaves));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,stream,const DeepCollectionEquality().hash(joins),const DeepCollectionEquality().hash(leaves));
+
+@override
+String toString() {
+  return 'StreamPresenceEvent(stream: $stream, joins: $joins, leaves: $leaves)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $StreamPresenceEventCopyWith<$Res> {
-  factory $StreamPresenceEventCopyWith(
-          StreamPresenceEvent value, $Res Function(StreamPresenceEvent) then) =
-      _$StreamPresenceEventCopyWithImpl<$Res, StreamPresenceEvent>;
-  @useResult
-  $Res call(
-      {RealtimeStream stream,
-      List<UserPresence> joins,
-      List<UserPresence> leaves});
+abstract mixin class $StreamPresenceEventCopyWith<$Res>  {
+  factory $StreamPresenceEventCopyWith(StreamPresenceEvent value, $Res Function(StreamPresenceEvent) _then) = _$StreamPresenceEventCopyWithImpl;
+@useResult
+$Res call({
+ RealtimeStream stream, List<UserPresence> joins, List<UserPresence> leaves
+});
 
-  $RealtimeStreamCopyWith<$Res> get stream;
+
+$RealtimeStreamCopyWith<$Res> get stream;
+
 }
-
 /// @nodoc
-class _$StreamPresenceEventCopyWithImpl<$Res, $Val extends StreamPresenceEvent>
+class _$StreamPresenceEventCopyWithImpl<$Res>
     implements $StreamPresenceEventCopyWith<$Res> {
-  _$StreamPresenceEventCopyWithImpl(this._value, this._then);
+  _$StreamPresenceEventCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final StreamPresenceEvent _self;
+  final $Res Function(StreamPresenceEvent) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? stream = null,
-    Object? joins = null,
-    Object? leaves = null,
-  }) {
-    return _then(_value.copyWith(
-      stream: null == stream
-          ? _value.stream
-          : stream // ignore: cast_nullable_to_non_nullable
-              as RealtimeStream,
-      joins: null == joins
-          ? _value.joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-      leaves: null == leaves
-          ? _value.leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ) as $Val);
-  }
+/// Create a copy of StreamPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? stream = null,Object? joins = null,Object? leaves = null,}) {
+  return _then(_self.copyWith(
+stream: null == stream ? _self.stream : stream // ignore: cast_nullable_to_non_nullable
+as RealtimeStream,joins: null == joins ? _self.joins : joins // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,leaves: null == leaves ? _self.leaves : leaves // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
+}
+/// Create a copy of StreamPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RealtimeStreamCopyWith<$Res> get stream {
+  
+  return $RealtimeStreamCopyWith<$Res>(_self.stream, (value) {
+    return _then(_self.copyWith(stream: value));
+  });
+}
+}
 
-  @override
-  @pragma('vm:prefer-inline')
-  $RealtimeStreamCopyWith<$Res> get stream {
-    return $RealtimeStreamCopyWith<$Res>(_value.stream, (value) {
-      return _then(_value.copyWith(stream: value) as $Val);
-    });
-  }
+
+/// Adds pattern-matching-related methods to [StreamPresenceEvent].
+extension StreamPresenceEventPatterns on StreamPresenceEvent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _StreamPresenceEvent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _StreamPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _StreamPresenceEvent value)  $default,){
+final _that = this;
+switch (_that) {
+case _StreamPresenceEvent():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _StreamPresenceEvent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _StreamPresenceEvent() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( RealtimeStream stream,  List<UserPresence> joins,  List<UserPresence> leaves)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _StreamPresenceEvent() when $default != null:
+return $default(_that.stream,_that.joins,_that.leaves);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( RealtimeStream stream,  List<UserPresence> joins,  List<UserPresence> leaves)  $default,) {final _that = this;
+switch (_that) {
+case _StreamPresenceEvent():
+return $default(_that.stream,_that.joins,_that.leaves);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( RealtimeStream stream,  List<UserPresence> joins,  List<UserPresence> leaves)?  $default,) {final _that = this;
+switch (_that) {
+case _StreamPresenceEvent() when $default != null:
+return $default(_that.stream,_that.joins,_that.leaves);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
-abstract class _$$StreamPresenceEventImplCopyWith<$Res>
-    implements $StreamPresenceEventCopyWith<$Res> {
-  factory _$$StreamPresenceEventImplCopyWith(_$StreamPresenceEventImpl value,
-          $Res Function(_$StreamPresenceEventImpl) then) =
-      __$$StreamPresenceEventImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {RealtimeStream stream,
-      List<UserPresence> joins,
-      List<UserPresence> leaves});
 
-  @override
-  $RealtimeStreamCopyWith<$Res> get stream;
+
+class _StreamPresenceEvent extends StreamPresenceEvent {
+  const _StreamPresenceEvent({required this.stream, required final  List<UserPresence> joins, required final  List<UserPresence> leaves}): _joins = joins,_leaves = leaves,super._();
+  
+
+/// The stream this presence event is for.
+@override final  RealtimeStream stream;
+/// The user presence that joined the stream.
+ final  List<UserPresence> _joins;
+/// The user presence that joined the stream.
+@override List<UserPresence> get joins {
+  if (_joins is EqualUnmodifiableListView) return _joins;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_joins);
+}
+
+/// The user presence that left the stream.
+ final  List<UserPresence> _leaves;
+/// The user presence that left the stream.
+@override List<UserPresence> get leaves {
+  if (_leaves is EqualUnmodifiableListView) return _leaves;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_leaves);
+}
+
+
+/// Create a copy of StreamPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$StreamPresenceEventCopyWith<_StreamPresenceEvent> get copyWith => __$StreamPresenceEventCopyWithImpl<_StreamPresenceEvent>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StreamPresenceEvent&&(identical(other.stream, stream) || other.stream == stream)&&const DeepCollectionEquality().equals(other._joins, _joins)&&const DeepCollectionEquality().equals(other._leaves, _leaves));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,stream,const DeepCollectionEquality().hash(_joins),const DeepCollectionEquality().hash(_leaves));
+
+@override
+String toString() {
+  return 'StreamPresenceEvent(stream: $stream, joins: $joins, leaves: $leaves)';
+}
+
+
 }
 
 /// @nodoc
-class __$$StreamPresenceEventImplCopyWithImpl<$Res>
-    extends _$StreamPresenceEventCopyWithImpl<$Res, _$StreamPresenceEventImpl>
-    implements _$$StreamPresenceEventImplCopyWith<$Res> {
-  __$$StreamPresenceEventImplCopyWithImpl(_$StreamPresenceEventImpl _value,
-      $Res Function(_$StreamPresenceEventImpl) _then)
-      : super(_value, _then);
+abstract mixin class _$StreamPresenceEventCopyWith<$Res> implements $StreamPresenceEventCopyWith<$Res> {
+  factory _$StreamPresenceEventCopyWith(_StreamPresenceEvent value, $Res Function(_StreamPresenceEvent) _then) = __$StreamPresenceEventCopyWithImpl;
+@override @useResult
+$Res call({
+ RealtimeStream stream, List<UserPresence> joins, List<UserPresence> leaves
+});
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? stream = null,
-    Object? joins = null,
-    Object? leaves = null,
-  }) {
-    return _then(_$StreamPresenceEventImpl(
-      stream: null == stream
-          ? _value.stream
-          : stream // ignore: cast_nullable_to_non_nullable
-              as RealtimeStream,
-      joins: null == joins
-          ? _value._joins
-          : joins // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-      leaves: null == leaves
-          ? _value._leaves
-          : leaves // ignore: cast_nullable_to_non_nullable
-              as List<UserPresence>,
-    ));
-  }
+
+@override $RealtimeStreamCopyWith<$Res> get stream;
+
 }
-
 /// @nodoc
+class __$StreamPresenceEventCopyWithImpl<$Res>
+    implements _$StreamPresenceEventCopyWith<$Res> {
+  __$StreamPresenceEventCopyWithImpl(this._self, this._then);
 
-class _$StreamPresenceEventImpl extends _StreamPresenceEvent {
-  const _$StreamPresenceEventImpl(
-      {required this.stream,
-      required final List<UserPresence> joins,
-      required final List<UserPresence> leaves})
-      : _joins = joins,
-        _leaves = leaves,
-        super._();
+  final _StreamPresenceEvent _self;
+  final $Res Function(_StreamPresenceEvent) _then;
 
-  /// The stream this presence event is for.
-  @override
-  final RealtimeStream stream;
-
-  /// The user presence that joined the stream.
-  final List<UserPresence> _joins;
-
-  /// The user presence that joined the stream.
-  @override
-  List<UserPresence> get joins {
-    if (_joins is EqualUnmodifiableListView) return _joins;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_joins);
-  }
-
-  /// The user presence that left the stream.
-  final List<UserPresence> _leaves;
-
-  /// The user presence that left the stream.
-  @override
-  List<UserPresence> get leaves {
-    if (_leaves is EqualUnmodifiableListView) return _leaves;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_leaves);
-  }
-
-  @override
-  String toString() {
-    return 'StreamPresenceEvent(stream: $stream, joins: $joins, leaves: $leaves)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$StreamPresenceEventImpl &&
-            (identical(other.stream, stream) || other.stream == stream) &&
-            const DeepCollectionEquality().equals(other._joins, _joins) &&
-            const DeepCollectionEquality().equals(other._leaves, _leaves));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      stream,
-      const DeepCollectionEquality().hash(_joins),
-      const DeepCollectionEquality().hash(_leaves));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$StreamPresenceEventImplCopyWith<_$StreamPresenceEventImpl> get copyWith =>
-      __$$StreamPresenceEventImplCopyWithImpl<_$StreamPresenceEventImpl>(
-          this, _$identity);
+/// Create a copy of StreamPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? stream = null,Object? joins = null,Object? leaves = null,}) {
+  return _then(_StreamPresenceEvent(
+stream: null == stream ? _self.stream : stream // ignore: cast_nullable_to_non_nullable
+as RealtimeStream,joins: null == joins ? _self._joins : joins // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,leaves: null == leaves ? _self._leaves : leaves // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
 }
 
-abstract class _StreamPresenceEvent extends StreamPresenceEvent {
-  const factory _StreamPresenceEvent(
-      {required final RealtimeStream stream,
-      required final List<UserPresence> joins,
-      required final List<UserPresence> leaves}) = _$StreamPresenceEventImpl;
-  const _StreamPresenceEvent._() : super._();
-
-  @override
-
-  /// The stream this presence event is for.
-  RealtimeStream get stream;
-  @override
-
-  /// The user presence that joined the stream.
-  List<UserPresence> get joins;
-  @override
-
-  /// The user presence that left the stream.
-  List<UserPresence> get leaves;
-  @override
-  @JsonKey(ignore: true)
-  _$$StreamPresenceEventImplCopyWith<_$StreamPresenceEventImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+/// Create a copy of StreamPresenceEvent
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RealtimeStreamCopyWith<$Res> get stream {
+  
+  return $RealtimeStreamCopyWith<$Res>(_self.stream, (value) {
+    return _then(_self.copyWith(stream: value));
+  });
 }
+}
+
+// dart format on

--- a/nakama/lib/src/models/status.g.dart
+++ b/nakama/lib/src/models/status.g.dart
@@ -6,8 +6,8 @@ part of 'status.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$UserPresenceImpl _$$UserPresenceImplFromJson(Map<String, dynamic> json) =>
-    _$UserPresenceImpl(
+_UserPresence _$UserPresenceFromJson(Map<String, dynamic> json) =>
+    _UserPresence(
       userId: json['user_id'] as String,
       sessionId: json['session_id'] as String,
       username: json['username'] as String,
@@ -15,7 +15,7 @@ _$UserPresenceImpl _$$UserPresenceImplFromJson(Map<String, dynamic> json) =>
       status: json['status'] as String?,
     );
 
-Map<String, dynamic> _$$UserPresenceImplToJson(_$UserPresenceImpl instance) =>
+Map<String, dynamic> _$UserPresenceToJson(_UserPresence instance) =>
     <String, dynamic>{
       'user_id': instance.userId,
       'session_id': instance.sessionId,

--- a/nakama/lib/src/models/storage.dart
+++ b/nakama/lib/src/models/storage.dart
@@ -7,7 +7,7 @@ part 'storage.freezed.dart';
 part 'storage.g.dart';
 
 @freezed
-class StorageObject with _$StorageObject {
+sealed class StorageObject with _$StorageObject {
   const StorageObject._();
 
   const factory StorageObject({
@@ -38,7 +38,7 @@ class StorageObject with _$StorageObject {
 }
 
 @freezed
-class StorageObjectList with _$StorageObjectList {
+sealed class StorageObjectList with _$StorageObjectList {
   const StorageObjectList._();
 
   const factory StorageObjectList({
@@ -55,7 +55,7 @@ class StorageObjectList with _$StorageObjectList {
 }
 
 @freezed
-class StorageObjectId with _$StorageObjectId {
+sealed class StorageObjectId with _$StorageObjectId {
   const StorageObjectId._();
 
   const factory StorageObjectId({
@@ -75,7 +75,7 @@ class StorageObjectId with _$StorageObjectId {
 }
 
 @freezed
-class StorageObjectWrite with _$StorageObjectWrite {
+sealed class StorageObjectWrite with _$StorageObjectWrite {
   const StorageObjectWrite._();
 
   const factory StorageObjectWrite({

--- a/nakama/lib/src/models/storage.freezed.dart
+++ b/nakama/lib/src/models/storage.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,1003 +9,1091 @@ part of 'storage.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-StorageObject _$StorageObjectFromJson(Map<String, dynamic> json) {
-  return _StorageObject.fromJson(json);
-}
 
 /// @nodoc
 mixin _$StorageObject {
-  @JsonKey(name: 'collection')
-  String get collection => throw _privateConstructorUsedError;
-  @JsonKey(name: 'key')
-  String get key => throw _privateConstructorUsedError;
-  @JsonKey(name: 'user_id')
-  String? get userId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'value')
-  String get value => throw _privateConstructorUsedError;
-  @JsonKey(name: 'version')
-  String get version => throw _privateConstructorUsedError;
-  @JsonKey(name: 'permission_read')
-  StorageReadPermission? get permissionRead =>
-      throw _privateConstructorUsedError;
-  @JsonKey(name: 'permission_write')
-  StorageWritePermission? get permissionWrite =>
-      throw _privateConstructorUsedError;
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'update_time')
-  DateTime? get updateTime => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $StorageObjectCopyWith<StorageObject> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'collection') String get collection;@JsonKey(name: 'key') String get key;@JsonKey(name: 'user_id') String? get userId;@JsonKey(name: 'value') String get value;@JsonKey(name: 'version') String get version;@JsonKey(name: 'permission_read') StorageReadPermission? get permissionRead;@JsonKey(name: 'permission_write') StorageWritePermission? get permissionWrite;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;
+/// Create a copy of StorageObject
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StorageObjectCopyWith<StorageObject> get copyWith => _$StorageObjectCopyWithImpl<StorageObject>(this as StorageObject, _$identity);
+
+  /// Serializes this StorageObject to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StorageObject&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.key, key) || other.key == key)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.value, value) || other.value == value)&&(identical(other.version, version) || other.version == version)&&(identical(other.permissionRead, permissionRead) || other.permissionRead == permissionRead)&&(identical(other.permissionWrite, permissionWrite) || other.permissionWrite == permissionWrite)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,collection,key,userId,value,version,permissionRead,permissionWrite,createTime,updateTime);
+
+@override
+String toString() {
+  return 'StorageObject(collection: $collection, key: $key, userId: $userId, value: $value, version: $version, permissionRead: $permissionRead, permissionWrite: $permissionWrite, createTime: $createTime, updateTime: $updateTime)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $StorageObjectCopyWith<$Res> {
-  factory $StorageObjectCopyWith(
-          StorageObject value, $Res Function(StorageObject) then) =
-      _$StorageObjectCopyWithImpl<$Res, StorageObject>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'collection') String collection,
-      @JsonKey(name: 'key') String key,
-      @JsonKey(name: 'user_id') String? userId,
-      @JsonKey(name: 'value') String value,
-      @JsonKey(name: 'version') String version,
-      @JsonKey(name: 'permission_read') StorageReadPermission? permissionRead,
-      @JsonKey(name: 'permission_write')
-      StorageWritePermission? permissionWrite,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'update_time') DateTime? updateTime});
-}
+abstract mixin class $StorageObjectCopyWith<$Res>  {
+  factory $StorageObjectCopyWith(StorageObject value, $Res Function(StorageObject) _then) = _$StorageObjectCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'collection') String collection,@JsonKey(name: 'key') String key,@JsonKey(name: 'user_id') String? userId,@JsonKey(name: 'value') String value,@JsonKey(name: 'version') String version,@JsonKey(name: 'permission_read') StorageReadPermission? permissionRead,@JsonKey(name: 'permission_write') StorageWritePermission? permissionWrite,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime
+});
 
+
+
+
+}
 /// @nodoc
-class _$StorageObjectCopyWithImpl<$Res, $Val extends StorageObject>
+class _$StorageObjectCopyWithImpl<$Res>
     implements $StorageObjectCopyWith<$Res> {
-  _$StorageObjectCopyWithImpl(this._value, this._then);
+  _$StorageObjectCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final StorageObject _self;
+  final $Res Function(StorageObject) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? collection = null,
-    Object? key = null,
-    Object? userId = freezed,
-    Object? value = null,
-    Object? version = null,
-    Object? permissionRead = freezed,
-    Object? permissionWrite = freezed,
-    Object? createTime = freezed,
-    Object? updateTime = freezed,
-  }) {
-    return _then(_value.copyWith(
-      collection: null == collection
-          ? _value.collection
-          : collection // ignore: cast_nullable_to_non_nullable
-              as String,
-      key: null == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: freezed == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: null == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String,
-      version: null == version
-          ? _value.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String,
-      permissionRead: freezed == permissionRead
-          ? _value.permissionRead
-          : permissionRead // ignore: cast_nullable_to_non_nullable
-              as StorageReadPermission?,
-      permissionWrite: freezed == permissionWrite
-          ? _value.permissionWrite
-          : permissionWrite // ignore: cast_nullable_to_non_nullable
-              as StorageWritePermission?,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updateTime: freezed == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ) as $Val);
-  }
+/// Create a copy of StorageObject
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? collection = null,Object? key = null,Object? userId = freezed,Object? value = null,Object? version = null,Object? permissionRead = freezed,Object? permissionWrite = freezed,Object? createTime = freezed,Object? updateTime = freezed,}) {
+  return _then(_self.copyWith(
+collection: null == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
+as String,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String,version: null == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String,permissionRead: freezed == permissionRead ? _self.permissionRead : permissionRead // ignore: cast_nullable_to_non_nullable
+as StorageReadPermission?,permissionWrite: freezed == permissionWrite ? _self.permissionWrite : permissionWrite // ignore: cast_nullable_to_non_nullable
+as StorageWritePermission?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$StorageObjectImplCopyWith<$Res>
-    implements $StorageObjectCopyWith<$Res> {
-  factory _$$StorageObjectImplCopyWith(
-          _$StorageObjectImpl value, $Res Function(_$StorageObjectImpl) then) =
-      __$$StorageObjectImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'collection') String collection,
-      @JsonKey(name: 'key') String key,
-      @JsonKey(name: 'user_id') String? userId,
-      @JsonKey(name: 'value') String value,
-      @JsonKey(name: 'version') String version,
-      @JsonKey(name: 'permission_read') StorageReadPermission? permissionRead,
-      @JsonKey(name: 'permission_write')
-      StorageWritePermission? permissionWrite,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'update_time') DateTime? updateTime});
 }
 
-/// @nodoc
-class __$$StorageObjectImplCopyWithImpl<$Res>
-    extends _$StorageObjectCopyWithImpl<$Res, _$StorageObjectImpl>
-    implements _$$StorageObjectImplCopyWith<$Res> {
-  __$$StorageObjectImplCopyWithImpl(
-      _$StorageObjectImpl _value, $Res Function(_$StorageObjectImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? collection = null,
-    Object? key = null,
-    Object? userId = freezed,
-    Object? value = null,
-    Object? version = null,
-    Object? permissionRead = freezed,
-    Object? permissionWrite = freezed,
-    Object? createTime = freezed,
-    Object? updateTime = freezed,
-  }) {
-    return _then(_$StorageObjectImpl(
-      collection: null == collection
-          ? _value.collection
-          : collection // ignore: cast_nullable_to_non_nullable
-              as String,
-      key: null == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: freezed == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: null == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String,
-      version: null == version
-          ? _value.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String,
-      permissionRead: freezed == permissionRead
-          ? _value.permissionRead
-          : permissionRead // ignore: cast_nullable_to_non_nullable
-              as StorageReadPermission?,
-      permissionWrite: freezed == permissionWrite
-          ? _value.permissionWrite
-          : permissionWrite // ignore: cast_nullable_to_non_nullable
-              as StorageWritePermission?,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updateTime: freezed == updateTime
-          ? _value.updateTime
-          : updateTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [StorageObject].
+extension StorageObjectPatterns on StorageObject {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _StorageObject value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _StorageObject() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _StorageObject value)  $default,){
+final _that = this;
+switch (_that) {
+case _StorageObject():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _StorageObject value)?  $default,){
+final _that = this;
+switch (_that) {
+case _StorageObject() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'user_id')  String? userId, @JsonKey(name: 'value')  String value, @JsonKey(name: 'version')  String version, @JsonKey(name: 'permission_read')  StorageReadPermission? permissionRead, @JsonKey(name: 'permission_write')  StorageWritePermission? permissionWrite, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _StorageObject() when $default != null:
+return $default(_that.collection,_that.key,_that.userId,_that.value,_that.version,_that.permissionRead,_that.permissionWrite,_that.createTime,_that.updateTime);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'user_id')  String? userId, @JsonKey(name: 'value')  String value, @JsonKey(name: 'version')  String version, @JsonKey(name: 'permission_read')  StorageReadPermission? permissionRead, @JsonKey(name: 'permission_write')  StorageWritePermission? permissionWrite, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime)  $default,) {final _that = this;
+switch (_that) {
+case _StorageObject():
+return $default(_that.collection,_that.key,_that.userId,_that.value,_that.version,_that.permissionRead,_that.permissionWrite,_that.createTime,_that.updateTime);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'user_id')  String? userId, @JsonKey(name: 'value')  String value, @JsonKey(name: 'version')  String version, @JsonKey(name: 'permission_read')  StorageReadPermission? permissionRead, @JsonKey(name: 'permission_write')  StorageWritePermission? permissionWrite, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime)?  $default,) {final _that = this;
+switch (_that) {
+case _StorageObject() when $default != null:
+return $default(_that.collection,_that.key,_that.userId,_that.value,_that.version,_that.permissionRead,_that.permissionWrite,_that.createTime,_that.updateTime);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$StorageObjectImpl extends _StorageObject {
-  const _$StorageObjectImpl(
-      {@JsonKey(name: 'collection') required this.collection,
-      @JsonKey(name: 'key') required this.key,
-      @JsonKey(name: 'user_id') this.userId,
-      @JsonKey(name: 'value') required this.value,
-      @JsonKey(name: 'version') required this.version,
-      @JsonKey(name: 'permission_read') this.permissionRead,
-      @JsonKey(name: 'permission_write') this.permissionWrite,
-      @JsonKey(name: 'create_time') this.createTime,
-      @JsonKey(name: 'update_time') this.updateTime})
-      : super._();
 
-  factory _$StorageObjectImpl.fromJson(Map<String, dynamic> json) =>
-      _$$StorageObjectImplFromJson(json);
+class _StorageObject extends StorageObject {
+  const _StorageObject({@JsonKey(name: 'collection') required this.collection, @JsonKey(name: 'key') required this.key, @JsonKey(name: 'user_id') this.userId, @JsonKey(name: 'value') required this.value, @JsonKey(name: 'version') required this.version, @JsonKey(name: 'permission_read') this.permissionRead, @JsonKey(name: 'permission_write') this.permissionWrite, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'update_time') this.updateTime}): super._();
+  factory _StorageObject.fromJson(Map<String, dynamic> json) => _$StorageObjectFromJson(json);
 
-  @override
-  @JsonKey(name: 'collection')
-  final String collection;
-  @override
-  @JsonKey(name: 'key')
-  final String key;
-  @override
-  @JsonKey(name: 'user_id')
-  final String? userId;
-  @override
-  @JsonKey(name: 'value')
-  final String value;
-  @override
-  @JsonKey(name: 'version')
-  final String version;
-  @override
-  @JsonKey(name: 'permission_read')
-  final StorageReadPermission? permissionRead;
-  @override
-  @JsonKey(name: 'permission_write')
-  final StorageWritePermission? permissionWrite;
-  @override
-  @JsonKey(name: 'create_time')
-  final DateTime? createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  final DateTime? updateTime;
+@override@JsonKey(name: 'collection') final  String collection;
+@override@JsonKey(name: 'key') final  String key;
+@override@JsonKey(name: 'user_id') final  String? userId;
+@override@JsonKey(name: 'value') final  String value;
+@override@JsonKey(name: 'version') final  String version;
+@override@JsonKey(name: 'permission_read') final  StorageReadPermission? permissionRead;
+@override@JsonKey(name: 'permission_write') final  StorageWritePermission? permissionWrite;
+@override@JsonKey(name: 'create_time') final  DateTime? createTime;
+@override@JsonKey(name: 'update_time') final  DateTime? updateTime;
 
-  @override
-  String toString() {
-    return 'StorageObject(collection: $collection, key: $key, userId: $userId, value: $value, version: $version, permissionRead: $permissionRead, permissionWrite: $permissionWrite, createTime: $createTime, updateTime: $updateTime)';
-  }
+/// Create a copy of StorageObject
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$StorageObjectCopyWith<_StorageObject> get copyWith => __$StorageObjectCopyWithImpl<_StorageObject>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$StorageObjectImpl &&
-            (identical(other.collection, collection) ||
-                other.collection == collection) &&
-            (identical(other.key, key) || other.key == key) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.value, value) || other.value == value) &&
-            (identical(other.version, version) || other.version == version) &&
-            (identical(other.permissionRead, permissionRead) ||
-                other.permissionRead == permissionRead) &&
-            (identical(other.permissionWrite, permissionWrite) ||
-                other.permissionWrite == permissionWrite) &&
-            (identical(other.createTime, createTime) ||
-                other.createTime == createTime) &&
-            (identical(other.updateTime, updateTime) ||
-                other.updateTime == updateTime));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, collection, key, userId, value,
-      version, permissionRead, permissionWrite, createTime, updateTime);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$StorageObjectImplCopyWith<_$StorageObjectImpl> get copyWith =>
-      __$$StorageObjectImplCopyWithImpl<_$StorageObjectImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$StorageObjectImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$StorageObjectToJson(this, );
 }
 
-abstract class _StorageObject extends StorageObject {
-  const factory _StorageObject(
-          {@JsonKey(name: 'collection') required final String collection,
-          @JsonKey(name: 'key') required final String key,
-          @JsonKey(name: 'user_id') final String? userId,
-          @JsonKey(name: 'value') required final String value,
-          @JsonKey(name: 'version') required final String version,
-          @JsonKey(name: 'permission_read')
-          final StorageReadPermission? permissionRead,
-          @JsonKey(name: 'permission_write')
-          final StorageWritePermission? permissionWrite,
-          @JsonKey(name: 'create_time') final DateTime? createTime,
-          @JsonKey(name: 'update_time') final DateTime? updateTime}) =
-      _$StorageObjectImpl;
-  const _StorageObject._() : super._();
-
-  factory _StorageObject.fromJson(Map<String, dynamic> json) =
-      _$StorageObjectImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'collection')
-  String get collection;
-  @override
-  @JsonKey(name: 'key')
-  String get key;
-  @override
-  @JsonKey(name: 'user_id')
-  String? get userId;
-  @override
-  @JsonKey(name: 'value')
-  String get value;
-  @override
-  @JsonKey(name: 'version')
-  String get version;
-  @override
-  @JsonKey(name: 'permission_read')
-  StorageReadPermission? get permissionRead;
-  @override
-  @JsonKey(name: 'permission_write')
-  StorageWritePermission? get permissionWrite;
-  @override
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime;
-  @override
-  @JsonKey(name: 'update_time')
-  DateTime? get updateTime;
-  @override
-  @JsonKey(ignore: true)
-  _$$StorageObjectImplCopyWith<_$StorageObjectImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StorageObject&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.key, key) || other.key == key)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.value, value) || other.value == value)&&(identical(other.version, version) || other.version == version)&&(identical(other.permissionRead, permissionRead) || other.permissionRead == permissionRead)&&(identical(other.permissionWrite, permissionWrite) || other.permissionWrite == permissionWrite)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.updateTime, updateTime) || other.updateTime == updateTime));
 }
 
-StorageObjectList _$StorageObjectListFromJson(Map<String, dynamic> json) {
-  return _StorageObjectList.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,collection,key,userId,value,version,permissionRead,permissionWrite,createTime,updateTime);
+
+@override
+String toString() {
+  return 'StorageObject(collection: $collection, key: $key, userId: $userId, value: $value, version: $version, permissionRead: $permissionRead, permissionWrite: $permissionWrite, createTime: $createTime, updateTime: $updateTime)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$StorageObjectCopyWith<$Res> implements $StorageObjectCopyWith<$Res> {
+  factory _$StorageObjectCopyWith(_StorageObject value, $Res Function(_StorageObject) _then) = __$StorageObjectCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'collection') String collection,@JsonKey(name: 'key') String key,@JsonKey(name: 'user_id') String? userId,@JsonKey(name: 'value') String value,@JsonKey(name: 'version') String version,@JsonKey(name: 'permission_read') StorageReadPermission? permissionRead,@JsonKey(name: 'permission_write') StorageWritePermission? permissionWrite,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime
+});
+
+
+
+
+}
+/// @nodoc
+class __$StorageObjectCopyWithImpl<$Res>
+    implements _$StorageObjectCopyWith<$Res> {
+  __$StorageObjectCopyWithImpl(this._self, this._then);
+
+  final _StorageObject _self;
+  final $Res Function(_StorageObject) _then;
+
+/// Create a copy of StorageObject
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? collection = null,Object? key = null,Object? userId = freezed,Object? value = null,Object? version = null,Object? permissionRead = freezed,Object? permissionWrite = freezed,Object? createTime = freezed,Object? updateTime = freezed,}) {
+  return _then(_StorageObject(
+collection: null == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
+as String,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String,version: null == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String,permissionRead: freezed == permissionRead ? _self.permissionRead : permissionRead // ignore: cast_nullable_to_non_nullable
+as StorageReadPermission?,permissionWrite: freezed == permissionWrite ? _self.permissionWrite : permissionWrite // ignore: cast_nullable_to_non_nullable
+as StorageWritePermission?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$StorageObjectList {
-  String? get cursor => throw _privateConstructorUsedError;
-  List<StorageObject> get objects => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $StorageObjectListCopyWith<StorageObjectList> get copyWith =>
-      throw _privateConstructorUsedError;
+ String? get cursor; List<StorageObject> get objects;
+/// Create a copy of StorageObjectList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StorageObjectListCopyWith<StorageObjectList> get copyWith => _$StorageObjectListCopyWithImpl<StorageObjectList>(this as StorageObjectList, _$identity);
+
+  /// Serializes this StorageObjectList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StorageObjectList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.objects, objects));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(objects));
+
+@override
+String toString() {
+  return 'StorageObjectList(cursor: $cursor, objects: $objects)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $StorageObjectListCopyWith<$Res> {
-  factory $StorageObjectListCopyWith(
-          StorageObjectList value, $Res Function(StorageObjectList) then) =
-      _$StorageObjectListCopyWithImpl<$Res, StorageObjectList>;
-  @useResult
-  $Res call({String? cursor, List<StorageObject> objects});
-}
+abstract mixin class $StorageObjectListCopyWith<$Res>  {
+  factory $StorageObjectListCopyWith(StorageObjectList value, $Res Function(StorageObjectList) _then) = _$StorageObjectListCopyWithImpl;
+@useResult
+$Res call({
+ String? cursor, List<StorageObject> objects
+});
 
+
+
+
+}
 /// @nodoc
-class _$StorageObjectListCopyWithImpl<$Res, $Val extends StorageObjectList>
+class _$StorageObjectListCopyWithImpl<$Res>
     implements $StorageObjectListCopyWith<$Res> {
-  _$StorageObjectListCopyWithImpl(this._value, this._then);
+  _$StorageObjectListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final StorageObjectList _self;
+  final $Res Function(StorageObjectList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? objects = null,
-  }) {
-    return _then(_value.copyWith(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      objects: null == objects
-          ? _value.objects
-          : objects // ignore: cast_nullable_to_non_nullable
-              as List<StorageObject>,
-    ) as $Val);
-  }
+/// Create a copy of StorageObjectList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? objects = null,}) {
+  return _then(_self.copyWith(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,objects: null == objects ? _self.objects : objects // ignore: cast_nullable_to_non_nullable
+as List<StorageObject>,
+  ));
 }
 
-/// @nodoc
-abstract class _$$StorageObjectListImplCopyWith<$Res>
-    implements $StorageObjectListCopyWith<$Res> {
-  factory _$$StorageObjectListImplCopyWith(_$StorageObjectListImpl value,
-          $Res Function(_$StorageObjectListImpl) then) =
-      __$$StorageObjectListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? cursor, List<StorageObject> objects});
 }
 
-/// @nodoc
-class __$$StorageObjectListImplCopyWithImpl<$Res>
-    extends _$StorageObjectListCopyWithImpl<$Res, _$StorageObjectListImpl>
-    implements _$$StorageObjectListImplCopyWith<$Res> {
-  __$$StorageObjectListImplCopyWithImpl(_$StorageObjectListImpl _value,
-      $Res Function(_$StorageObjectListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? objects = null,
-  }) {
-    return _then(_$StorageObjectListImpl(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      objects: null == objects
-          ? _value._objects
-          : objects // ignore: cast_nullable_to_non_nullable
-              as List<StorageObject>,
-    ));
-  }
+/// Adds pattern-matching-related methods to [StorageObjectList].
+extension StorageObjectListPatterns on StorageObjectList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _StorageObjectList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _StorageObjectList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _StorageObjectList value)  $default,){
+final _that = this;
+switch (_that) {
+case _StorageObjectList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _StorageObjectList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _StorageObjectList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor,  List<StorageObject> objects)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _StorageObjectList() when $default != null:
+return $default(_that.cursor,_that.objects);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor,  List<StorageObject> objects)  $default,) {final _that = this;
+switch (_that) {
+case _StorageObjectList():
+return $default(_that.cursor,_that.objects);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor,  List<StorageObject> objects)?  $default,) {final _that = this;
+switch (_that) {
+case _StorageObjectList() when $default != null:
+return $default(_that.cursor,_that.objects);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$StorageObjectListImpl extends _StorageObjectList {
-  const _$StorageObjectListImpl(
-      {this.cursor, required final List<StorageObject> objects})
-      : _objects = objects,
-        super._();
 
-  factory _$StorageObjectListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$StorageObjectListImplFromJson(json);
+class _StorageObjectList extends StorageObjectList {
+  const _StorageObjectList({this.cursor, required final  List<StorageObject> objects}): _objects = objects,super._();
+  factory _StorageObjectList.fromJson(Map<String, dynamic> json) => _$StorageObjectListFromJson(json);
 
-  @override
-  final String? cursor;
-  final List<StorageObject> _objects;
-  @override
-  List<StorageObject> get objects {
-    if (_objects is EqualUnmodifiableListView) return _objects;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_objects);
-  }
-
-  @override
-  String toString() {
-    return 'StorageObjectList(cursor: $cursor, objects: $objects)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$StorageObjectListImpl &&
-            (identical(other.cursor, cursor) || other.cursor == cursor) &&
-            const DeepCollectionEquality().equals(other._objects, _objects));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, cursor, const DeepCollectionEquality().hash(_objects));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$StorageObjectListImplCopyWith<_$StorageObjectListImpl> get copyWith =>
-      __$$StorageObjectListImplCopyWithImpl<_$StorageObjectListImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$StorageObjectListImplToJson(
-      this,
-    );
-  }
+@override final  String? cursor;
+ final  List<StorageObject> _objects;
+@override List<StorageObject> get objects {
+  if (_objects is EqualUnmodifiableListView) return _objects;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_objects);
 }
 
-abstract class _StorageObjectList extends StorageObjectList {
-  const factory _StorageObjectList(
-      {final String? cursor,
-      required final List<StorageObject> objects}) = _$StorageObjectListImpl;
-  const _StorageObjectList._() : super._();
 
-  factory _StorageObjectList.fromJson(Map<String, dynamic> json) =
-      _$StorageObjectListImpl.fromJson;
+/// Create a copy of StorageObjectList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$StorageObjectListCopyWith<_StorageObjectList> get copyWith => __$StorageObjectListCopyWithImpl<_StorageObjectList>(this, _$identity);
 
-  @override
-  String? get cursor;
-  @override
-  List<StorageObject> get objects;
-  @override
-  @JsonKey(ignore: true)
-  _$$StorageObjectListImplCopyWith<_$StorageObjectListImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$StorageObjectListToJson(this, );
 }
 
-StorageObjectId _$StorageObjectIdFromJson(Map<String, dynamic> json) {
-  return _StorageObjectId.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StorageObjectList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._objects, _objects));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(_objects));
+
+@override
+String toString() {
+  return 'StorageObjectList(cursor: $cursor, objects: $objects)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$StorageObjectListCopyWith<$Res> implements $StorageObjectListCopyWith<$Res> {
+  factory _$StorageObjectListCopyWith(_StorageObjectList value, $Res Function(_StorageObjectList) _then) = __$StorageObjectListCopyWithImpl;
+@override @useResult
+$Res call({
+ String? cursor, List<StorageObject> objects
+});
+
+
+
+
+}
+/// @nodoc
+class __$StorageObjectListCopyWithImpl<$Res>
+    implements _$StorageObjectListCopyWith<$Res> {
+  __$StorageObjectListCopyWithImpl(this._self, this._then);
+
+  final _StorageObjectList _self;
+  final $Res Function(_StorageObjectList) _then;
+
+/// Create a copy of StorageObjectList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? objects = null,}) {
+  return _then(_StorageObjectList(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,objects: null == objects ? _self._objects : objects // ignore: cast_nullable_to_non_nullable
+as List<StorageObject>,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$StorageObjectId {
-  @JsonKey(name: 'collection')
-  String get collection => throw _privateConstructorUsedError;
-  @JsonKey(name: 'key')
-  String get key => throw _privateConstructorUsedError;
-  @JsonKey(name: 'user_id')
-  String? get userId => throw _privateConstructorUsedError;
-  @JsonKey(name: 'version')
-  String? get version => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $StorageObjectIdCopyWith<StorageObjectId> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'collection') String get collection;@JsonKey(name: 'key') String get key;@JsonKey(name: 'user_id') String? get userId;@JsonKey(name: 'version') String? get version;
+/// Create a copy of StorageObjectId
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StorageObjectIdCopyWith<StorageObjectId> get copyWith => _$StorageObjectIdCopyWithImpl<StorageObjectId>(this as StorageObjectId, _$identity);
+
+  /// Serializes this StorageObjectId to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StorageObjectId&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.key, key) || other.key == key)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.version, version) || other.version == version));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,collection,key,userId,version);
+
+@override
+String toString() {
+  return 'StorageObjectId(collection: $collection, key: $key, userId: $userId, version: $version)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $StorageObjectIdCopyWith<$Res> {
-  factory $StorageObjectIdCopyWith(
-          StorageObjectId value, $Res Function(StorageObjectId) then) =
-      _$StorageObjectIdCopyWithImpl<$Res, StorageObjectId>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'collection') String collection,
-      @JsonKey(name: 'key') String key,
-      @JsonKey(name: 'user_id') String? userId,
-      @JsonKey(name: 'version') String? version});
-}
+abstract mixin class $StorageObjectIdCopyWith<$Res>  {
+  factory $StorageObjectIdCopyWith(StorageObjectId value, $Res Function(StorageObjectId) _then) = _$StorageObjectIdCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'collection') String collection,@JsonKey(name: 'key') String key,@JsonKey(name: 'user_id') String? userId,@JsonKey(name: 'version') String? version
+});
 
+
+
+
+}
 /// @nodoc
-class _$StorageObjectIdCopyWithImpl<$Res, $Val extends StorageObjectId>
+class _$StorageObjectIdCopyWithImpl<$Res>
     implements $StorageObjectIdCopyWith<$Res> {
-  _$StorageObjectIdCopyWithImpl(this._value, this._then);
+  _$StorageObjectIdCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final StorageObjectId _self;
+  final $Res Function(StorageObjectId) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? collection = null,
-    Object? key = null,
-    Object? userId = freezed,
-    Object? version = freezed,
-  }) {
-    return _then(_value.copyWith(
-      collection: null == collection
-          ? _value.collection
-          : collection // ignore: cast_nullable_to_non_nullable
-              as String,
-      key: null == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: freezed == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      version: freezed == version
-          ? _value.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of StorageObjectId
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? collection = null,Object? key = null,Object? userId = freezed,Object? version = freezed,}) {
+  return _then(_self.copyWith(
+collection: null == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
+as String,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,version: freezed == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$StorageObjectIdImplCopyWith<$Res>
-    implements $StorageObjectIdCopyWith<$Res> {
-  factory _$$StorageObjectIdImplCopyWith(_$StorageObjectIdImpl value,
-          $Res Function(_$StorageObjectIdImpl) then) =
-      __$$StorageObjectIdImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'collection') String collection,
-      @JsonKey(name: 'key') String key,
-      @JsonKey(name: 'user_id') String? userId,
-      @JsonKey(name: 'version') String? version});
 }
 
-/// @nodoc
-class __$$StorageObjectIdImplCopyWithImpl<$Res>
-    extends _$StorageObjectIdCopyWithImpl<$Res, _$StorageObjectIdImpl>
-    implements _$$StorageObjectIdImplCopyWith<$Res> {
-  __$$StorageObjectIdImplCopyWithImpl(
-      _$StorageObjectIdImpl _value, $Res Function(_$StorageObjectIdImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? collection = null,
-    Object? key = null,
-    Object? userId = freezed,
-    Object? version = freezed,
-  }) {
-    return _then(_$StorageObjectIdImpl(
-      collection: null == collection
-          ? _value.collection
-          : collection // ignore: cast_nullable_to_non_nullable
-              as String,
-      key: null == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: freezed == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      version: freezed == version
-          ? _value.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [StorageObjectId].
+extension StorageObjectIdPatterns on StorageObjectId {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _StorageObjectId value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _StorageObjectId() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _StorageObjectId value)  $default,){
+final _that = this;
+switch (_that) {
+case _StorageObjectId():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _StorageObjectId value)?  $default,){
+final _that = this;
+switch (_that) {
+case _StorageObjectId() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'user_id')  String? userId, @JsonKey(name: 'version')  String? version)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _StorageObjectId() when $default != null:
+return $default(_that.collection,_that.key,_that.userId,_that.version);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'user_id')  String? userId, @JsonKey(name: 'version')  String? version)  $default,) {final _that = this;
+switch (_that) {
+case _StorageObjectId():
+return $default(_that.collection,_that.key,_that.userId,_that.version);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'user_id')  String? userId, @JsonKey(name: 'version')  String? version)?  $default,) {final _that = this;
+switch (_that) {
+case _StorageObjectId() when $default != null:
+return $default(_that.collection,_that.key,_that.userId,_that.version);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$StorageObjectIdImpl extends _StorageObjectId {
-  const _$StorageObjectIdImpl(
-      {@JsonKey(name: 'collection') required this.collection,
-      @JsonKey(name: 'key') required this.key,
-      @JsonKey(name: 'user_id') this.userId,
-      @JsonKey(name: 'version') this.version})
-      : super._();
 
-  factory _$StorageObjectIdImpl.fromJson(Map<String, dynamic> json) =>
-      _$$StorageObjectIdImplFromJson(json);
+class _StorageObjectId extends StorageObjectId {
+  const _StorageObjectId({@JsonKey(name: 'collection') required this.collection, @JsonKey(name: 'key') required this.key, @JsonKey(name: 'user_id') this.userId, @JsonKey(name: 'version') this.version}): super._();
+  factory _StorageObjectId.fromJson(Map<String, dynamic> json) => _$StorageObjectIdFromJson(json);
 
-  @override
-  @JsonKey(name: 'collection')
-  final String collection;
-  @override
-  @JsonKey(name: 'key')
-  final String key;
-  @override
-  @JsonKey(name: 'user_id')
-  final String? userId;
-  @override
-  @JsonKey(name: 'version')
-  final String? version;
+@override@JsonKey(name: 'collection') final  String collection;
+@override@JsonKey(name: 'key') final  String key;
+@override@JsonKey(name: 'user_id') final  String? userId;
+@override@JsonKey(name: 'version') final  String? version;
 
-  @override
-  String toString() {
-    return 'StorageObjectId(collection: $collection, key: $key, userId: $userId, version: $version)';
-  }
+/// Create a copy of StorageObjectId
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$StorageObjectIdCopyWith<_StorageObjectId> get copyWith => __$StorageObjectIdCopyWithImpl<_StorageObjectId>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$StorageObjectIdImpl &&
-            (identical(other.collection, collection) ||
-                other.collection == collection) &&
-            (identical(other.key, key) || other.key == key) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.version, version) || other.version == version));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, collection, key, userId, version);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$StorageObjectIdImplCopyWith<_$StorageObjectIdImpl> get copyWith =>
-      __$$StorageObjectIdImplCopyWithImpl<_$StorageObjectIdImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$StorageObjectIdImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$StorageObjectIdToJson(this, );
 }
 
-abstract class _StorageObjectId extends StorageObjectId {
-  const factory _StorageObjectId(
-      {@JsonKey(name: 'collection') required final String collection,
-      @JsonKey(name: 'key') required final String key,
-      @JsonKey(name: 'user_id') final String? userId,
-      @JsonKey(name: 'version') final String? version}) = _$StorageObjectIdImpl;
-  const _StorageObjectId._() : super._();
-
-  factory _StorageObjectId.fromJson(Map<String, dynamic> json) =
-      _$StorageObjectIdImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'collection')
-  String get collection;
-  @override
-  @JsonKey(name: 'key')
-  String get key;
-  @override
-  @JsonKey(name: 'user_id')
-  String? get userId;
-  @override
-  @JsonKey(name: 'version')
-  String? get version;
-  @override
-  @JsonKey(ignore: true)
-  _$$StorageObjectIdImplCopyWith<_$StorageObjectIdImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StorageObjectId&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.key, key) || other.key == key)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.version, version) || other.version == version));
 }
 
-StorageObjectWrite _$StorageObjectWriteFromJson(Map<String, dynamic> json) {
-  return _StorageObjectWrite.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,collection,key,userId,version);
+
+@override
+String toString() {
+  return 'StorageObjectId(collection: $collection, key: $key, userId: $userId, version: $version)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$StorageObjectIdCopyWith<$Res> implements $StorageObjectIdCopyWith<$Res> {
+  factory _$StorageObjectIdCopyWith(_StorageObjectId value, $Res Function(_StorageObjectId) _then) = __$StorageObjectIdCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'collection') String collection,@JsonKey(name: 'key') String key,@JsonKey(name: 'user_id') String? userId,@JsonKey(name: 'version') String? version
+});
+
+
+
+
+}
+/// @nodoc
+class __$StorageObjectIdCopyWithImpl<$Res>
+    implements _$StorageObjectIdCopyWith<$Res> {
+  __$StorageObjectIdCopyWithImpl(this._self, this._then);
+
+  final _StorageObjectId _self;
+  final $Res Function(_StorageObjectId) _then;
+
+/// Create a copy of StorageObjectId
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? collection = null,Object? key = null,Object? userId = freezed,Object? version = freezed,}) {
+  return _then(_StorageObjectId(
+collection: null == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
+as String,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,version: freezed == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$StorageObjectWrite {
-  @JsonKey(name: 'collection')
-  String get collection => throw _privateConstructorUsedError;
-  @JsonKey(name: 'key')
-  String get key => throw _privateConstructorUsedError;
-  @JsonKey(name: 'value')
-  String get value => throw _privateConstructorUsedError;
-  @JsonKey(name: 'version')
-  String? get version => throw _privateConstructorUsedError;
-  @JsonKey(name: 'permission_read')
-  StorageReadPermission? get permissionRead =>
-      throw _privateConstructorUsedError;
-  @JsonKey(name: 'permission_write')
-  StorageWritePermission? get permissionWrite =>
-      throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $StorageObjectWriteCopyWith<StorageObjectWrite> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'collection') String get collection;@JsonKey(name: 'key') String get key;@JsonKey(name: 'value') String get value;@JsonKey(name: 'version') String? get version;@JsonKey(name: 'permission_read') StorageReadPermission? get permissionRead;@JsonKey(name: 'permission_write') StorageWritePermission? get permissionWrite;
+/// Create a copy of StorageObjectWrite
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StorageObjectWriteCopyWith<StorageObjectWrite> get copyWith => _$StorageObjectWriteCopyWithImpl<StorageObjectWrite>(this as StorageObjectWrite, _$identity);
+
+  /// Serializes this StorageObjectWrite to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StorageObjectWrite&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.version, version) || other.version == version)&&(identical(other.permissionRead, permissionRead) || other.permissionRead == permissionRead)&&(identical(other.permissionWrite, permissionWrite) || other.permissionWrite == permissionWrite));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,collection,key,value,version,permissionRead,permissionWrite);
+
+@override
+String toString() {
+  return 'StorageObjectWrite(collection: $collection, key: $key, value: $value, version: $version, permissionRead: $permissionRead, permissionWrite: $permissionWrite)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $StorageObjectWriteCopyWith<$Res> {
-  factory $StorageObjectWriteCopyWith(
-          StorageObjectWrite value, $Res Function(StorageObjectWrite) then) =
-      _$StorageObjectWriteCopyWithImpl<$Res, StorageObjectWrite>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'collection') String collection,
-      @JsonKey(name: 'key') String key,
-      @JsonKey(name: 'value') String value,
-      @JsonKey(name: 'version') String? version,
-      @JsonKey(name: 'permission_read') StorageReadPermission? permissionRead,
-      @JsonKey(name: 'permission_write')
-      StorageWritePermission? permissionWrite});
-}
+abstract mixin class $StorageObjectWriteCopyWith<$Res>  {
+  factory $StorageObjectWriteCopyWith(StorageObjectWrite value, $Res Function(StorageObjectWrite) _then) = _$StorageObjectWriteCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'collection') String collection,@JsonKey(name: 'key') String key,@JsonKey(name: 'value') String value,@JsonKey(name: 'version') String? version,@JsonKey(name: 'permission_read') StorageReadPermission? permissionRead,@JsonKey(name: 'permission_write') StorageWritePermission? permissionWrite
+});
 
+
+
+
+}
 /// @nodoc
-class _$StorageObjectWriteCopyWithImpl<$Res, $Val extends StorageObjectWrite>
+class _$StorageObjectWriteCopyWithImpl<$Res>
     implements $StorageObjectWriteCopyWith<$Res> {
-  _$StorageObjectWriteCopyWithImpl(this._value, this._then);
+  _$StorageObjectWriteCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final StorageObjectWrite _self;
+  final $Res Function(StorageObjectWrite) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? collection = null,
-    Object? key = null,
-    Object? value = null,
-    Object? version = freezed,
-    Object? permissionRead = freezed,
-    Object? permissionWrite = freezed,
-  }) {
-    return _then(_value.copyWith(
-      collection: null == collection
-          ? _value.collection
-          : collection // ignore: cast_nullable_to_non_nullable
-              as String,
-      key: null == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      value: null == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String,
-      version: freezed == version
-          ? _value.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String?,
-      permissionRead: freezed == permissionRead
-          ? _value.permissionRead
-          : permissionRead // ignore: cast_nullable_to_non_nullable
-              as StorageReadPermission?,
-      permissionWrite: freezed == permissionWrite
-          ? _value.permissionWrite
-          : permissionWrite // ignore: cast_nullable_to_non_nullable
-              as StorageWritePermission?,
-    ) as $Val);
-  }
+/// Create a copy of StorageObjectWrite
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? collection = null,Object? key = null,Object? value = null,Object? version = freezed,Object? permissionRead = freezed,Object? permissionWrite = freezed,}) {
+  return _then(_self.copyWith(
+collection: null == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
+as String,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String,value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String,version: freezed == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String?,permissionRead: freezed == permissionRead ? _self.permissionRead : permissionRead // ignore: cast_nullable_to_non_nullable
+as StorageReadPermission?,permissionWrite: freezed == permissionWrite ? _self.permissionWrite : permissionWrite // ignore: cast_nullable_to_non_nullable
+as StorageWritePermission?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$StorageObjectWriteImplCopyWith<$Res>
-    implements $StorageObjectWriteCopyWith<$Res> {
-  factory _$$StorageObjectWriteImplCopyWith(_$StorageObjectWriteImpl value,
-          $Res Function(_$StorageObjectWriteImpl) then) =
-      __$$StorageObjectWriteImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'collection') String collection,
-      @JsonKey(name: 'key') String key,
-      @JsonKey(name: 'value') String value,
-      @JsonKey(name: 'version') String? version,
-      @JsonKey(name: 'permission_read') StorageReadPermission? permissionRead,
-      @JsonKey(name: 'permission_write')
-      StorageWritePermission? permissionWrite});
 }
 
-/// @nodoc
-class __$$StorageObjectWriteImplCopyWithImpl<$Res>
-    extends _$StorageObjectWriteCopyWithImpl<$Res, _$StorageObjectWriteImpl>
-    implements _$$StorageObjectWriteImplCopyWith<$Res> {
-  __$$StorageObjectWriteImplCopyWithImpl(_$StorageObjectWriteImpl _value,
-      $Res Function(_$StorageObjectWriteImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? collection = null,
-    Object? key = null,
-    Object? value = null,
-    Object? version = freezed,
-    Object? permissionRead = freezed,
-    Object? permissionWrite = freezed,
-  }) {
-    return _then(_$StorageObjectWriteImpl(
-      collection: null == collection
-          ? _value.collection
-          : collection // ignore: cast_nullable_to_non_nullable
-              as String,
-      key: null == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      value: null == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String,
-      version: freezed == version
-          ? _value.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String?,
-      permissionRead: freezed == permissionRead
-          ? _value.permissionRead
-          : permissionRead // ignore: cast_nullable_to_non_nullable
-              as StorageReadPermission?,
-      permissionWrite: freezed == permissionWrite
-          ? _value.permissionWrite
-          : permissionWrite // ignore: cast_nullable_to_non_nullable
-              as StorageWritePermission?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [StorageObjectWrite].
+extension StorageObjectWritePatterns on StorageObjectWrite {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _StorageObjectWrite value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _StorageObjectWrite() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _StorageObjectWrite value)  $default,){
+final _that = this;
+switch (_that) {
+case _StorageObjectWrite():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _StorageObjectWrite value)?  $default,){
+final _that = this;
+switch (_that) {
+case _StorageObjectWrite() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'value')  String value, @JsonKey(name: 'version')  String? version, @JsonKey(name: 'permission_read')  StorageReadPermission? permissionRead, @JsonKey(name: 'permission_write')  StorageWritePermission? permissionWrite)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _StorageObjectWrite() when $default != null:
+return $default(_that.collection,_that.key,_that.value,_that.version,_that.permissionRead,_that.permissionWrite);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'value')  String value, @JsonKey(name: 'version')  String? version, @JsonKey(name: 'permission_read')  StorageReadPermission? permissionRead, @JsonKey(name: 'permission_write')  StorageWritePermission? permissionWrite)  $default,) {final _that = this;
+switch (_that) {
+case _StorageObjectWrite():
+return $default(_that.collection,_that.key,_that.value,_that.version,_that.permissionRead,_that.permissionWrite);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'collection')  String collection, @JsonKey(name: 'key')  String key, @JsonKey(name: 'value')  String value, @JsonKey(name: 'version')  String? version, @JsonKey(name: 'permission_read')  StorageReadPermission? permissionRead, @JsonKey(name: 'permission_write')  StorageWritePermission? permissionWrite)?  $default,) {final _that = this;
+switch (_that) {
+case _StorageObjectWrite() when $default != null:
+return $default(_that.collection,_that.key,_that.value,_that.version,_that.permissionRead,_that.permissionWrite);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$StorageObjectWriteImpl extends _StorageObjectWrite {
-  const _$StorageObjectWriteImpl(
-      {@JsonKey(name: 'collection') required this.collection,
-      @JsonKey(name: 'key') required this.key,
-      @JsonKey(name: 'value') required this.value,
-      @JsonKey(name: 'version') this.version,
-      @JsonKey(name: 'permission_read') this.permissionRead,
-      @JsonKey(name: 'permission_write') this.permissionWrite})
-      : super._();
 
-  factory _$StorageObjectWriteImpl.fromJson(Map<String, dynamic> json) =>
-      _$$StorageObjectWriteImplFromJson(json);
+class _StorageObjectWrite extends StorageObjectWrite {
+  const _StorageObjectWrite({@JsonKey(name: 'collection') required this.collection, @JsonKey(name: 'key') required this.key, @JsonKey(name: 'value') required this.value, @JsonKey(name: 'version') this.version, @JsonKey(name: 'permission_read') this.permissionRead, @JsonKey(name: 'permission_write') this.permissionWrite}): super._();
+  factory _StorageObjectWrite.fromJson(Map<String, dynamic> json) => _$StorageObjectWriteFromJson(json);
 
-  @override
-  @JsonKey(name: 'collection')
-  final String collection;
-  @override
-  @JsonKey(name: 'key')
-  final String key;
-  @override
-  @JsonKey(name: 'value')
-  final String value;
-  @override
-  @JsonKey(name: 'version')
-  final String? version;
-  @override
-  @JsonKey(name: 'permission_read')
-  final StorageReadPermission? permissionRead;
-  @override
-  @JsonKey(name: 'permission_write')
-  final StorageWritePermission? permissionWrite;
+@override@JsonKey(name: 'collection') final  String collection;
+@override@JsonKey(name: 'key') final  String key;
+@override@JsonKey(name: 'value') final  String value;
+@override@JsonKey(name: 'version') final  String? version;
+@override@JsonKey(name: 'permission_read') final  StorageReadPermission? permissionRead;
+@override@JsonKey(name: 'permission_write') final  StorageWritePermission? permissionWrite;
 
-  @override
-  String toString() {
-    return 'StorageObjectWrite(collection: $collection, key: $key, value: $value, version: $version, permissionRead: $permissionRead, permissionWrite: $permissionWrite)';
-  }
+/// Create a copy of StorageObjectWrite
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$StorageObjectWriteCopyWith<_StorageObjectWrite> get copyWith => __$StorageObjectWriteCopyWithImpl<_StorageObjectWrite>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$StorageObjectWriteImpl &&
-            (identical(other.collection, collection) ||
-                other.collection == collection) &&
-            (identical(other.key, key) || other.key == key) &&
-            (identical(other.value, value) || other.value == value) &&
-            (identical(other.version, version) || other.version == version) &&
-            (identical(other.permissionRead, permissionRead) ||
-                other.permissionRead == permissionRead) &&
-            (identical(other.permissionWrite, permissionWrite) ||
-                other.permissionWrite == permissionWrite));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, collection, key, value, version,
-      permissionRead, permissionWrite);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$StorageObjectWriteImplCopyWith<_$StorageObjectWriteImpl> get copyWith =>
-      __$$StorageObjectWriteImplCopyWithImpl<_$StorageObjectWriteImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$StorageObjectWriteImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$StorageObjectWriteToJson(this, );
 }
 
-abstract class _StorageObjectWrite extends StorageObjectWrite {
-  const factory _StorageObjectWrite(
-          {@JsonKey(name: 'collection') required final String collection,
-          @JsonKey(name: 'key') required final String key,
-          @JsonKey(name: 'value') required final String value,
-          @JsonKey(name: 'version') final String? version,
-          @JsonKey(name: 'permission_read')
-          final StorageReadPermission? permissionRead,
-          @JsonKey(name: 'permission_write')
-          final StorageWritePermission? permissionWrite}) =
-      _$StorageObjectWriteImpl;
-  const _StorageObjectWrite._() : super._();
-
-  factory _StorageObjectWrite.fromJson(Map<String, dynamic> json) =
-      _$StorageObjectWriteImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'collection')
-  String get collection;
-  @override
-  @JsonKey(name: 'key')
-  String get key;
-  @override
-  @JsonKey(name: 'value')
-  String get value;
-  @override
-  @JsonKey(name: 'version')
-  String? get version;
-  @override
-  @JsonKey(name: 'permission_read')
-  StorageReadPermission? get permissionRead;
-  @override
-  @JsonKey(name: 'permission_write')
-  StorageWritePermission? get permissionWrite;
-  @override
-  @JsonKey(ignore: true)
-  _$$StorageObjectWriteImplCopyWith<_$StorageObjectWriteImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StorageObjectWrite&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.version, version) || other.version == version)&&(identical(other.permissionRead, permissionRead) || other.permissionRead == permissionRead)&&(identical(other.permissionWrite, permissionWrite) || other.permissionWrite == permissionWrite));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,collection,key,value,version,permissionRead,permissionWrite);
+
+@override
+String toString() {
+  return 'StorageObjectWrite(collection: $collection, key: $key, value: $value, version: $version, permissionRead: $permissionRead, permissionWrite: $permissionWrite)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$StorageObjectWriteCopyWith<$Res> implements $StorageObjectWriteCopyWith<$Res> {
+  factory _$StorageObjectWriteCopyWith(_StorageObjectWrite value, $Res Function(_StorageObjectWrite) _then) = __$StorageObjectWriteCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'collection') String collection,@JsonKey(name: 'key') String key,@JsonKey(name: 'value') String value,@JsonKey(name: 'version') String? version,@JsonKey(name: 'permission_read') StorageReadPermission? permissionRead,@JsonKey(name: 'permission_write') StorageWritePermission? permissionWrite
+});
+
+
+
+
+}
+/// @nodoc
+class __$StorageObjectWriteCopyWithImpl<$Res>
+    implements _$StorageObjectWriteCopyWith<$Res> {
+  __$StorageObjectWriteCopyWithImpl(this._self, this._then);
+
+  final _StorageObjectWrite _self;
+  final $Res Function(_StorageObjectWrite) _then;
+
+/// Create a copy of StorageObjectWrite
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? collection = null,Object? key = null,Object? value = null,Object? version = freezed,Object? permissionRead = freezed,Object? permissionWrite = freezed,}) {
+  return _then(_StorageObjectWrite(
+collection: null == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
+as String,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String,value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String,version: freezed == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String?,permissionRead: freezed == permissionRead ? _self.permissionRead : permissionRead // ignore: cast_nullable_to_non_nullable
+as StorageReadPermission?,permissionWrite: freezed == permissionWrite ? _self.permissionWrite : permissionWrite // ignore: cast_nullable_to_non_nullable
+as StorageWritePermission?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/nakama/lib/src/models/storage.g.dart
+++ b/nakama/lib/src/models/storage.g.dart
@@ -6,17 +6,21 @@ part of 'storage.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$StorageObjectImpl _$$StorageObjectImplFromJson(Map<String, dynamic> json) =>
-    _$StorageObjectImpl(
+_StorageObject _$StorageObjectFromJson(Map<String, dynamic> json) =>
+    _StorageObject(
       collection: json['collection'] as String,
       key: json['key'] as String,
       userId: json['user_id'] as String?,
       value: json['value'] as String,
       version: json['version'] as String,
       permissionRead: $enumDecodeNullable(
-          _$StorageReadPermissionEnumMap, json['permission_read']),
+        _$StorageReadPermissionEnumMap,
+        json['permission_read'],
+      ),
       permissionWrite: $enumDecodeNullable(
-          _$StorageWritePermissionEnumMap, json['permission_write']),
+        _$StorageWritePermissionEnumMap,
+        json['permission_write'],
+      ),
       createTime: json['create_time'] == null
           ? null
           : DateTime.parse(json['create_time'] as String),
@@ -25,20 +29,19 @@ _$StorageObjectImpl _$$StorageObjectImplFromJson(Map<String, dynamic> json) =>
           : DateTime.parse(json['update_time'] as String),
     );
 
-Map<String, dynamic> _$$StorageObjectImplToJson(_$StorageObjectImpl instance) =>
-    <String, dynamic>{
-      'collection': instance.collection,
-      'key': instance.key,
-      'user_id': instance.userId,
-      'value': instance.value,
-      'version': instance.version,
-      'permission_read':
-          _$StorageReadPermissionEnumMap[instance.permissionRead],
-      'permission_write':
-          _$StorageWritePermissionEnumMap[instance.permissionWrite],
-      'create_time': instance.createTime?.toIso8601String(),
-      'update_time': instance.updateTime?.toIso8601String(),
-    };
+Map<String, dynamic> _$StorageObjectToJson(
+  _StorageObject instance,
+) => <String, dynamic>{
+  'collection': instance.collection,
+  'key': instance.key,
+  'user_id': instance.userId,
+  'value': instance.value,
+  'version': instance.version,
+  'permission_read': _$StorageReadPermissionEnumMap[instance.permissionRead],
+  'permission_write': _$StorageWritePermissionEnumMap[instance.permissionWrite],
+  'create_time': instance.createTime?.toIso8601String(),
+  'update_time': instance.updateTime?.toIso8601String(),
+};
 
 const _$StorageReadPermissionEnumMap = {
   StorageReadPermission.noRead: 0,
@@ -51,33 +54,26 @@ const _$StorageWritePermissionEnumMap = {
   StorageWritePermission.ownerWrite: 1,
 };
 
-_$StorageObjectListImpl _$$StorageObjectListImplFromJson(
-        Map<String, dynamic> json) =>
-    _$StorageObjectListImpl(
+_StorageObjectList _$StorageObjectListFromJson(Map<String, dynamic> json) =>
+    _StorageObjectList(
       cursor: json['cursor'] as String?,
       objects: (json['objects'] as List<dynamic>)
           .map((e) => StorageObject.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$StorageObjectListImplToJson(
-        _$StorageObjectListImpl instance) =>
-    <String, dynamic>{
-      'cursor': instance.cursor,
-      'objects': instance.objects,
-    };
+Map<String, dynamic> _$StorageObjectListToJson(_StorageObjectList instance) =>
+    <String, dynamic>{'cursor': instance.cursor, 'objects': instance.objects};
 
-_$StorageObjectIdImpl _$$StorageObjectIdImplFromJson(
-        Map<String, dynamic> json) =>
-    _$StorageObjectIdImpl(
+_StorageObjectId _$StorageObjectIdFromJson(Map<String, dynamic> json) =>
+    _StorageObjectId(
       collection: json['collection'] as String,
       key: json['key'] as String,
       userId: json['user_id'] as String?,
       version: json['version'] as String?,
     );
 
-Map<String, dynamic> _$$StorageObjectIdImplToJson(
-        _$StorageObjectIdImpl instance) =>
+Map<String, dynamic> _$StorageObjectIdToJson(_StorageObjectId instance) =>
     <String, dynamic>{
       'collection': instance.collection,
       'key': instance.key,
@@ -85,28 +81,29 @@ Map<String, dynamic> _$$StorageObjectIdImplToJson(
       'version': instance.version,
     };
 
-_$StorageObjectWriteImpl _$$StorageObjectWriteImplFromJson(
-        Map<String, dynamic> json) =>
-    _$StorageObjectWriteImpl(
+_StorageObjectWrite _$StorageObjectWriteFromJson(Map<String, dynamic> json) =>
+    _StorageObjectWrite(
       collection: json['collection'] as String,
       key: json['key'] as String,
       value: json['value'] as String,
       version: json['version'] as String?,
       permissionRead: $enumDecodeNullable(
-          _$StorageReadPermissionEnumMap, json['permission_read']),
+        _$StorageReadPermissionEnumMap,
+        json['permission_read'],
+      ),
       permissionWrite: $enumDecodeNullable(
-          _$StorageWritePermissionEnumMap, json['permission_write']),
+        _$StorageWritePermissionEnumMap,
+        json['permission_write'],
+      ),
     );
 
-Map<String, dynamic> _$$StorageObjectWriteImplToJson(
-        _$StorageObjectWriteImpl instance) =>
-    <String, dynamic>{
-      'collection': instance.collection,
-      'key': instance.key,
-      'value': instance.value,
-      'version': instance.version,
-      'permission_read':
-          _$StorageReadPermissionEnumMap[instance.permissionRead],
-      'permission_write':
-          _$StorageWritePermissionEnumMap[instance.permissionWrite],
-    };
+Map<String, dynamic> _$StorageObjectWriteToJson(
+  _StorageObjectWrite instance,
+) => <String, dynamic>{
+  'collection': instance.collection,
+  'key': instance.key,
+  'value': instance.value,
+  'version': instance.version,
+  'permission_read': _$StorageReadPermissionEnumMap[instance.permissionRead],
+  'permission_write': _$StorageWritePermissionEnumMap[instance.permissionWrite],
+};

--- a/nakama/lib/src/models/tournament.dart
+++ b/nakama/lib/src/models/tournament.dart
@@ -6,7 +6,7 @@ part 'tournament.freezed.dart';
 part 'tournament.g.dart';
 
 @freezed
-class Tournament with _$Tournament {
+sealed class Tournament with _$Tournament {
   const Tournament._();
 
   const factory Tournament({
@@ -55,7 +55,7 @@ class Tournament with _$Tournament {
 }
 
 @freezed
-class TournamentList with _$TournamentList {
+sealed class TournamentList with _$TournamentList {
   const TournamentList._();
 
   const factory TournamentList({
@@ -72,7 +72,7 @@ class TournamentList with _$TournamentList {
 }
 
 @freezed
-class TournamentRecordList with _$TournamentRecordList {
+sealed class TournamentRecordList with _$TournamentRecordList {
   const TournamentRecordList._();
 
   const factory TournamentRecordList({

--- a/nakama/lib/src/models/tournament.freezed.dart
+++ b/nakama/lib/src/models/tournament.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,984 +9,858 @@ part of 'tournament.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-Tournament _$TournamentFromJson(Map<String, dynamic> json) {
-  return _Tournament.fromJson(json);
-}
 
 /// @nodoc
 mixin _$Tournament {
-  @JsonKey(name: 'id')
-  String get id => throw _privateConstructorUsedError;
-  @JsonKey(name: 'title')
-  String? get title => throw _privateConstructorUsedError;
-  @JsonKey(name: 'description')
-  String? get description => throw _privateConstructorUsedError;
-  @JsonKey(name: 'category')
-  int? get category => throw _privateConstructorUsedError;
-  @JsonKey(name: 'sort_order')
-  int? get sortOrder => throw _privateConstructorUsedError;
-  @JsonKey(name: 'size')
-  int? get size => throw _privateConstructorUsedError;
-  @JsonKey(name: 'max_size')
-  int? get maxSize => throw _privateConstructorUsedError;
-  @JsonKey(name: 'max_num_score')
-  int? get maxNumScore => throw _privateConstructorUsedError;
-  @JsonKey(name: 'can_enter')
-  bool? get canEnter => throw _privateConstructorUsedError;
-  @JsonKey(name: 'end_active')
-  int? get endActive => throw _privateConstructorUsedError;
-  @JsonKey(name: 'next_reset')
-  int? get nextReset => throw _privateConstructorUsedError;
-  @JsonKey(name: 'metadata')
-  String? get metadata => throw _privateConstructorUsedError;
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'start_time')
-  DateTime? get startTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'end_time')
-  DateTime? get endTime => throw _privateConstructorUsedError;
-  @JsonKey(name: 'duration')
-  int? get duration => throw _privateConstructorUsedError;
-  @JsonKey(name: 'start_active')
-  int? get startActive => throw _privateConstructorUsedError;
-  @JsonKey(name: 'prev_reset')
-  int? get prevReset => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $TournamentCopyWith<Tournament> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'id') String get id;@JsonKey(name: 'title') String? get title;@JsonKey(name: 'description') String? get description;@JsonKey(name: 'category') int? get category;@JsonKey(name: 'sort_order') int? get sortOrder;@JsonKey(name: 'size') int? get size;@JsonKey(name: 'max_size') int? get maxSize;@JsonKey(name: 'max_num_score') int? get maxNumScore;@JsonKey(name: 'can_enter') bool? get canEnter;@JsonKey(name: 'end_active') int? get endActive;@JsonKey(name: 'next_reset') int? get nextReset;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'start_time') DateTime? get startTime;@JsonKey(name: 'end_time') DateTime? get endTime;@JsonKey(name: 'duration') int? get duration;@JsonKey(name: 'start_active') int? get startActive;@JsonKey(name: 'prev_reset') int? get prevReset;
+/// Create a copy of Tournament
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TournamentCopyWith<Tournament> get copyWith => _$TournamentCopyWithImpl<Tournament>(this as Tournament, _$identity);
+
+  /// Serializes this Tournament to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Tournament&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.category, category) || other.category == category)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.size, size) || other.size == size)&&(identical(other.maxSize, maxSize) || other.maxSize == maxSize)&&(identical(other.maxNumScore, maxNumScore) || other.maxNumScore == maxNumScore)&&(identical(other.canEnter, canEnter) || other.canEnter == canEnter)&&(identical(other.endActive, endActive) || other.endActive == endActive)&&(identical(other.nextReset, nextReset) || other.nextReset == nextReset)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.startActive, startActive) || other.startActive == startActive)&&(identical(other.prevReset, prevReset) || other.prevReset == prevReset));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,description,category,sortOrder,size,maxSize,maxNumScore,canEnter,endActive,nextReset,metadata,createTime,startTime,endTime,duration,startActive,prevReset);
+
+@override
+String toString() {
+  return 'Tournament(id: $id, title: $title, description: $description, category: $category, sortOrder: $sortOrder, size: $size, maxSize: $maxSize, maxNumScore: $maxNumScore, canEnter: $canEnter, endActive: $endActive, nextReset: $nextReset, metadata: $metadata, createTime: $createTime, startTime: $startTime, endTime: $endTime, duration: $duration, startActive: $startActive, prevReset: $prevReset)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $TournamentCopyWith<$Res> {
-  factory $TournamentCopyWith(
-          Tournament value, $Res Function(Tournament) then) =
-      _$TournamentCopyWithImpl<$Res, Tournament>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'id') String id,
-      @JsonKey(name: 'title') String? title,
-      @JsonKey(name: 'description') String? description,
-      @JsonKey(name: 'category') int? category,
-      @JsonKey(name: 'sort_order') int? sortOrder,
-      @JsonKey(name: 'size') int? size,
-      @JsonKey(name: 'max_size') int? maxSize,
-      @JsonKey(name: 'max_num_score') int? maxNumScore,
-      @JsonKey(name: 'can_enter') bool? canEnter,
-      @JsonKey(name: 'end_active') int? endActive,
-      @JsonKey(name: 'next_reset') int? nextReset,
-      @JsonKey(name: 'metadata') String? metadata,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'start_time') DateTime? startTime,
-      @JsonKey(name: 'end_time') DateTime? endTime,
-      @JsonKey(name: 'duration') int? duration,
-      @JsonKey(name: 'start_active') int? startActive,
-      @JsonKey(name: 'prev_reset') int? prevReset});
-}
+abstract mixin class $TournamentCopyWith<$Res>  {
+  factory $TournamentCopyWith(Tournament value, $Res Function(Tournament) _then) = _$TournamentCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'id') String id,@JsonKey(name: 'title') String? title,@JsonKey(name: 'description') String? description,@JsonKey(name: 'category') int? category,@JsonKey(name: 'sort_order') int? sortOrder,@JsonKey(name: 'size') int? size,@JsonKey(name: 'max_size') int? maxSize,@JsonKey(name: 'max_num_score') int? maxNumScore,@JsonKey(name: 'can_enter') bool? canEnter,@JsonKey(name: 'end_active') int? endActive,@JsonKey(name: 'next_reset') int? nextReset,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'start_time') DateTime? startTime,@JsonKey(name: 'end_time') DateTime? endTime,@JsonKey(name: 'duration') int? duration,@JsonKey(name: 'start_active') int? startActive,@JsonKey(name: 'prev_reset') int? prevReset
+});
 
+
+
+
+}
 /// @nodoc
-class _$TournamentCopyWithImpl<$Res, $Val extends Tournament>
+class _$TournamentCopyWithImpl<$Res>
     implements $TournamentCopyWith<$Res> {
-  _$TournamentCopyWithImpl(this._value, this._then);
+  _$TournamentCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Tournament _self;
+  final $Res Function(Tournament) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? title = freezed,
-    Object? description = freezed,
-    Object? category = freezed,
-    Object? sortOrder = freezed,
-    Object? size = freezed,
-    Object? maxSize = freezed,
-    Object? maxNumScore = freezed,
-    Object? canEnter = freezed,
-    Object? endActive = freezed,
-    Object? nextReset = freezed,
-    Object? metadata = freezed,
-    Object? createTime = freezed,
-    Object? startTime = freezed,
-    Object? endTime = freezed,
-    Object? duration = freezed,
-    Object? startActive = freezed,
-    Object? prevReset = freezed,
-  }) {
-    return _then(_value.copyWith(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      title: freezed == title
-          ? _value.title
-          : title // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _value.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      category: freezed == category
-          ? _value.category
-          : category // ignore: cast_nullable_to_non_nullable
-              as int?,
-      sortOrder: freezed == sortOrder
-          ? _value.sortOrder
-          : sortOrder // ignore: cast_nullable_to_non_nullable
-              as int?,
-      size: freezed == size
-          ? _value.size
-          : size // ignore: cast_nullable_to_non_nullable
-              as int?,
-      maxSize: freezed == maxSize
-          ? _value.maxSize
-          : maxSize // ignore: cast_nullable_to_non_nullable
-              as int?,
-      maxNumScore: freezed == maxNumScore
-          ? _value.maxNumScore
-          : maxNumScore // ignore: cast_nullable_to_non_nullable
-              as int?,
-      canEnter: freezed == canEnter
-          ? _value.canEnter
-          : canEnter // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      endActive: freezed == endActive
-          ? _value.endActive
-          : endActive // ignore: cast_nullable_to_non_nullable
-              as int?,
-      nextReset: freezed == nextReset
-          ? _value.nextReset
-          : nextReset // ignore: cast_nullable_to_non_nullable
-              as int?,
-      metadata: freezed == metadata
-          ? _value.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as String?,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      startTime: freezed == startTime
-          ? _value.startTime
-          : startTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      endTime: freezed == endTime
-          ? _value.endTime
-          : endTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      duration: freezed == duration
-          ? _value.duration
-          : duration // ignore: cast_nullable_to_non_nullable
-              as int?,
-      startActive: freezed == startActive
-          ? _value.startActive
-          : startActive // ignore: cast_nullable_to_non_nullable
-              as int?,
-      prevReset: freezed == prevReset
-          ? _value.prevReset
-          : prevReset // ignore: cast_nullable_to_non_nullable
-              as int?,
-    ) as $Val);
-  }
+/// Create a copy of Tournament
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = freezed,Object? description = freezed,Object? category = freezed,Object? sortOrder = freezed,Object? size = freezed,Object? maxSize = freezed,Object? maxNumScore = freezed,Object? canEnter = freezed,Object? endActive = freezed,Object? nextReset = freezed,Object? metadata = freezed,Object? createTime = freezed,Object? startTime = freezed,Object? endTime = freezed,Object? duration = freezed,Object? startActive = freezed,Object? prevReset = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,category: freezed == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
+as int?,sortOrder: freezed == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as int?,size: freezed == size ? _self.size : size // ignore: cast_nullable_to_non_nullable
+as int?,maxSize: freezed == maxSize ? _self.maxSize : maxSize // ignore: cast_nullable_to_non_nullable
+as int?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
+as int?,canEnter: freezed == canEnter ? _self.canEnter : canEnter // ignore: cast_nullable_to_non_nullable
+as bool?,endActive: freezed == endActive ? _self.endActive : endActive // ignore: cast_nullable_to_non_nullable
+as int?,nextReset: freezed == nextReset ? _self.nextReset : nextReset // ignore: cast_nullable_to_non_nullable
+as int?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,startTime: freezed == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,endTime: freezed == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,duration: freezed == duration ? _self.duration : duration // ignore: cast_nullable_to_non_nullable
+as int?,startActive: freezed == startActive ? _self.startActive : startActive // ignore: cast_nullable_to_non_nullable
+as int?,prevReset: freezed == prevReset ? _self.prevReset : prevReset // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$TournamentImplCopyWith<$Res>
-    implements $TournamentCopyWith<$Res> {
-  factory _$$TournamentImplCopyWith(
-          _$TournamentImpl value, $Res Function(_$TournamentImpl) then) =
-      __$$TournamentImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'id') String id,
-      @JsonKey(name: 'title') String? title,
-      @JsonKey(name: 'description') String? description,
-      @JsonKey(name: 'category') int? category,
-      @JsonKey(name: 'sort_order') int? sortOrder,
-      @JsonKey(name: 'size') int? size,
-      @JsonKey(name: 'max_size') int? maxSize,
-      @JsonKey(name: 'max_num_score') int? maxNumScore,
-      @JsonKey(name: 'can_enter') bool? canEnter,
-      @JsonKey(name: 'end_active') int? endActive,
-      @JsonKey(name: 'next_reset') int? nextReset,
-      @JsonKey(name: 'metadata') String? metadata,
-      @JsonKey(name: 'create_time') DateTime? createTime,
-      @JsonKey(name: 'start_time') DateTime? startTime,
-      @JsonKey(name: 'end_time') DateTime? endTime,
-      @JsonKey(name: 'duration') int? duration,
-      @JsonKey(name: 'start_active') int? startActive,
-      @JsonKey(name: 'prev_reset') int? prevReset});
 }
 
-/// @nodoc
-class __$$TournamentImplCopyWithImpl<$Res>
-    extends _$TournamentCopyWithImpl<$Res, _$TournamentImpl>
-    implements _$$TournamentImplCopyWith<$Res> {
-  __$$TournamentImplCopyWithImpl(
-      _$TournamentImpl _value, $Res Function(_$TournamentImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? title = freezed,
-    Object? description = freezed,
-    Object? category = freezed,
-    Object? sortOrder = freezed,
-    Object? size = freezed,
-    Object? maxSize = freezed,
-    Object? maxNumScore = freezed,
-    Object? canEnter = freezed,
-    Object? endActive = freezed,
-    Object? nextReset = freezed,
-    Object? metadata = freezed,
-    Object? createTime = freezed,
-    Object? startTime = freezed,
-    Object? endTime = freezed,
-    Object? duration = freezed,
-    Object? startActive = freezed,
-    Object? prevReset = freezed,
-  }) {
-    return _then(_$TournamentImpl(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      title: freezed == title
-          ? _value.title
-          : title // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _value.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      category: freezed == category
-          ? _value.category
-          : category // ignore: cast_nullable_to_non_nullable
-              as int?,
-      sortOrder: freezed == sortOrder
-          ? _value.sortOrder
-          : sortOrder // ignore: cast_nullable_to_non_nullable
-              as int?,
-      size: freezed == size
-          ? _value.size
-          : size // ignore: cast_nullable_to_non_nullable
-              as int?,
-      maxSize: freezed == maxSize
-          ? _value.maxSize
-          : maxSize // ignore: cast_nullable_to_non_nullable
-              as int?,
-      maxNumScore: freezed == maxNumScore
-          ? _value.maxNumScore
-          : maxNumScore // ignore: cast_nullable_to_non_nullable
-              as int?,
-      canEnter: freezed == canEnter
-          ? _value.canEnter
-          : canEnter // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      endActive: freezed == endActive
-          ? _value.endActive
-          : endActive // ignore: cast_nullable_to_non_nullable
-              as int?,
-      nextReset: freezed == nextReset
-          ? _value.nextReset
-          : nextReset // ignore: cast_nullable_to_non_nullable
-              as int?,
-      metadata: freezed == metadata
-          ? _value.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as String?,
-      createTime: freezed == createTime
-          ? _value.createTime
-          : createTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      startTime: freezed == startTime
-          ? _value.startTime
-          : startTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      endTime: freezed == endTime
-          ? _value.endTime
-          : endTime // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      duration: freezed == duration
-          ? _value.duration
-          : duration // ignore: cast_nullable_to_non_nullable
-              as int?,
-      startActive: freezed == startActive
-          ? _value.startActive
-          : startActive // ignore: cast_nullable_to_non_nullable
-              as int?,
-      prevReset: freezed == prevReset
-          ? _value.prevReset
-          : prevReset // ignore: cast_nullable_to_non_nullable
-              as int?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Tournament].
+extension TournamentPatterns on Tournament {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Tournament value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Tournament() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Tournament value)  $default,){
+final _that = this;
+switch (_that) {
+case _Tournament():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Tournament value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Tournament() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'title')  String? title, @JsonKey(name: 'description')  String? description, @JsonKey(name: 'category')  int? category, @JsonKey(name: 'sort_order')  int? sortOrder, @JsonKey(name: 'size')  int? size, @JsonKey(name: 'max_size')  int? maxSize, @JsonKey(name: 'max_num_score')  int? maxNumScore, @JsonKey(name: 'can_enter')  bool? canEnter, @JsonKey(name: 'end_active')  int? endActive, @JsonKey(name: 'next_reset')  int? nextReset, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'start_time')  DateTime? startTime, @JsonKey(name: 'end_time')  DateTime? endTime, @JsonKey(name: 'duration')  int? duration, @JsonKey(name: 'start_active')  int? startActive, @JsonKey(name: 'prev_reset')  int? prevReset)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Tournament() when $default != null:
+return $default(_that.id,_that.title,_that.description,_that.category,_that.sortOrder,_that.size,_that.maxSize,_that.maxNumScore,_that.canEnter,_that.endActive,_that.nextReset,_that.metadata,_that.createTime,_that.startTime,_that.endTime,_that.duration,_that.startActive,_that.prevReset);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'title')  String? title, @JsonKey(name: 'description')  String? description, @JsonKey(name: 'category')  int? category, @JsonKey(name: 'sort_order')  int? sortOrder, @JsonKey(name: 'size')  int? size, @JsonKey(name: 'max_size')  int? maxSize, @JsonKey(name: 'max_num_score')  int? maxNumScore, @JsonKey(name: 'can_enter')  bool? canEnter, @JsonKey(name: 'end_active')  int? endActive, @JsonKey(name: 'next_reset')  int? nextReset, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'start_time')  DateTime? startTime, @JsonKey(name: 'end_time')  DateTime? endTime, @JsonKey(name: 'duration')  int? duration, @JsonKey(name: 'start_active')  int? startActive, @JsonKey(name: 'prev_reset')  int? prevReset)  $default,) {final _that = this;
+switch (_that) {
+case _Tournament():
+return $default(_that.id,_that.title,_that.description,_that.category,_that.sortOrder,_that.size,_that.maxSize,_that.maxNumScore,_that.canEnter,_that.endActive,_that.nextReset,_that.metadata,_that.createTime,_that.startTime,_that.endTime,_that.duration,_that.startActive,_that.prevReset);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'id')  String id, @JsonKey(name: 'title')  String? title, @JsonKey(name: 'description')  String? description, @JsonKey(name: 'category')  int? category, @JsonKey(name: 'sort_order')  int? sortOrder, @JsonKey(name: 'size')  int? size, @JsonKey(name: 'max_size')  int? maxSize, @JsonKey(name: 'max_num_score')  int? maxNumScore, @JsonKey(name: 'can_enter')  bool? canEnter, @JsonKey(name: 'end_active')  int? endActive, @JsonKey(name: 'next_reset')  int? nextReset, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'start_time')  DateTime? startTime, @JsonKey(name: 'end_time')  DateTime? endTime, @JsonKey(name: 'duration')  int? duration, @JsonKey(name: 'start_active')  int? startActive, @JsonKey(name: 'prev_reset')  int? prevReset)?  $default,) {final _that = this;
+switch (_that) {
+case _Tournament() when $default != null:
+return $default(_that.id,_that.title,_that.description,_that.category,_that.sortOrder,_that.size,_that.maxSize,_that.maxNumScore,_that.canEnter,_that.endActive,_that.nextReset,_that.metadata,_that.createTime,_that.startTime,_that.endTime,_that.duration,_that.startActive,_that.prevReset);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$TournamentImpl extends _Tournament {
-  const _$TournamentImpl(
-      {@JsonKey(name: 'id') required this.id,
-      @JsonKey(name: 'title') this.title,
-      @JsonKey(name: 'description') this.description,
-      @JsonKey(name: 'category') this.category,
-      @JsonKey(name: 'sort_order') this.sortOrder,
-      @JsonKey(name: 'size') this.size,
-      @JsonKey(name: 'max_size') this.maxSize,
-      @JsonKey(name: 'max_num_score') this.maxNumScore,
-      @JsonKey(name: 'can_enter') this.canEnter,
-      @JsonKey(name: 'end_active') this.endActive,
-      @JsonKey(name: 'next_reset') this.nextReset,
-      @JsonKey(name: 'metadata') this.metadata,
-      @JsonKey(name: 'create_time') this.createTime,
-      @JsonKey(name: 'start_time') this.startTime,
-      @JsonKey(name: 'end_time') this.endTime,
-      @JsonKey(name: 'duration') this.duration,
-      @JsonKey(name: 'start_active') this.startActive,
-      @JsonKey(name: 'prev_reset') this.prevReset})
-      : super._();
 
-  factory _$TournamentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$TournamentImplFromJson(json);
+class _Tournament extends Tournament {
+  const _Tournament({@JsonKey(name: 'id') required this.id, @JsonKey(name: 'title') this.title, @JsonKey(name: 'description') this.description, @JsonKey(name: 'category') this.category, @JsonKey(name: 'sort_order') this.sortOrder, @JsonKey(name: 'size') this.size, @JsonKey(name: 'max_size') this.maxSize, @JsonKey(name: 'max_num_score') this.maxNumScore, @JsonKey(name: 'can_enter') this.canEnter, @JsonKey(name: 'end_active') this.endActive, @JsonKey(name: 'next_reset') this.nextReset, @JsonKey(name: 'metadata') this.metadata, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'start_time') this.startTime, @JsonKey(name: 'end_time') this.endTime, @JsonKey(name: 'duration') this.duration, @JsonKey(name: 'start_active') this.startActive, @JsonKey(name: 'prev_reset') this.prevReset}): super._();
+  factory _Tournament.fromJson(Map<String, dynamic> json) => _$TournamentFromJson(json);
 
-  @override
-  @JsonKey(name: 'id')
-  final String id;
-  @override
-  @JsonKey(name: 'title')
-  final String? title;
-  @override
-  @JsonKey(name: 'description')
-  final String? description;
-  @override
-  @JsonKey(name: 'category')
-  final int? category;
-  @override
-  @JsonKey(name: 'sort_order')
-  final int? sortOrder;
-  @override
-  @JsonKey(name: 'size')
-  final int? size;
-  @override
-  @JsonKey(name: 'max_size')
-  final int? maxSize;
-  @override
-  @JsonKey(name: 'max_num_score')
-  final int? maxNumScore;
-  @override
-  @JsonKey(name: 'can_enter')
-  final bool? canEnter;
-  @override
-  @JsonKey(name: 'end_active')
-  final int? endActive;
-  @override
-  @JsonKey(name: 'next_reset')
-  final int? nextReset;
-  @override
-  @JsonKey(name: 'metadata')
-  final String? metadata;
-  @override
-  @JsonKey(name: 'create_time')
-  final DateTime? createTime;
-  @override
-  @JsonKey(name: 'start_time')
-  final DateTime? startTime;
-  @override
-  @JsonKey(name: 'end_time')
-  final DateTime? endTime;
-  @override
-  @JsonKey(name: 'duration')
-  final int? duration;
-  @override
-  @JsonKey(name: 'start_active')
-  final int? startActive;
-  @override
-  @JsonKey(name: 'prev_reset')
-  final int? prevReset;
+@override@JsonKey(name: 'id') final  String id;
+@override@JsonKey(name: 'title') final  String? title;
+@override@JsonKey(name: 'description') final  String? description;
+@override@JsonKey(name: 'category') final  int? category;
+@override@JsonKey(name: 'sort_order') final  int? sortOrder;
+@override@JsonKey(name: 'size') final  int? size;
+@override@JsonKey(name: 'max_size') final  int? maxSize;
+@override@JsonKey(name: 'max_num_score') final  int? maxNumScore;
+@override@JsonKey(name: 'can_enter') final  bool? canEnter;
+@override@JsonKey(name: 'end_active') final  int? endActive;
+@override@JsonKey(name: 'next_reset') final  int? nextReset;
+@override@JsonKey(name: 'metadata') final  String? metadata;
+@override@JsonKey(name: 'create_time') final  DateTime? createTime;
+@override@JsonKey(name: 'start_time') final  DateTime? startTime;
+@override@JsonKey(name: 'end_time') final  DateTime? endTime;
+@override@JsonKey(name: 'duration') final  int? duration;
+@override@JsonKey(name: 'start_active') final  int? startActive;
+@override@JsonKey(name: 'prev_reset') final  int? prevReset;
 
-  @override
-  String toString() {
-    return 'Tournament(id: $id, title: $title, description: $description, category: $category, sortOrder: $sortOrder, size: $size, maxSize: $maxSize, maxNumScore: $maxNumScore, canEnter: $canEnter, endActive: $endActive, nextReset: $nextReset, metadata: $metadata, createTime: $createTime, startTime: $startTime, endTime: $endTime, duration: $duration, startActive: $startActive, prevReset: $prevReset)';
-  }
+/// Create a copy of Tournament
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TournamentCopyWith<_Tournament> get copyWith => __$TournamentCopyWithImpl<_Tournament>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$TournamentImpl &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.title, title) || other.title == title) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            (identical(other.category, category) ||
-                other.category == category) &&
-            (identical(other.sortOrder, sortOrder) ||
-                other.sortOrder == sortOrder) &&
-            (identical(other.size, size) || other.size == size) &&
-            (identical(other.maxSize, maxSize) || other.maxSize == maxSize) &&
-            (identical(other.maxNumScore, maxNumScore) ||
-                other.maxNumScore == maxNumScore) &&
-            (identical(other.canEnter, canEnter) ||
-                other.canEnter == canEnter) &&
-            (identical(other.endActive, endActive) ||
-                other.endActive == endActive) &&
-            (identical(other.nextReset, nextReset) ||
-                other.nextReset == nextReset) &&
-            (identical(other.metadata, metadata) ||
-                other.metadata == metadata) &&
-            (identical(other.createTime, createTime) ||
-                other.createTime == createTime) &&
-            (identical(other.startTime, startTime) ||
-                other.startTime == startTime) &&
-            (identical(other.endTime, endTime) || other.endTime == endTime) &&
-            (identical(other.duration, duration) ||
-                other.duration == duration) &&
-            (identical(other.startActive, startActive) ||
-                other.startActive == startActive) &&
-            (identical(other.prevReset, prevReset) ||
-                other.prevReset == prevReset));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      title,
-      description,
-      category,
-      sortOrder,
-      size,
-      maxSize,
-      maxNumScore,
-      canEnter,
-      endActive,
-      nextReset,
-      metadata,
-      createTime,
-      startTime,
-      endTime,
-      duration,
-      startActive,
-      prevReset);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$TournamentImplCopyWith<_$TournamentImpl> get copyWith =>
-      __$$TournamentImplCopyWithImpl<_$TournamentImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$TournamentImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$TournamentToJson(this, );
 }
 
-abstract class _Tournament extends Tournament {
-  const factory _Tournament(
-      {@JsonKey(name: 'id') required final String id,
-      @JsonKey(name: 'title') final String? title,
-      @JsonKey(name: 'description') final String? description,
-      @JsonKey(name: 'category') final int? category,
-      @JsonKey(name: 'sort_order') final int? sortOrder,
-      @JsonKey(name: 'size') final int? size,
-      @JsonKey(name: 'max_size') final int? maxSize,
-      @JsonKey(name: 'max_num_score') final int? maxNumScore,
-      @JsonKey(name: 'can_enter') final bool? canEnter,
-      @JsonKey(name: 'end_active') final int? endActive,
-      @JsonKey(name: 'next_reset') final int? nextReset,
-      @JsonKey(name: 'metadata') final String? metadata,
-      @JsonKey(name: 'create_time') final DateTime? createTime,
-      @JsonKey(name: 'start_time') final DateTime? startTime,
-      @JsonKey(name: 'end_time') final DateTime? endTime,
-      @JsonKey(name: 'duration') final int? duration,
-      @JsonKey(name: 'start_active') final int? startActive,
-      @JsonKey(name: 'prev_reset') final int? prevReset}) = _$TournamentImpl;
-  const _Tournament._() : super._();
-
-  factory _Tournament.fromJson(Map<String, dynamic> json) =
-      _$TournamentImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'id')
-  String get id;
-  @override
-  @JsonKey(name: 'title')
-  String? get title;
-  @override
-  @JsonKey(name: 'description')
-  String? get description;
-  @override
-  @JsonKey(name: 'category')
-  int? get category;
-  @override
-  @JsonKey(name: 'sort_order')
-  int? get sortOrder;
-  @override
-  @JsonKey(name: 'size')
-  int? get size;
-  @override
-  @JsonKey(name: 'max_size')
-  int? get maxSize;
-  @override
-  @JsonKey(name: 'max_num_score')
-  int? get maxNumScore;
-  @override
-  @JsonKey(name: 'can_enter')
-  bool? get canEnter;
-  @override
-  @JsonKey(name: 'end_active')
-  int? get endActive;
-  @override
-  @JsonKey(name: 'next_reset')
-  int? get nextReset;
-  @override
-  @JsonKey(name: 'metadata')
-  String? get metadata;
-  @override
-  @JsonKey(name: 'create_time')
-  DateTime? get createTime;
-  @override
-  @JsonKey(name: 'start_time')
-  DateTime? get startTime;
-  @override
-  @JsonKey(name: 'end_time')
-  DateTime? get endTime;
-  @override
-  @JsonKey(name: 'duration')
-  int? get duration;
-  @override
-  @JsonKey(name: 'start_active')
-  int? get startActive;
-  @override
-  @JsonKey(name: 'prev_reset')
-  int? get prevReset;
-  @override
-  @JsonKey(ignore: true)
-  _$$TournamentImplCopyWith<_$TournamentImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Tournament&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.category, category) || other.category == category)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.size, size) || other.size == size)&&(identical(other.maxSize, maxSize) || other.maxSize == maxSize)&&(identical(other.maxNumScore, maxNumScore) || other.maxNumScore == maxNumScore)&&(identical(other.canEnter, canEnter) || other.canEnter == canEnter)&&(identical(other.endActive, endActive) || other.endActive == endActive)&&(identical(other.nextReset, nextReset) || other.nextReset == nextReset)&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.createTime, createTime) || other.createTime == createTime)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.startActive, startActive) || other.startActive == startActive)&&(identical(other.prevReset, prevReset) || other.prevReset == prevReset));
 }
 
-TournamentList _$TournamentListFromJson(Map<String, dynamic> json) {
-  return _TournamentList.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,description,category,sortOrder,size,maxSize,maxNumScore,canEnter,endActive,nextReset,metadata,createTime,startTime,endTime,duration,startActive,prevReset);
+
+@override
+String toString() {
+  return 'Tournament(id: $id, title: $title, description: $description, category: $category, sortOrder: $sortOrder, size: $size, maxSize: $maxSize, maxNumScore: $maxNumScore, canEnter: $canEnter, endActive: $endActive, nextReset: $nextReset, metadata: $metadata, createTime: $createTime, startTime: $startTime, endTime: $endTime, duration: $duration, startActive: $startActive, prevReset: $prevReset)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TournamentCopyWith<$Res> implements $TournamentCopyWith<$Res> {
+  factory _$TournamentCopyWith(_Tournament value, $Res Function(_Tournament) _then) = __$TournamentCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'id') String id,@JsonKey(name: 'title') String? title,@JsonKey(name: 'description') String? description,@JsonKey(name: 'category') int? category,@JsonKey(name: 'sort_order') int? sortOrder,@JsonKey(name: 'size') int? size,@JsonKey(name: 'max_size') int? maxSize,@JsonKey(name: 'max_num_score') int? maxNumScore,@JsonKey(name: 'can_enter') bool? canEnter,@JsonKey(name: 'end_active') int? endActive,@JsonKey(name: 'next_reset') int? nextReset,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'start_time') DateTime? startTime,@JsonKey(name: 'end_time') DateTime? endTime,@JsonKey(name: 'duration') int? duration,@JsonKey(name: 'start_active') int? startActive,@JsonKey(name: 'prev_reset') int? prevReset
+});
+
+
+
+
+}
+/// @nodoc
+class __$TournamentCopyWithImpl<$Res>
+    implements _$TournamentCopyWith<$Res> {
+  __$TournamentCopyWithImpl(this._self, this._then);
+
+  final _Tournament _self;
+  final $Res Function(_Tournament) _then;
+
+/// Create a copy of Tournament
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = freezed,Object? description = freezed,Object? category = freezed,Object? sortOrder = freezed,Object? size = freezed,Object? maxSize = freezed,Object? maxNumScore = freezed,Object? canEnter = freezed,Object? endActive = freezed,Object? nextReset = freezed,Object? metadata = freezed,Object? createTime = freezed,Object? startTime = freezed,Object? endTime = freezed,Object? duration = freezed,Object? startActive = freezed,Object? prevReset = freezed,}) {
+  return _then(_Tournament(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,category: freezed == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
+as int?,sortOrder: freezed == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as int?,size: freezed == size ? _self.size : size // ignore: cast_nullable_to_non_nullable
+as int?,maxSize: freezed == maxSize ? _self.maxSize : maxSize // ignore: cast_nullable_to_non_nullable
+as int?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
+as int?,canEnter: freezed == canEnter ? _self.canEnter : canEnter // ignore: cast_nullable_to_non_nullable
+as bool?,endActive: freezed == endActive ? _self.endActive : endActive // ignore: cast_nullable_to_non_nullable
+as int?,nextReset: freezed == nextReset ? _self.nextReset : nextReset // ignore: cast_nullable_to_non_nullable
+as int?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,startTime: freezed == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,endTime: freezed == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as DateTime?,duration: freezed == duration ? _self.duration : duration // ignore: cast_nullable_to_non_nullable
+as int?,startActive: freezed == startActive ? _self.startActive : startActive // ignore: cast_nullable_to_non_nullable
+as int?,prevReset: freezed == prevReset ? _self.prevReset : prevReset // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$TournamentList {
-  String? get cursor => throw _privateConstructorUsedError;
-  List<Tournament> get tournaments => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $TournamentListCopyWith<TournamentList> get copyWith =>
-      throw _privateConstructorUsedError;
+ String? get cursor; List<Tournament> get tournaments;
+/// Create a copy of TournamentList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TournamentListCopyWith<TournamentList> get copyWith => _$TournamentListCopyWithImpl<TournamentList>(this as TournamentList, _$identity);
+
+  /// Serializes this TournamentList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TournamentList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.tournaments, tournaments));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(tournaments));
+
+@override
+String toString() {
+  return 'TournamentList(cursor: $cursor, tournaments: $tournaments)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $TournamentListCopyWith<$Res> {
-  factory $TournamentListCopyWith(
-          TournamentList value, $Res Function(TournamentList) then) =
-      _$TournamentListCopyWithImpl<$Res, TournamentList>;
-  @useResult
-  $Res call({String? cursor, List<Tournament> tournaments});
-}
+abstract mixin class $TournamentListCopyWith<$Res>  {
+  factory $TournamentListCopyWith(TournamentList value, $Res Function(TournamentList) _then) = _$TournamentListCopyWithImpl;
+@useResult
+$Res call({
+ String? cursor, List<Tournament> tournaments
+});
 
+
+
+
+}
 /// @nodoc
-class _$TournamentListCopyWithImpl<$Res, $Val extends TournamentList>
+class _$TournamentListCopyWithImpl<$Res>
     implements $TournamentListCopyWith<$Res> {
-  _$TournamentListCopyWithImpl(this._value, this._then);
+  _$TournamentListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final TournamentList _self;
+  final $Res Function(TournamentList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? tournaments = null,
-  }) {
-    return _then(_value.copyWith(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      tournaments: null == tournaments
-          ? _value.tournaments
-          : tournaments // ignore: cast_nullable_to_non_nullable
-              as List<Tournament>,
-    ) as $Val);
-  }
+/// Create a copy of TournamentList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? tournaments = null,}) {
+  return _then(_self.copyWith(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,tournaments: null == tournaments ? _self.tournaments : tournaments // ignore: cast_nullable_to_non_nullable
+as List<Tournament>,
+  ));
 }
 
-/// @nodoc
-abstract class _$$TournamentListImplCopyWith<$Res>
-    implements $TournamentListCopyWith<$Res> {
-  factory _$$TournamentListImplCopyWith(_$TournamentListImpl value,
-          $Res Function(_$TournamentListImpl) then) =
-      __$$TournamentListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? cursor, List<Tournament> tournaments});
 }
 
-/// @nodoc
-class __$$TournamentListImplCopyWithImpl<$Res>
-    extends _$TournamentListCopyWithImpl<$Res, _$TournamentListImpl>
-    implements _$$TournamentListImplCopyWith<$Res> {
-  __$$TournamentListImplCopyWithImpl(
-      _$TournamentListImpl _value, $Res Function(_$TournamentListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? cursor = freezed,
-    Object? tournaments = null,
-  }) {
-    return _then(_$TournamentListImpl(
-      cursor: freezed == cursor
-          ? _value.cursor
-          : cursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      tournaments: null == tournaments
-          ? _value._tournaments
-          : tournaments // ignore: cast_nullable_to_non_nullable
-              as List<Tournament>,
-    ));
-  }
+/// Adds pattern-matching-related methods to [TournamentList].
+extension TournamentListPatterns on TournamentList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TournamentList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TournamentList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TournamentList value)  $default,){
+final _that = this;
+switch (_that) {
+case _TournamentList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TournamentList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TournamentList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor,  List<Tournament> tournaments)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TournamentList() when $default != null:
+return $default(_that.cursor,_that.tournaments);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor,  List<Tournament> tournaments)  $default,) {final _that = this;
+switch (_that) {
+case _TournamentList():
+return $default(_that.cursor,_that.tournaments);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor,  List<Tournament> tournaments)?  $default,) {final _that = this;
+switch (_that) {
+case _TournamentList() when $default != null:
+return $default(_that.cursor,_that.tournaments);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$TournamentListImpl extends _TournamentList {
-  const _$TournamentListImpl(
-      {this.cursor, required final List<Tournament> tournaments})
-      : _tournaments = tournaments,
-        super._();
 
-  factory _$TournamentListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$TournamentListImplFromJson(json);
+class _TournamentList extends TournamentList {
+  const _TournamentList({this.cursor, required final  List<Tournament> tournaments}): _tournaments = tournaments,super._();
+  factory _TournamentList.fromJson(Map<String, dynamic> json) => _$TournamentListFromJson(json);
 
-  @override
-  final String? cursor;
-  final List<Tournament> _tournaments;
-  @override
-  List<Tournament> get tournaments {
-    if (_tournaments is EqualUnmodifiableListView) return _tournaments;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_tournaments);
-  }
-
-  @override
-  String toString() {
-    return 'TournamentList(cursor: $cursor, tournaments: $tournaments)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$TournamentListImpl &&
-            (identical(other.cursor, cursor) || other.cursor == cursor) &&
-            const DeepCollectionEquality()
-                .equals(other._tournaments, _tournaments));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, cursor, const DeepCollectionEquality().hash(_tournaments));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$TournamentListImplCopyWith<_$TournamentListImpl> get copyWith =>
-      __$$TournamentListImplCopyWithImpl<_$TournamentListImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$TournamentListImplToJson(
-      this,
-    );
-  }
+@override final  String? cursor;
+ final  List<Tournament> _tournaments;
+@override List<Tournament> get tournaments {
+  if (_tournaments is EqualUnmodifiableListView) return _tournaments;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_tournaments);
 }
 
-abstract class _TournamentList extends TournamentList {
-  const factory _TournamentList(
-      {final String? cursor,
-      required final List<Tournament> tournaments}) = _$TournamentListImpl;
-  const _TournamentList._() : super._();
 
-  factory _TournamentList.fromJson(Map<String, dynamic> json) =
-      _$TournamentListImpl.fromJson;
+/// Create a copy of TournamentList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TournamentListCopyWith<_TournamentList> get copyWith => __$TournamentListCopyWithImpl<_TournamentList>(this, _$identity);
 
-  @override
-  String? get cursor;
-  @override
-  List<Tournament> get tournaments;
-  @override
-  @JsonKey(ignore: true)
-  _$$TournamentListImplCopyWith<_$TournamentListImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$TournamentListToJson(this, );
 }
 
-TournamentRecordList _$TournamentRecordListFromJson(Map<String, dynamic> json) {
-  return _TournamentRecordList.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TournamentList&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._tournaments, _tournaments));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(_tournaments));
+
+@override
+String toString() {
+  return 'TournamentList(cursor: $cursor, tournaments: $tournaments)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TournamentListCopyWith<$Res> implements $TournamentListCopyWith<$Res> {
+  factory _$TournamentListCopyWith(_TournamentList value, $Res Function(_TournamentList) _then) = __$TournamentListCopyWithImpl;
+@override @useResult
+$Res call({
+ String? cursor, List<Tournament> tournaments
+});
+
+
+
+
+}
+/// @nodoc
+class __$TournamentListCopyWithImpl<$Res>
+    implements _$TournamentListCopyWith<$Res> {
+  __$TournamentListCopyWithImpl(this._self, this._then);
+
+  final _TournamentList _self;
+  final $Res Function(_TournamentList) _then;
+
+/// Create a copy of TournamentList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? tournaments = null,}) {
+  return _then(_TournamentList(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,tournaments: null == tournaments ? _self._tournaments : tournaments // ignore: cast_nullable_to_non_nullable
+as List<Tournament>,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$TournamentRecordList {
-  @JsonKey(name: 'records')
-  List<LeaderboardRecord> get records => throw _privateConstructorUsedError;
-  @JsonKey(name: 'owner_records')
-  List<LeaderboardRecord> get ownerRecords =>
-      throw _privateConstructorUsedError;
-  @JsonKey(name: 'next_cursor')
-  String? get nextCursor => throw _privateConstructorUsedError;
-  @JsonKey(name: 'previous_cursor')
-  String? get previousCursor => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $TournamentRecordListCopyWith<TournamentRecordList> get copyWith =>
-      throw _privateConstructorUsedError;
+@JsonKey(name: 'records') List<LeaderboardRecord> get records;@JsonKey(name: 'owner_records') List<LeaderboardRecord> get ownerRecords;@JsonKey(name: 'next_cursor') String? get nextCursor;@JsonKey(name: 'previous_cursor') String? get previousCursor;
+/// Create a copy of TournamentRecordList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TournamentRecordListCopyWith<TournamentRecordList> get copyWith => _$TournamentRecordListCopyWithImpl<TournamentRecordList>(this as TournamentRecordList, _$identity);
+
+  /// Serializes this TournamentRecordList to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TournamentRecordList&&const DeepCollectionEquality().equals(other.records, records)&&const DeepCollectionEquality().equals(other.ownerRecords, ownerRecords)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.previousCursor, previousCursor) || other.previousCursor == previousCursor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(records),const DeepCollectionEquality().hash(ownerRecords),nextCursor,previousCursor);
+
+@override
+String toString() {
+  return 'TournamentRecordList(records: $records, ownerRecords: $ownerRecords, nextCursor: $nextCursor, previousCursor: $previousCursor)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $TournamentRecordListCopyWith<$Res> {
-  factory $TournamentRecordListCopyWith(TournamentRecordList value,
-          $Res Function(TournamentRecordList) then) =
-      _$TournamentRecordListCopyWithImpl<$Res, TournamentRecordList>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'records') List<LeaderboardRecord> records,
-      @JsonKey(name: 'owner_records') List<LeaderboardRecord> ownerRecords,
-      @JsonKey(name: 'next_cursor') String? nextCursor,
-      @JsonKey(name: 'previous_cursor') String? previousCursor});
-}
+abstract mixin class $TournamentRecordListCopyWith<$Res>  {
+  factory $TournamentRecordListCopyWith(TournamentRecordList value, $Res Function(TournamentRecordList) _then) = _$TournamentRecordListCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'records') List<LeaderboardRecord> records,@JsonKey(name: 'owner_records') List<LeaderboardRecord> ownerRecords,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'previous_cursor') String? previousCursor
+});
 
+
+
+
+}
 /// @nodoc
-class _$TournamentRecordListCopyWithImpl<$Res,
-        $Val extends TournamentRecordList>
+class _$TournamentRecordListCopyWithImpl<$Res>
     implements $TournamentRecordListCopyWith<$Res> {
-  _$TournamentRecordListCopyWithImpl(this._value, this._then);
+  _$TournamentRecordListCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final TournamentRecordList _self;
+  final $Res Function(TournamentRecordList) _then;
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? records = null,
-    Object? ownerRecords = null,
-    Object? nextCursor = freezed,
-    Object? previousCursor = freezed,
-  }) {
-    return _then(_value.copyWith(
-      records: null == records
-          ? _value.records
-          : records // ignore: cast_nullable_to_non_nullable
-              as List<LeaderboardRecord>,
-      ownerRecords: null == ownerRecords
-          ? _value.ownerRecords
-          : ownerRecords // ignore: cast_nullable_to_non_nullable
-              as List<LeaderboardRecord>,
-      nextCursor: freezed == nextCursor
-          ? _value.nextCursor
-          : nextCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      previousCursor: freezed == previousCursor
-          ? _value.previousCursor
-          : previousCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of TournamentRecordList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? records = null,Object? ownerRecords = null,Object? nextCursor = freezed,Object? previousCursor = freezed,}) {
+  return _then(_self.copyWith(
+records: null == records ? _self.records : records // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>,ownerRecords: null == ownerRecords ? _self.ownerRecords : ownerRecords // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,previousCursor: freezed == previousCursor ? _self.previousCursor : previousCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$TournamentRecordListImplCopyWith<$Res>
-    implements $TournamentRecordListCopyWith<$Res> {
-  factory _$$TournamentRecordListImplCopyWith(_$TournamentRecordListImpl value,
-          $Res Function(_$TournamentRecordListImpl) then) =
-      __$$TournamentRecordListImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'records') List<LeaderboardRecord> records,
-      @JsonKey(name: 'owner_records') List<LeaderboardRecord> ownerRecords,
-      @JsonKey(name: 'next_cursor') String? nextCursor,
-      @JsonKey(name: 'previous_cursor') String? previousCursor});
 }
 
-/// @nodoc
-class __$$TournamentRecordListImplCopyWithImpl<$Res>
-    extends _$TournamentRecordListCopyWithImpl<$Res, _$TournamentRecordListImpl>
-    implements _$$TournamentRecordListImplCopyWith<$Res> {
-  __$$TournamentRecordListImplCopyWithImpl(_$TournamentRecordListImpl _value,
-      $Res Function(_$TournamentRecordListImpl) _then)
-      : super(_value, _then);
 
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? records = null,
-    Object? ownerRecords = null,
-    Object? nextCursor = freezed,
-    Object? previousCursor = freezed,
-  }) {
-    return _then(_$TournamentRecordListImpl(
-      records: null == records
-          ? _value._records
-          : records // ignore: cast_nullable_to_non_nullable
-              as List<LeaderboardRecord>,
-      ownerRecords: null == ownerRecords
-          ? _value._ownerRecords
-          : ownerRecords // ignore: cast_nullable_to_non_nullable
-              as List<LeaderboardRecord>,
-      nextCursor: freezed == nextCursor
-          ? _value.nextCursor
-          : nextCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      previousCursor: freezed == previousCursor
-          ? _value.previousCursor
-          : previousCursor // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [TournamentRecordList].
+extension TournamentRecordListPatterns on TournamentRecordList {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TournamentRecordList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TournamentRecordList() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TournamentRecordList value)  $default,){
+final _that = this;
+switch (_that) {
+case _TournamentRecordList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TournamentRecordList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TournamentRecordList() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'records')  List<LeaderboardRecord> records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord> ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'previous_cursor')  String? previousCursor)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TournamentRecordList() when $default != null:
+return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.previousCursor);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'records')  List<LeaderboardRecord> records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord> ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'previous_cursor')  String? previousCursor)  $default,) {final _that = this;
+switch (_that) {
+case _TournamentRecordList():
+return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.previousCursor);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'records')  List<LeaderboardRecord> records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord> ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'previous_cursor')  String? previousCursor)?  $default,) {final _that = this;
+switch (_that) {
+case _TournamentRecordList() when $default != null:
+return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.previousCursor);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$TournamentRecordListImpl extends _TournamentRecordList {
-  const _$TournamentRecordListImpl(
-      {@JsonKey(name: 'records') required final List<LeaderboardRecord> records,
-      @JsonKey(name: 'owner_records')
-      required final List<LeaderboardRecord> ownerRecords,
-      @JsonKey(name: 'next_cursor') this.nextCursor,
-      @JsonKey(name: 'previous_cursor') this.previousCursor})
-      : _records = records,
-        _ownerRecords = ownerRecords,
-        super._();
 
-  factory _$TournamentRecordListImpl.fromJson(Map<String, dynamic> json) =>
-      _$$TournamentRecordListImplFromJson(json);
+class _TournamentRecordList extends TournamentRecordList {
+  const _TournamentRecordList({@JsonKey(name: 'records') required final  List<LeaderboardRecord> records, @JsonKey(name: 'owner_records') required final  List<LeaderboardRecord> ownerRecords, @JsonKey(name: 'next_cursor') this.nextCursor, @JsonKey(name: 'previous_cursor') this.previousCursor}): _records = records,_ownerRecords = ownerRecords,super._();
+  factory _TournamentRecordList.fromJson(Map<String, dynamic> json) => _$TournamentRecordListFromJson(json);
 
-  final List<LeaderboardRecord> _records;
-  @override
-  @JsonKey(name: 'records')
-  List<LeaderboardRecord> get records {
-    if (_records is EqualUnmodifiableListView) return _records;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_records);
-  }
-
-  final List<LeaderboardRecord> _ownerRecords;
-  @override
-  @JsonKey(name: 'owner_records')
-  List<LeaderboardRecord> get ownerRecords {
-    if (_ownerRecords is EqualUnmodifiableListView) return _ownerRecords;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_ownerRecords);
-  }
-
-  @override
-  @JsonKey(name: 'next_cursor')
-  final String? nextCursor;
-  @override
-  @JsonKey(name: 'previous_cursor')
-  final String? previousCursor;
-
-  @override
-  String toString() {
-    return 'TournamentRecordList(records: $records, ownerRecords: $ownerRecords, nextCursor: $nextCursor, previousCursor: $previousCursor)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$TournamentRecordListImpl &&
-            const DeepCollectionEquality().equals(other._records, _records) &&
-            const DeepCollectionEquality()
-                .equals(other._ownerRecords, _ownerRecords) &&
-            (identical(other.nextCursor, nextCursor) ||
-                other.nextCursor == nextCursor) &&
-            (identical(other.previousCursor, previousCursor) ||
-                other.previousCursor == previousCursor));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(_records),
-      const DeepCollectionEquality().hash(_ownerRecords),
-      nextCursor,
-      previousCursor);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$TournamentRecordListImplCopyWith<_$TournamentRecordListImpl>
-      get copyWith =>
-          __$$TournamentRecordListImplCopyWithImpl<_$TournamentRecordListImpl>(
-              this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$TournamentRecordListImplToJson(
-      this,
-    );
-  }
+ final  List<LeaderboardRecord> _records;
+@override@JsonKey(name: 'records') List<LeaderboardRecord> get records {
+  if (_records is EqualUnmodifiableListView) return _records;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_records);
 }
 
-abstract class _TournamentRecordList extends TournamentRecordList {
-  const factory _TournamentRecordList(
-      {@JsonKey(name: 'records') required final List<LeaderboardRecord> records,
-      @JsonKey(name: 'owner_records')
-      required final List<LeaderboardRecord> ownerRecords,
-      @JsonKey(name: 'next_cursor') final String? nextCursor,
-      @JsonKey(name: 'previous_cursor')
-      final String? previousCursor}) = _$TournamentRecordListImpl;
-  const _TournamentRecordList._() : super._();
-
-  factory _TournamentRecordList.fromJson(Map<String, dynamic> json) =
-      _$TournamentRecordListImpl.fromJson;
-
-  @override
-  @JsonKey(name: 'records')
-  List<LeaderboardRecord> get records;
-  @override
-  @JsonKey(name: 'owner_records')
-  List<LeaderboardRecord> get ownerRecords;
-  @override
-  @JsonKey(name: 'next_cursor')
-  String? get nextCursor;
-  @override
-  @JsonKey(name: 'previous_cursor')
-  String? get previousCursor;
-  @override
-  @JsonKey(ignore: true)
-  _$$TournamentRecordListImplCopyWith<_$TournamentRecordListImpl>
-      get copyWith => throw _privateConstructorUsedError;
+ final  List<LeaderboardRecord> _ownerRecords;
+@override@JsonKey(name: 'owner_records') List<LeaderboardRecord> get ownerRecords {
+  if (_ownerRecords is EqualUnmodifiableListView) return _ownerRecords;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_ownerRecords);
 }
+
+@override@JsonKey(name: 'next_cursor') final  String? nextCursor;
+@override@JsonKey(name: 'previous_cursor') final  String? previousCursor;
+
+/// Create a copy of TournamentRecordList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TournamentRecordListCopyWith<_TournamentRecordList> get copyWith => __$TournamentRecordListCopyWithImpl<_TournamentRecordList>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TournamentRecordListToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TournamentRecordList&&const DeepCollectionEquality().equals(other._records, _records)&&const DeepCollectionEquality().equals(other._ownerRecords, _ownerRecords)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.previousCursor, previousCursor) || other.previousCursor == previousCursor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_records),const DeepCollectionEquality().hash(_ownerRecords),nextCursor,previousCursor);
+
+@override
+String toString() {
+  return 'TournamentRecordList(records: $records, ownerRecords: $ownerRecords, nextCursor: $nextCursor, previousCursor: $previousCursor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TournamentRecordListCopyWith<$Res> implements $TournamentRecordListCopyWith<$Res> {
+  factory _$TournamentRecordListCopyWith(_TournamentRecordList value, $Res Function(_TournamentRecordList) _then) = __$TournamentRecordListCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'records') List<LeaderboardRecord> records,@JsonKey(name: 'owner_records') List<LeaderboardRecord> ownerRecords,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'previous_cursor') String? previousCursor
+});
+
+
+
+
+}
+/// @nodoc
+class __$TournamentRecordListCopyWithImpl<$Res>
+    implements _$TournamentRecordListCopyWith<$Res> {
+  __$TournamentRecordListCopyWithImpl(this._self, this._then);
+
+  final _TournamentRecordList _self;
+  final $Res Function(_TournamentRecordList) _then;
+
+/// Create a copy of TournamentRecordList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? records = null,Object? ownerRecords = null,Object? nextCursor = freezed,Object? previousCursor = freezed,}) {
+  return _then(_TournamentRecordList(
+records: null == records ? _self._records : records // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>,ownerRecords: null == ownerRecords ? _self._ownerRecords : ownerRecords // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,previousCursor: freezed == previousCursor ? _self.previousCursor : previousCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/nakama/lib/src/models/tournament.g.dart
+++ b/nakama/lib/src/models/tournament.g.dart
@@ -6,35 +6,34 @@ part of 'tournament.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$TournamentImpl _$$TournamentImplFromJson(Map<String, dynamic> json) =>
-    _$TournamentImpl(
-      id: json['id'] as String,
-      title: json['title'] as String?,
-      description: json['description'] as String?,
-      category: json['category'] as int?,
-      sortOrder: json['sort_order'] as int?,
-      size: json['size'] as int?,
-      maxSize: json['max_size'] as int?,
-      maxNumScore: json['max_num_score'] as int?,
-      canEnter: json['can_enter'] as bool?,
-      endActive: json['end_active'] as int?,
-      nextReset: json['next_reset'] as int?,
-      metadata: json['metadata'] as String?,
-      createTime: json['create_time'] == null
-          ? null
-          : DateTime.parse(json['create_time'] as String),
-      startTime: json['start_time'] == null
-          ? null
-          : DateTime.parse(json['start_time'] as String),
-      endTime: json['end_time'] == null
-          ? null
-          : DateTime.parse(json['end_time'] as String),
-      duration: json['duration'] as int?,
-      startActive: json['start_active'] as int?,
-      prevReset: json['prev_reset'] as int?,
-    );
+_Tournament _$TournamentFromJson(Map<String, dynamic> json) => _Tournament(
+  id: json['id'] as String,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  category: (json['category'] as num?)?.toInt(),
+  sortOrder: (json['sort_order'] as num?)?.toInt(),
+  size: (json['size'] as num?)?.toInt(),
+  maxSize: (json['max_size'] as num?)?.toInt(),
+  maxNumScore: (json['max_num_score'] as num?)?.toInt(),
+  canEnter: json['can_enter'] as bool?,
+  endActive: (json['end_active'] as num?)?.toInt(),
+  nextReset: (json['next_reset'] as num?)?.toInt(),
+  metadata: json['metadata'] as String?,
+  createTime: json['create_time'] == null
+      ? null
+      : DateTime.parse(json['create_time'] as String),
+  startTime: json['start_time'] == null
+      ? null
+      : DateTime.parse(json['start_time'] as String),
+  endTime: json['end_time'] == null
+      ? null
+      : DateTime.parse(json['end_time'] as String),
+  duration: (json['duration'] as num?)?.toInt(),
+  startActive: (json['start_active'] as num?)?.toInt(),
+  prevReset: (json['prev_reset'] as num?)?.toInt(),
+);
 
-Map<String, dynamic> _$$TournamentImplToJson(_$TournamentImpl instance) =>
+Map<String, dynamic> _$TournamentToJson(_Tournament instance) =>
     <String, dynamic>{
       'id': instance.id,
       'title': instance.title,
@@ -56,39 +55,38 @@ Map<String, dynamic> _$$TournamentImplToJson(_$TournamentImpl instance) =>
       'prev_reset': instance.prevReset,
     };
 
-_$TournamentListImpl _$$TournamentListImplFromJson(Map<String, dynamic> json) =>
-    _$TournamentListImpl(
+_TournamentList _$TournamentListFromJson(Map<String, dynamic> json) =>
+    _TournamentList(
       cursor: json['cursor'] as String?,
       tournaments: (json['tournaments'] as List<dynamic>)
           .map((e) => Tournament.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$TournamentListImplToJson(
-        _$TournamentListImpl instance) =>
+Map<String, dynamic> _$TournamentListToJson(_TournamentList instance) =>
     <String, dynamic>{
       'cursor': instance.cursor,
       'tournaments': instance.tournaments,
     };
 
-_$TournamentRecordListImpl _$$TournamentRecordListImplFromJson(
-        Map<String, dynamic> json) =>
-    _$TournamentRecordListImpl(
-      records: (json['records'] as List<dynamic>)
-          .map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      ownerRecords: (json['owner_records'] as List<dynamic>)
-          .map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      nextCursor: json['next_cursor'] as String?,
-      previousCursor: json['previous_cursor'] as String?,
-    );
+_TournamentRecordList _$TournamentRecordListFromJson(
+  Map<String, dynamic> json,
+) => _TournamentRecordList(
+  records: (json['records'] as List<dynamic>)
+      .map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  ownerRecords: (json['owner_records'] as List<dynamic>)
+      .map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  nextCursor: json['next_cursor'] as String?,
+  previousCursor: json['previous_cursor'] as String?,
+);
 
-Map<String, dynamic> _$$TournamentRecordListImplToJson(
-        _$TournamentRecordListImpl instance) =>
-    <String, dynamic>{
-      'records': instance.records,
-      'owner_records': instance.ownerRecords,
-      'next_cursor': instance.nextCursor,
-      'previous_cursor': instance.previousCursor,
-    };
+Map<String, dynamic> _$TournamentRecordListToJson(
+  _TournamentRecordList instance,
+) => <String, dynamic>{
+  'records': instance.records,
+  'owner_records': instance.ownerRecords,
+  'next_cursor': instance.nextCursor,
+  'previous_cursor': instance.previousCursor,
+};

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -109,7 +109,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     Map<String, String>? vars,
   }) async {
     final res = await _client.sessionRefresh(
-      api.SessionRefreshRequest(token: session.refreshToken, vars: vars),
+      api.SessionRefreshRequest(token: session.refreshToken, vars: vars?.entries),
     );
 
     return model.Session.fromDto(res);
@@ -1379,7 +1379,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       {required model.Session session, required String token, bool reset = false, Map<String, String>? vars}) async {
     await _client.importFacebookFriends(
       api.ImportFacebookFriendsRequest(
-        account: AccountFacebook(token: token, vars: vars),
+        account: AccountFacebook(token: token, vars: vars?.entries),
         reset: api.BoolValue(value: reset),
       ),
       options: _getSessionCallOptions(session),
@@ -1395,7 +1395,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }) async {
     await _client.importSteamFriends(
       api.ImportSteamFriendsRequest(
-        account: AccountSteam(token: token, vars: vars),
+        account: AccountSteam(token: token, vars: vars?.entries),
         reset: api.BoolValue(value: reset),
       ),
       options: _getSessionCallOptions(session),

--- a/nakama/lib/src/nakama_websocket_client.dart
+++ b/nakama/lib/src/nakama_websocket_client.dart
@@ -172,7 +172,7 @@ class NakamaWebsocketClient {
     ]);
   }
 
-  void _onData(msg) {
+  void _onData(dynamic msg) {
     try {
       final receivedEnvelope = rtpb.Envelope.fromBuffer(msg);
       _log.info('onData: $receivedEnvelope');
@@ -352,8 +352,8 @@ class NakamaWebsocketClient {
       minCount: minCount,
       maxCount: maxCount,
       query: query,
-      numericProperties: numericProperties,
-      stringProperties: stringProperties,
+      numericProperties: numericProperties?.entries,
+      stringProperties: stringProperties?.entries,
     )));
 
     return PartyMatchmakerTicket.fromDto(res);
@@ -394,8 +394,8 @@ class NakamaWebsocketClient {
         matchmakerAdd: rtpb.MatchmakerAdd(
       maxCount: maxCount,
       minCount: minCount,
-      numericProperties: numericProperties,
-      stringProperties: stringProperties,
+      numericProperties: numericProperties?.entries,
+      stringProperties: stringProperties?.entries,
       query: query,
     )));
 
@@ -496,8 +496,6 @@ class NakamaWebsocketClient {
             return rtpb.ChannelJoin_Type.GROUP;
           case ChannelType.directMessage:
             return rtpb.ChannelJoin_Type.DIRECT_MESSAGE;
-          default:
-            return rtpb.ChannelJoin_Type.TYPE_UNSPECIFIED;
         }
       }()
           .value,

--- a/nakama/lib/src/rest/api_client.gen.g.dart
+++ b/nakama/lib/src/rest/api_client.gen.g.dart
@@ -6,43 +6,57 @@ part of 'api_client.gen.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-GroupUserListGroupUser _$GroupUserListGroupUserFromJson(Map<String, dynamic> json) => GroupUserListGroupUser(
-      state: json['state'] as int?,
-      user: json['user'] == null ? null : ApiUser.fromJson(json['user'] as Map<String, dynamic>),
-    );
+GroupUserListGroupUser _$GroupUserListGroupUserFromJson(
+  Map<String, dynamic> json,
+) => GroupUserListGroupUser(
+  state: (json['state'] as num?)?.toInt(),
+  user: json['user'] == null
+      ? null
+      : ApiUser.fromJson(json['user'] as Map<String, dynamic>),
+);
 
-Map<String, dynamic> _$GroupUserListGroupUserToJson(GroupUserListGroupUser instance) => <String, dynamic>{
-      'state': instance.state,
-      'user': instance.user?.toJson(),
-    };
+Map<String, dynamic> _$GroupUserListGroupUserToJson(
+  GroupUserListGroupUser instance,
+) => <String, dynamic>{
+  'state': instance.state,
+  'user': instance.user?.toJson(),
+};
 
-UserGroupListUserGroup _$UserGroupListUserGroupFromJson(Map<String, dynamic> json) => UserGroupListUserGroup(
-      group: json['group'] == null ? null : ApiGroup.fromJson(json['group'] as Map<String, dynamic>),
-      state: json['state'] as int?,
-    );
+UserGroupListUserGroup _$UserGroupListUserGroupFromJson(
+  Map<String, dynamic> json,
+) => UserGroupListUserGroup(
+  group: json['group'] == null
+      ? null
+      : ApiGroup.fromJson(json['group'] as Map<String, dynamic>),
+  state: (json['state'] as num?)?.toInt(),
+);
 
-Map<String, dynamic> _$UserGroupListUserGroupToJson(UserGroupListUserGroup instance) => <String, dynamic>{
-      'group': instance.group?.toJson(),
-      'state': instance.state,
-    };
+Map<String, dynamic> _$UserGroupListUserGroupToJson(
+  UserGroupListUserGroup instance,
+) => <String, dynamic>{
+  'group': instance.group?.toJson(),
+  'state': instance.state,
+};
 
-WriteLeaderboardRecordRequestLeaderboardRecordWrite _$WriteLeaderboardRecordRequestLeaderboardRecordWriteFromJson(
-        Map<String, dynamic> json) =>
-    WriteLeaderboardRecordRequestLeaderboardRecordWrite(
-      metadata: json['metadata'] as String?,
-      operator: $enumDecodeNullable(_$ApiOperatorEnumMap, json['operator']),
-      score: json['score'] as String?,
-      subscore: json['subscore'] as String?,
-    );
+WriteLeaderboardRecordRequestLeaderboardRecordWrite
+_$WriteLeaderboardRecordRequestLeaderboardRecordWriteFromJson(
+  Map<String, dynamic> json,
+) => WriteLeaderboardRecordRequestLeaderboardRecordWrite(
+  metadata: json['metadata'] as String?,
+  operator: $enumDecodeNullable(_$ApiOperatorEnumMap, json['operator']),
+  score: json['score'] as String?,
+  subscore: json['subscore'] as String?,
+);
 
-Map<String, dynamic> _$WriteLeaderboardRecordRequestLeaderboardRecordWriteToJson(
-        WriteLeaderboardRecordRequestLeaderboardRecordWrite instance) =>
-    <String, dynamic>{
-      'metadata': instance.metadata,
-      'operator': _$ApiOperatorEnumMap[instance.operator],
-      'score': instance.score,
-      'subscore': instance.subscore,
-    };
+Map<String, dynamic>
+_$WriteLeaderboardRecordRequestLeaderboardRecordWriteToJson(
+  WriteLeaderboardRecordRequestLeaderboardRecordWrite instance,
+) => <String, dynamic>{
+  'metadata': instance.metadata,
+  'operator': _$ApiOperatorEnumMap[instance.operator],
+  'score': instance.score,
+  'subscore': instance.subscore,
+};
 
 const _$ApiOperatorEnumMap = {
   ApiOperator.noOverride: 'NO_OVERRIDE',
@@ -52,37 +66,41 @@ const _$ApiOperatorEnumMap = {
   ApiOperator.decrement: 'DECREMENT',
 };
 
-WriteTournamentRecordRequestTournamentRecordWrite _$WriteTournamentRecordRequestTournamentRecordWriteFromJson(
-        Map<String, dynamic> json) =>
-    WriteTournamentRecordRequestTournamentRecordWrite(
-      metadata: json['metadata'] as String?,
-      operator: $enumDecodeNullable(_$ApiOperatorEnumMap, json['operator']),
-      score: json['score'] as String?,
-      subscore: json['subscore'] as String?,
-    );
+WriteTournamentRecordRequestTournamentRecordWrite
+_$WriteTournamentRecordRequestTournamentRecordWriteFromJson(
+  Map<String, dynamic> json,
+) => WriteTournamentRecordRequestTournamentRecordWrite(
+  metadata: json['metadata'] as String?,
+  operator: $enumDecodeNullable(_$ApiOperatorEnumMap, json['operator']),
+  score: json['score'] as String?,
+  subscore: json['subscore'] as String?,
+);
 
 Map<String, dynamic> _$WriteTournamentRecordRequestTournamentRecordWriteToJson(
-        WriteTournamentRecordRequestTournamentRecordWrite instance) =>
-    <String, dynamic>{
-      'metadata': instance.metadata,
-      'operator': _$ApiOperatorEnumMap[instance.operator],
-      'score': instance.score,
-      'subscore': instance.subscore,
-    };
+  WriteTournamentRecordRequestTournamentRecordWrite instance,
+) => <String, dynamic>{
+  'metadata': instance.metadata,
+  'operator': _$ApiOperatorEnumMap[instance.operator],
+  'score': instance.score,
+  'subscore': instance.subscore,
+};
 
 ApiAccount _$ApiAccountFromJson(Map<String, dynamic> json) => ApiAccount(
-      customId: json['custom_id'] as String?,
-      devices: (json['devices'] as List<dynamic>?)
-          ?.map((e) => ApiAccountDevice.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      disableTime: json['disable_time'] as String?,
-      email: json['email'] as String?,
-      user: json['user'] == null ? null : ApiUser.fromJson(json['user'] as Map<String, dynamic>),
-      verifyTime: json['verify_time'] as String?,
-      wallet: json['wallet'] as String?,
-    );
+  customId: json['custom_id'] as String?,
+  devices: (json['devices'] as List<dynamic>?)
+      ?.map((e) => ApiAccountDevice.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  disableTime: json['disable_time'] as String?,
+  email: json['email'] as String?,
+  user: json['user'] == null
+      ? null
+      : ApiUser.fromJson(json['user'] as Map<String, dynamic>),
+  verifyTime: json['verify_time'] as String?,
+  wallet: json['wallet'] as String?,
+);
 
-Map<String, dynamic> _$ApiAccountToJson(ApiAccount instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiAccountToJson(ApiAccount instance) =>
+    <String, dynamic>{
       'custom_id': instance.customId,
       'devices': instance.devices?.map((e) => e.toJson()).toList(),
       'disable_time': instance.disableTime,
@@ -92,43 +110,41 @@ Map<String, dynamic> _$ApiAccountToJson(ApiAccount instance) => <String, dynamic
       'wallet': instance.wallet,
     };
 
-ApiAccountApple _$ApiAccountAppleFromJson(Map<String, dynamic> json) => ApiAccountApple(
+ApiAccountApple _$ApiAccountAppleFromJson(Map<String, dynamic> json) =>
+    ApiAccountApple(
       token: json['token'] as String?,
       vars: (json['vars'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
     );
 
-Map<String, dynamic> _$ApiAccountAppleToJson(ApiAccountApple instance) => <String, dynamic>{
-      'token': instance.token,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiAccountAppleToJson(ApiAccountApple instance) =>
+    <String, dynamic>{'token': instance.token, 'vars': instance.vars};
 
-ApiAccountCustom _$ApiAccountCustomFromJson(Map<String, dynamic> json) => ApiAccountCustom(
+ApiAccountCustom _$ApiAccountCustomFromJson(Map<String, dynamic> json) =>
+    ApiAccountCustom(
       id: json['id'] as String?,
       vars: (json['vars'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
     );
 
-Map<String, dynamic> _$ApiAccountCustomToJson(ApiAccountCustom instance) => <String, dynamic>{
-      'id': instance.id,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiAccountCustomToJson(ApiAccountCustom instance) =>
+    <String, dynamic>{'id': instance.id, 'vars': instance.vars};
 
-ApiAccountDevice _$ApiAccountDeviceFromJson(Map<String, dynamic> json) => ApiAccountDevice(
+ApiAccountDevice _$ApiAccountDeviceFromJson(Map<String, dynamic> json) =>
+    ApiAccountDevice(
       id: json['id'] as String?,
       vars: (json['vars'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
     );
 
-Map<String, dynamic> _$ApiAccountDeviceToJson(ApiAccountDevice instance) => <String, dynamic>{
-      'id': instance.id,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiAccountDeviceToJson(ApiAccountDevice instance) =>
+    <String, dynamic>{'id': instance.id, 'vars': instance.vars};
 
-ApiAccountEmail _$ApiAccountEmailFromJson(Map<String, dynamic> json) => ApiAccountEmail(
+ApiAccountEmail _$ApiAccountEmailFromJson(Map<String, dynamic> json) =>
+    ApiAccountEmail(
       email: json['email'] as String?,
       password: json['password'] as String?,
       vars: (json['vars'] as Map<String, dynamic>?)?.map(
@@ -136,86 +152,92 @@ ApiAccountEmail _$ApiAccountEmailFromJson(Map<String, dynamic> json) => ApiAccou
       ),
     );
 
-Map<String, dynamic> _$ApiAccountEmailToJson(ApiAccountEmail instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiAccountEmailToJson(ApiAccountEmail instance) =>
+    <String, dynamic>{
       'email': instance.email,
       'password': instance.password,
       'vars': instance.vars,
     };
 
-ApiAccountFacebook _$ApiAccountFacebookFromJson(Map<String, dynamic> json) => ApiAccountFacebook(
+ApiAccountFacebook _$ApiAccountFacebookFromJson(Map<String, dynamic> json) =>
+    ApiAccountFacebook(
       token: json['token'] as String?,
       vars: (json['vars'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
     );
 
-Map<String, dynamic> _$ApiAccountFacebookToJson(ApiAccountFacebook instance) => <String, dynamic>{
-      'token': instance.token,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiAccountFacebookToJson(ApiAccountFacebook instance) =>
+    <String, dynamic>{'token': instance.token, 'vars': instance.vars};
 
-ApiAccountFacebookInstantGame _$ApiAccountFacebookInstantGameFromJson(Map<String, dynamic> json) =>
-    ApiAccountFacebookInstantGame(
-      signedPlayerInfo: json['signed_player_info'] as String?,
-      vars: (json['vars'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
-    );
+ApiAccountFacebookInstantGame _$ApiAccountFacebookInstantGameFromJson(
+  Map<String, dynamic> json,
+) => ApiAccountFacebookInstantGame(
+  signedPlayerInfo: json['signed_player_info'] as String?,
+  vars: (json['vars'] as Map<String, dynamic>?)?.map(
+    (k, e) => MapEntry(k, e as String),
+  ),
+);
 
-Map<String, dynamic> _$ApiAccountFacebookInstantGameToJson(ApiAccountFacebookInstantGame instance) => <String, dynamic>{
-      'signed_player_info': instance.signedPlayerInfo,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiAccountFacebookInstantGameToJson(
+  ApiAccountFacebookInstantGame instance,
+) => <String, dynamic>{
+  'signed_player_info': instance.signedPlayerInfo,
+  'vars': instance.vars,
+};
 
-ApiAccountGameCenter _$ApiAccountGameCenterFromJson(Map<String, dynamic> json) => ApiAccountGameCenter(
-      bundleId: json['bundle_id'] as String?,
-      playerId: json['player_id'] as String?,
-      publicKeyUrl: json['public_key_url'] as String?,
-      salt: json['salt'] as String?,
-      signature: json['signature'] as String?,
-      timestampSeconds: json['timestamp_seconds'] as String?,
-      vars: (json['vars'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
-    );
+ApiAccountGameCenter _$ApiAccountGameCenterFromJson(
+  Map<String, dynamic> json,
+) => ApiAccountGameCenter(
+  bundleId: json['bundle_id'] as String?,
+  playerId: json['player_id'] as String?,
+  publicKeyUrl: json['public_key_url'] as String?,
+  salt: json['salt'] as String?,
+  signature: json['signature'] as String?,
+  timestampSeconds: json['timestamp_seconds'] as String?,
+  vars: (json['vars'] as Map<String, dynamic>?)?.map(
+    (k, e) => MapEntry(k, e as String),
+  ),
+);
 
-Map<String, dynamic> _$ApiAccountGameCenterToJson(ApiAccountGameCenter instance) => <String, dynamic>{
-      'bundle_id': instance.bundleId,
-      'player_id': instance.playerId,
-      'public_key_url': instance.publicKeyUrl,
-      'salt': instance.salt,
-      'signature': instance.signature,
-      'timestamp_seconds': instance.timestampSeconds,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiAccountGameCenterToJson(
+  ApiAccountGameCenter instance,
+) => <String, dynamic>{
+  'bundle_id': instance.bundleId,
+  'player_id': instance.playerId,
+  'public_key_url': instance.publicKeyUrl,
+  'salt': instance.salt,
+  'signature': instance.signature,
+  'timestamp_seconds': instance.timestampSeconds,
+  'vars': instance.vars,
+};
 
-ApiAccountGoogle _$ApiAccountGoogleFromJson(Map<String, dynamic> json) => ApiAccountGoogle(
+ApiAccountGoogle _$ApiAccountGoogleFromJson(Map<String, dynamic> json) =>
+    ApiAccountGoogle(
       token: json['token'] as String?,
       vars: (json['vars'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
     );
 
-Map<String, dynamic> _$ApiAccountGoogleToJson(ApiAccountGoogle instance) => <String, dynamic>{
-      'token': instance.token,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiAccountGoogleToJson(ApiAccountGoogle instance) =>
+    <String, dynamic>{'token': instance.token, 'vars': instance.vars};
 
-ApiAccountSteam _$ApiAccountSteamFromJson(Map<String, dynamic> json) => ApiAccountSteam(
+ApiAccountSteam _$ApiAccountSteamFromJson(Map<String, dynamic> json) =>
+    ApiAccountSteam(
       token: json['token'] as String?,
       vars: (json['vars'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
     );
 
-Map<String, dynamic> _$ApiAccountSteamToJson(ApiAccountSteam instance) => <String, dynamic>{
-      'token': instance.token,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiAccountSteamToJson(ApiAccountSteam instance) =>
+    <String, dynamic>{'token': instance.token, 'vars': instance.vars};
 
-ApiChannelMessage _$ApiChannelMessageFromJson(Map<String, dynamic> json) => ApiChannelMessage(
+ApiChannelMessage _$ApiChannelMessageFromJson(Map<String, dynamic> json) =>
+    ApiChannelMessage(
       channelId: json['channel_id'] as String?,
-      code: json['code'] as int?,
+      code: (json['code'] as num?)?.toInt(),
       content: json['content'] as String?,
       createTime: json['create_time'] as String?,
       groupId: json['group_id'] as String?,
@@ -229,7 +251,8 @@ ApiChannelMessage _$ApiChannelMessageFromJson(Map<String, dynamic> json) => ApiC
       username: json['username'] as String?,
     );
 
-Map<String, dynamic> _$ApiChannelMessageToJson(ApiChannelMessage instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiChannelMessageToJson(ApiChannelMessage instance) =>
+    <String, dynamic>{
       'channel_id': instance.channelId,
       'code': instance.code,
       'content': instance.content,
@@ -245,251 +268,295 @@ Map<String, dynamic> _$ApiChannelMessageToJson(ApiChannelMessage instance) => <S
       'username': instance.username,
     };
 
-ApiChannelMessageList _$ApiChannelMessageListFromJson(Map<String, dynamic> json) => ApiChannelMessageList(
-      cacheableCursor: json['cacheable_cursor'] as String?,
-      messages: (json['messages'] as List<dynamic>?)
-          ?.map((e) => ApiChannelMessage.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      nextCursor: json['next_cursor'] as String?,
-      prevCursor: json['prev_cursor'] as String?,
-    );
+ApiChannelMessageList _$ApiChannelMessageListFromJson(
+  Map<String, dynamic> json,
+) => ApiChannelMessageList(
+  cacheableCursor: json['cacheable_cursor'] as String?,
+  messages: (json['messages'] as List<dynamic>?)
+      ?.map((e) => ApiChannelMessage.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  nextCursor: json['next_cursor'] as String?,
+  prevCursor: json['prev_cursor'] as String?,
+);
 
-Map<String, dynamic> _$ApiChannelMessageListToJson(ApiChannelMessageList instance) => <String, dynamic>{
-      'cacheable_cursor': instance.cacheableCursor,
-      'messages': instance.messages?.map((e) => e.toJson()).toList(),
-      'next_cursor': instance.nextCursor,
-      'prev_cursor': instance.prevCursor,
-    };
+Map<String, dynamic> _$ApiChannelMessageListToJson(
+  ApiChannelMessageList instance,
+) => <String, dynamic>{
+  'cacheable_cursor': instance.cacheableCursor,
+  'messages': instance.messages?.map((e) => e.toJson()).toList(),
+  'next_cursor': instance.nextCursor,
+  'prev_cursor': instance.prevCursor,
+};
 
-ApiCreateGroupRequest _$ApiCreateGroupRequestFromJson(Map<String, dynamic> json) => ApiCreateGroupRequest(
-      avatarUrl: json['avatar_url'] as String?,
-      description: json['description'] as String?,
-      langTag: json['lang_tag'] as String?,
-      maxCount: json['max_count'] as int?,
-      name: json['name'] as String?,
-      open: json['open'] as bool?,
-    );
+ApiCreateGroupRequest _$ApiCreateGroupRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiCreateGroupRequest(
+  avatarUrl: json['avatar_url'] as String?,
+  description: json['description'] as String?,
+  langTag: json['lang_tag'] as String?,
+  maxCount: (json['max_count'] as num?)?.toInt(),
+  name: json['name'] as String?,
+  open: json['open'] as bool?,
+);
 
-Map<String, dynamic> _$ApiCreateGroupRequestToJson(ApiCreateGroupRequest instance) => <String, dynamic>{
-      'avatar_url': instance.avatarUrl,
-      'description': instance.description,
-      'lang_tag': instance.langTag,
-      'max_count': instance.maxCount,
-      'name': instance.name,
-      'open': instance.open,
-    };
+Map<String, dynamic> _$ApiCreateGroupRequestToJson(
+  ApiCreateGroupRequest instance,
+) => <String, dynamic>{
+  'avatar_url': instance.avatarUrl,
+  'description': instance.description,
+  'lang_tag': instance.langTag,
+  'max_count': instance.maxCount,
+  'name': instance.name,
+  'open': instance.open,
+};
 
-ApiDeleteStorageObjectId _$ApiDeleteStorageObjectIdFromJson(Map<String, dynamic> json) => ApiDeleteStorageObjectId(
-      collection: json['collection'] as String?,
-      key: json['key'] as String?,
-      version: json['version'] as String?,
-    );
+ApiDeleteStorageObjectId _$ApiDeleteStorageObjectIdFromJson(
+  Map<String, dynamic> json,
+) => ApiDeleteStorageObjectId(
+  collection: json['collection'] as String?,
+  key: json['key'] as String?,
+  version: json['version'] as String?,
+);
 
-Map<String, dynamic> _$ApiDeleteStorageObjectIdToJson(ApiDeleteStorageObjectId instance) => <String, dynamic>{
-      'collection': instance.collection,
-      'key': instance.key,
-      'version': instance.version,
-    };
+Map<String, dynamic> _$ApiDeleteStorageObjectIdToJson(
+  ApiDeleteStorageObjectId instance,
+) => <String, dynamic>{
+  'collection': instance.collection,
+  'key': instance.key,
+  'version': instance.version,
+};
 
-ApiDeleteStorageObjectsRequest _$ApiDeleteStorageObjectsRequestFromJson(Map<String, dynamic> json) =>
-    ApiDeleteStorageObjectsRequest(
-      objectIds: (json['object_ids'] as List<dynamic>?)
-          ?.map((e) => ApiDeleteStorageObjectId.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+ApiDeleteStorageObjectsRequest _$ApiDeleteStorageObjectsRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiDeleteStorageObjectsRequest(
+  objectIds: (json['object_ids'] as List<dynamic>?)
+      ?.map((e) => ApiDeleteStorageObjectId.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiDeleteStorageObjectsRequestToJson(ApiDeleteStorageObjectsRequest instance) =>
-    <String, dynamic>{
-      'object_ids': instance.objectIds?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiDeleteStorageObjectsRequestToJson(
+  ApiDeleteStorageObjectsRequest instance,
+) => <String, dynamic>{
+  'object_ids': instance.objectIds?.map((e) => e.toJson()).toList(),
+};
 
 ApiEvent _$ApiEventFromJson(Map<String, dynamic> json) => ApiEvent(
-      external: json['external'] as bool?,
-      name: json['name'] as String?,
-      properties: (json['properties'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
-      timestamp: json['timestamp'] as String?,
-    );
+  external: json['external'] as bool?,
+  name: json['name'] as String?,
+  properties: (json['properties'] as Map<String, dynamic>?)?.map(
+    (k, e) => MapEntry(k, e as String),
+  ),
+  timestamp: json['timestamp'] as String?,
+);
 
 Map<String, dynamic> _$ApiEventToJson(ApiEvent instance) => <String, dynamic>{
-      'external': instance.external,
-      'name': instance.name,
-      'properties': instance.properties,
-      'timestamp': instance.timestamp,
-    };
+  'external': instance.external,
+  'name': instance.name,
+  'properties': instance.properties,
+  'timestamp': instance.timestamp,
+};
 
 ApiFriend _$ApiFriendFromJson(Map<String, dynamic> json) => ApiFriend(
-      state: json['state'] as int?,
-      updateTime: json['update_time'] as String?,
-      user: json['user'] == null ? null : ApiUser.fromJson(json['user'] as Map<String, dynamic>),
-    );
+  state: (json['state'] as num?)?.toInt(),
+  updateTime: json['update_time'] as String?,
+  user: json['user'] == null
+      ? null
+      : ApiUser.fromJson(json['user'] as Map<String, dynamic>),
+);
 
 Map<String, dynamic> _$ApiFriendToJson(ApiFriend instance) => <String, dynamic>{
-      'state': instance.state,
-      'update_time': instance.updateTime,
-      'user': instance.user?.toJson(),
-    };
+  'state': instance.state,
+  'update_time': instance.updateTime,
+  'user': instance.user?.toJson(),
+};
 
-ApiFriendList _$ApiFriendListFromJson(Map<String, dynamic> json) => ApiFriendList(
+ApiFriendList _$ApiFriendListFromJson(Map<String, dynamic> json) =>
+    ApiFriendList(
       cursor: json['cursor'] as String?,
-      friends: (json['friends'] as List<dynamic>?)?.map((e) => ApiFriend.fromJson(e as Map<String, dynamic>)).toList(),
+      friends: (json['friends'] as List<dynamic>?)
+          ?.map((e) => ApiFriend.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
-Map<String, dynamic> _$ApiFriendListToJson(ApiFriendList instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiFriendListToJson(ApiFriendList instance) =>
+    <String, dynamic>{
       'cursor': instance.cursor,
       'friends': instance.friends?.map((e) => e.toJson()).toList(),
     };
 
 ApiGroup _$ApiGroupFromJson(Map<String, dynamic> json) => ApiGroup(
-      avatarUrl: json['avatar_url'] as String?,
-      createTime: json['create_time'] as String?,
-      creatorId: json['creator_id'] as String?,
-      description: json['description'] as String?,
-      edgeCount: json['edge_count'] as int?,
-      id: json['id'] as String?,
-      langTag: json['lang_tag'] as String?,
-      maxCount: json['max_count'] as int?,
-      metadata: json['metadata'] as String?,
-      name: json['name'] as String?,
-      open: json['open'] as bool?,
-      updateTime: json['update_time'] as String?,
-    );
+  avatarUrl: json['avatar_url'] as String?,
+  createTime: json['create_time'] as String?,
+  creatorId: json['creator_id'] as String?,
+  description: json['description'] as String?,
+  edgeCount: (json['edge_count'] as num?)?.toInt(),
+  id: json['id'] as String?,
+  langTag: json['lang_tag'] as String?,
+  maxCount: (json['max_count'] as num?)?.toInt(),
+  metadata: json['metadata'] as String?,
+  name: json['name'] as String?,
+  open: json['open'] as bool?,
+  updateTime: json['update_time'] as String?,
+);
 
 Map<String, dynamic> _$ApiGroupToJson(ApiGroup instance) => <String, dynamic>{
-      'avatar_url': instance.avatarUrl,
-      'create_time': instance.createTime,
-      'creator_id': instance.creatorId,
-      'description': instance.description,
-      'edge_count': instance.edgeCount,
-      'id': instance.id,
-      'lang_tag': instance.langTag,
-      'max_count': instance.maxCount,
-      'metadata': instance.metadata,
-      'name': instance.name,
-      'open': instance.open,
-      'update_time': instance.updateTime,
-    };
+  'avatar_url': instance.avatarUrl,
+  'create_time': instance.createTime,
+  'creator_id': instance.creatorId,
+  'description': instance.description,
+  'edge_count': instance.edgeCount,
+  'id': instance.id,
+  'lang_tag': instance.langTag,
+  'max_count': instance.maxCount,
+  'metadata': instance.metadata,
+  'name': instance.name,
+  'open': instance.open,
+  'update_time': instance.updateTime,
+};
 
 ApiGroupList _$ApiGroupListFromJson(Map<String, dynamic> json) => ApiGroupList(
-      cursor: json['cursor'] as String?,
-      groups: (json['groups'] as List<dynamic>?)?.map((e) => ApiGroup.fromJson(e as Map<String, dynamic>)).toList(),
-    );
+  cursor: json['cursor'] as String?,
+  groups: (json['groups'] as List<dynamic>?)
+      ?.map((e) => ApiGroup.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiGroupListToJson(ApiGroupList instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiGroupListToJson(ApiGroupList instance) =>
+    <String, dynamic>{
       'cursor': instance.cursor,
       'groups': instance.groups?.map((e) => e.toJson()).toList(),
     };
 
-ApiGroupUserList _$ApiGroupUserListFromJson(Map<String, dynamic> json) => ApiGroupUserList(
+ApiGroupUserList _$ApiGroupUserListFromJson(Map<String, dynamic> json) =>
+    ApiGroupUserList(
       cursor: json['cursor'] as String?,
       groupUsers: (json['group_users'] as List<dynamic>?)
-          ?.map((e) => GroupUserListGroupUser.fromJson(e as Map<String, dynamic>))
+          ?.map(
+            (e) => GroupUserListGroupUser.fromJson(e as Map<String, dynamic>),
+          )
           .toList(),
     );
 
-Map<String, dynamic> _$ApiGroupUserListToJson(ApiGroupUserList instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiGroupUserListToJson(ApiGroupUserList instance) =>
+    <String, dynamic>{
       'cursor': instance.cursor,
       'group_users': instance.groupUsers?.map((e) => e.toJson()).toList(),
     };
 
-ApiLeaderboardRecord _$ApiLeaderboardRecordFromJson(Map<String, dynamic> json) => ApiLeaderboardRecord(
-      createTime: json['create_time'] as String?,
-      expiryTime: json['expiry_time'] as String?,
-      leaderboardId: json['leaderboard_id'] as String?,
-      maxNumScore: json['max_num_score'] as int?,
-      metadata: json['metadata'] as String?,
-      numScore: json['num_score'] as int?,
-      ownerId: json['owner_id'] as String?,
-      rank: json['rank'] as String?,
-      score: json['score'] as String?,
-      subscore: json['subscore'] as String?,
-      updateTime: json['update_time'] as String?,
-      username: json['username'] as String?,
-    );
+ApiLeaderboardRecord _$ApiLeaderboardRecordFromJson(
+  Map<String, dynamic> json,
+) => ApiLeaderboardRecord(
+  createTime: json['create_time'] as String?,
+  expiryTime: json['expiry_time'] as String?,
+  leaderboardId: json['leaderboard_id'] as String?,
+  maxNumScore: (json['max_num_score'] as num?)?.toInt(),
+  metadata: json['metadata'] as String?,
+  numScore: (json['num_score'] as num?)?.toInt(),
+  ownerId: json['owner_id'] as String?,
+  rank: json['rank'] as String?,
+  score: json['score'] as String?,
+  subscore: json['subscore'] as String?,
+  updateTime: json['update_time'] as String?,
+  username: json['username'] as String?,
+);
 
-Map<String, dynamic> _$ApiLeaderboardRecordToJson(ApiLeaderboardRecord instance) => <String, dynamic>{
-      'create_time': instance.createTime,
-      'expiry_time': instance.expiryTime,
-      'leaderboard_id': instance.leaderboardId,
-      'max_num_score': instance.maxNumScore,
-      'metadata': instance.metadata,
-      'num_score': instance.numScore,
-      'owner_id': instance.ownerId,
-      'rank': instance.rank,
-      'score': instance.score,
-      'subscore': instance.subscore,
-      'update_time': instance.updateTime,
-      'username': instance.username,
-    };
+Map<String, dynamic> _$ApiLeaderboardRecordToJson(
+  ApiLeaderboardRecord instance,
+) => <String, dynamic>{
+  'create_time': instance.createTime,
+  'expiry_time': instance.expiryTime,
+  'leaderboard_id': instance.leaderboardId,
+  'max_num_score': instance.maxNumScore,
+  'metadata': instance.metadata,
+  'num_score': instance.numScore,
+  'owner_id': instance.ownerId,
+  'rank': instance.rank,
+  'score': instance.score,
+  'subscore': instance.subscore,
+  'update_time': instance.updateTime,
+  'username': instance.username,
+};
 
-ApiLeaderboardRecordList _$ApiLeaderboardRecordListFromJson(Map<String, dynamic> json) => ApiLeaderboardRecordList(
-      nextCursor: json['next_cursor'] as String?,
-      ownerRecords: (json['owner_records'] as List<dynamic>?)
-          ?.map((e) => ApiLeaderboardRecord.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      prevCursor: json['prev_cursor'] as String?,
-      records: (json['records'] as List<dynamic>?)
-          ?.map((e) => ApiLeaderboardRecord.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+ApiLeaderboardRecordList _$ApiLeaderboardRecordListFromJson(
+  Map<String, dynamic> json,
+) => ApiLeaderboardRecordList(
+  nextCursor: json['next_cursor'] as String?,
+  ownerRecords: (json['owner_records'] as List<dynamic>?)
+      ?.map((e) => ApiLeaderboardRecord.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  prevCursor: json['prev_cursor'] as String?,
+  records: (json['records'] as List<dynamic>?)
+      ?.map((e) => ApiLeaderboardRecord.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiLeaderboardRecordListToJson(ApiLeaderboardRecordList instance) => <String, dynamic>{
-      'next_cursor': instance.nextCursor,
-      'owner_records': instance.ownerRecords?.map((e) => e.toJson()).toList(),
-      'prev_cursor': instance.prevCursor,
-      'records': instance.records?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiLeaderboardRecordListToJson(
+  ApiLeaderboardRecordList instance,
+) => <String, dynamic>{
+  'next_cursor': instance.nextCursor,
+  'owner_records': instance.ownerRecords?.map((e) => e.toJson()).toList(),
+  'prev_cursor': instance.prevCursor,
+  'records': instance.records?.map((e) => e.toJson()).toList(),
+};
 
-ApiLinkSteamRequest _$ApiLinkSteamRequestFromJson(Map<String, dynamic> json) => ApiLinkSteamRequest(
-      account: json['account'] == null ? null : ApiAccountSteam.fromJson(json['account'] as Map<String, dynamic>),
+ApiLinkSteamRequest _$ApiLinkSteamRequestFromJson(Map<String, dynamic> json) =>
+    ApiLinkSteamRequest(
+      account: json['account'] == null
+          ? null
+          : ApiAccountSteam.fromJson(json['account'] as Map<String, dynamic>),
       sync: json['sync'] as bool?,
     );
 
-Map<String, dynamic> _$ApiLinkSteamRequestToJson(ApiLinkSteamRequest instance) => <String, dynamic>{
-      'account': instance.account?.toJson(),
-      'sync': instance.sync,
-    };
+Map<String, dynamic> _$ApiLinkSteamRequestToJson(
+  ApiLinkSteamRequest instance,
+) => <String, dynamic>{
+  'account': instance.account?.toJson(),
+  'sync': instance.sync,
+};
 
-ApiListSubscriptionsRequest _$ApiListSubscriptionsRequestFromJson(Map<String, dynamic> json) =>
-    ApiListSubscriptionsRequest(
-      cursor: json['cursor'] as String?,
-      limit: json['limit'] as int?,
-    );
+ApiListSubscriptionsRequest _$ApiListSubscriptionsRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiListSubscriptionsRequest(
+  cursor: json['cursor'] as String?,
+  limit: (json['limit'] as num?)?.toInt(),
+);
 
-Map<String, dynamic> _$ApiListSubscriptionsRequestToJson(ApiListSubscriptionsRequest instance) => <String, dynamic>{
-      'cursor': instance.cursor,
-      'limit': instance.limit,
-    };
+Map<String, dynamic> _$ApiListSubscriptionsRequestToJson(
+  ApiListSubscriptionsRequest instance,
+) => <String, dynamic>{'cursor': instance.cursor, 'limit': instance.limit};
 
 ApiMatch _$ApiMatchFromJson(Map<String, dynamic> json) => ApiMatch(
-      authoritative: json['authoritative'] as bool?,
-      handlerName: json['handler_name'] as String?,
-      label: json['label'] as String?,
-      matchId: json['match_id'] as String?,
-      size: json['size'] as int?,
-      tickRate: json['tick_rate'] as int?,
-    );
+  authoritative: json['authoritative'] as bool?,
+  handlerName: json['handler_name'] as String?,
+  label: json['label'] as String?,
+  matchId: json['match_id'] as String?,
+  size: (json['size'] as num?)?.toInt(),
+  tickRate: (json['tick_rate'] as num?)?.toInt(),
+);
 
 Map<String, dynamic> _$ApiMatchToJson(ApiMatch instance) => <String, dynamic>{
-      'authoritative': instance.authoritative,
-      'handler_name': instance.handlerName,
-      'label': instance.label,
-      'match_id': instance.matchId,
-      'size': instance.size,
-      'tick_rate': instance.tickRate,
-    };
+  'authoritative': instance.authoritative,
+  'handler_name': instance.handlerName,
+  'label': instance.label,
+  'match_id': instance.matchId,
+  'size': instance.size,
+  'tick_rate': instance.tickRate,
+};
 
 ApiMatchList _$ApiMatchListFromJson(Map<String, dynamic> json) => ApiMatchList(
-      matches: (json['matches'] as List<dynamic>?)?.map((e) => ApiMatch.fromJson(e as Map<String, dynamic>)).toList(),
-    );
+  matches: (json['matches'] as List<dynamic>?)
+      ?.map((e) => ApiMatch.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiMatchListToJson(ApiMatchList instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiMatchListToJson(ApiMatchList instance) =>
+    <String, dynamic>{
       'matches': instance.matches?.map((e) => e.toJson()).toList(),
     };
 
-ApiNotification _$ApiNotificationFromJson(Map<String, dynamic> json) => ApiNotification(
-      code: json['code'] as int?,
+ApiNotification _$ApiNotificationFromJson(Map<String, dynamic> json) =>
+    ApiNotification(
+      code: (json['code'] as num?)?.toInt(),
       content: json['content'] as String?,
       createTime: json['create_time'] as String?,
       id: json['id'] as String?,
@@ -498,7 +565,8 @@ ApiNotification _$ApiNotificationFromJson(Map<String, dynamic> json) => ApiNotif
       subject: json['subject'] as String?,
     );
 
-Map<String, dynamic> _$ApiNotificationToJson(ApiNotification instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiNotificationToJson(ApiNotification instance) =>
+    <String, dynamic>{
       'code': instance.code,
       'content': instance.content,
       'create_time': instance.createTime,
@@ -508,100 +576,118 @@ Map<String, dynamic> _$ApiNotificationToJson(ApiNotification instance) => <Strin
       'subject': instance.subject,
     };
 
-ApiNotificationList _$ApiNotificationListFromJson(Map<String, dynamic> json) => ApiNotificationList(
+ApiNotificationList _$ApiNotificationListFromJson(Map<String, dynamic> json) =>
+    ApiNotificationList(
       cacheableCursor: json['cacheable_cursor'] as String?,
       notifications: (json['notifications'] as List<dynamic>?)
           ?.map((e) => ApiNotification.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$ApiNotificationListToJson(ApiNotificationList instance) => <String, dynamic>{
-      'cacheable_cursor': instance.cacheableCursor,
-      'notifications': instance.notifications?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiNotificationListToJson(
+  ApiNotificationList instance,
+) => <String, dynamic>{
+  'cacheable_cursor': instance.cacheableCursor,
+  'notifications': instance.notifications?.map((e) => e.toJson()).toList(),
+};
 
-ApiReadStorageObjectId _$ApiReadStorageObjectIdFromJson(Map<String, dynamic> json) => ApiReadStorageObjectId(
-      collection: json['collection'] as String?,
-      key: json['key'] as String?,
-      userId: json['user_id'] as String?,
-    );
+ApiReadStorageObjectId _$ApiReadStorageObjectIdFromJson(
+  Map<String, dynamic> json,
+) => ApiReadStorageObjectId(
+  collection: json['collection'] as String?,
+  key: json['key'] as String?,
+  userId: json['user_id'] as String?,
+);
 
-Map<String, dynamic> _$ApiReadStorageObjectIdToJson(ApiReadStorageObjectId instance) => <String, dynamic>{
-      'collection': instance.collection,
-      'key': instance.key,
-      'user_id': instance.userId,
-    };
+Map<String, dynamic> _$ApiReadStorageObjectIdToJson(
+  ApiReadStorageObjectId instance,
+) => <String, dynamic>{
+  'collection': instance.collection,
+  'key': instance.key,
+  'user_id': instance.userId,
+};
 
-ApiReadStorageObjectsRequest _$ApiReadStorageObjectsRequestFromJson(Map<String, dynamic> json) =>
-    ApiReadStorageObjectsRequest(
-      objectIds: (json['object_ids'] as List<dynamic>?)
-          ?.map((e) => ApiReadStorageObjectId.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+ApiReadStorageObjectsRequest _$ApiReadStorageObjectsRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiReadStorageObjectsRequest(
+  objectIds: (json['object_ids'] as List<dynamic>?)
+      ?.map((e) => ApiReadStorageObjectId.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiReadStorageObjectsRequestToJson(ApiReadStorageObjectsRequest instance) => <String, dynamic>{
-      'object_ids': instance.objectIds?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiReadStorageObjectsRequestToJson(
+  ApiReadStorageObjectsRequest instance,
+) => <String, dynamic>{
+  'object_ids': instance.objectIds?.map((e) => e.toJson()).toList(),
+};
 
 ApiRpc _$ApiRpcFromJson(Map<String, dynamic> json) => ApiRpc(
-      httpKey: json['http_key'] as String?,
-      id: json['id'] as String?,
-      payload: json['payload'] as String?,
-    );
+  httpKey: json['http_key'] as String?,
+  id: json['id'] as String?,
+  payload: json['payload'] as String?,
+);
 
 Map<String, dynamic> _$ApiRpcToJson(ApiRpc instance) => <String, dynamic>{
-      'http_key': instance.httpKey,
-      'id': instance.id,
-      'payload': instance.payload,
-    };
+  'http_key': instance.httpKey,
+  'id': instance.id,
+  'payload': instance.payload,
+};
 
 ApiSession _$ApiSessionFromJson(Map<String, dynamic> json) => ApiSession(
-      created: json['created'] as bool?,
-      refreshToken: json['refresh_token'] as String?,
-      token: json['token'] as String?,
-    );
+  created: json['created'] as bool?,
+  refreshToken: json['refresh_token'] as String?,
+  token: json['token'] as String?,
+);
 
-Map<String, dynamic> _$ApiSessionToJson(ApiSession instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiSessionToJson(ApiSession instance) =>
+    <String, dynamic>{
       'created': instance.created,
       'refresh_token': instance.refreshToken,
       'token': instance.token,
     };
 
-ApiSessionLogoutRequest _$ApiSessionLogoutRequestFromJson(Map<String, dynamic> json) => ApiSessionLogoutRequest(
-      refreshToken: json['refresh_token'] as String?,
-      token: json['token'] as String?,
-    );
+ApiSessionLogoutRequest _$ApiSessionLogoutRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiSessionLogoutRequest(
+  refreshToken: json['refresh_token'] as String?,
+  token: json['token'] as String?,
+);
 
-Map<String, dynamic> _$ApiSessionLogoutRequestToJson(ApiSessionLogoutRequest instance) => <String, dynamic>{
-      'refresh_token': instance.refreshToken,
-      'token': instance.token,
-    };
+Map<String, dynamic> _$ApiSessionLogoutRequestToJson(
+  ApiSessionLogoutRequest instance,
+) => <String, dynamic>{
+  'refresh_token': instance.refreshToken,
+  'token': instance.token,
+};
 
-ApiSessionRefreshRequest _$ApiSessionRefreshRequestFromJson(Map<String, dynamic> json) => ApiSessionRefreshRequest(
-      token: json['token'] as String?,
-      vars: (json['vars'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
-      ),
-    );
+ApiSessionRefreshRequest _$ApiSessionRefreshRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiSessionRefreshRequest(
+  token: json['token'] as String?,
+  vars: (json['vars'] as Map<String, dynamic>?)?.map(
+    (k, e) => MapEntry(k, e as String),
+  ),
+);
 
-Map<String, dynamic> _$ApiSessionRefreshRequestToJson(ApiSessionRefreshRequest instance) => <String, dynamic>{
-      'token': instance.token,
-      'vars': instance.vars,
-    };
+Map<String, dynamic> _$ApiSessionRefreshRequestToJson(
+  ApiSessionRefreshRequest instance,
+) => <String, dynamic>{'token': instance.token, 'vars': instance.vars};
 
-ApiStorageObject _$ApiStorageObjectFromJson(Map<String, dynamic> json) => ApiStorageObject(
+ApiStorageObject _$ApiStorageObjectFromJson(Map<String, dynamic> json) =>
+    ApiStorageObject(
       collection: json['collection'] as String?,
       createTime: json['create_time'] as String?,
       key: json['key'] as String?,
-      permissionRead: json['permission_read'] as int?,
-      permissionWrite: json['permission_write'] as int?,
+      permissionRead: (json['permission_read'] as num?)?.toInt(),
+      permissionWrite: (json['permission_write'] as num?)?.toInt(),
       updateTime: json['update_time'] as String?,
       userId: json['user_id'] as String?,
       value: json['value'] as String?,
       version: json['version'] as String?,
     );
 
-Map<String, dynamic> _$ApiStorageObjectToJson(ApiStorageObject instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiStorageObjectToJson(ApiStorageObject instance) =>
+    <String, dynamic>{
       'collection': instance.collection,
       'create_time': instance.createTime,
       'key': instance.key,
@@ -613,89 +699,108 @@ Map<String, dynamic> _$ApiStorageObjectToJson(ApiStorageObject instance) => <Str
       'version': instance.version,
     };
 
-ApiStorageObjectAck _$ApiStorageObjectAckFromJson(Map<String, dynamic> json) => ApiStorageObjectAck(
+ApiStorageObjectAck _$ApiStorageObjectAckFromJson(Map<String, dynamic> json) =>
+    ApiStorageObjectAck(
       collection: json['collection'] as String?,
       key: json['key'] as String?,
       userId: json['user_id'] as String?,
       version: json['version'] as String?,
     );
 
-Map<String, dynamic> _$ApiStorageObjectAckToJson(ApiStorageObjectAck instance) => <String, dynamic>{
-      'collection': instance.collection,
-      'key': instance.key,
-      'user_id': instance.userId,
-      'version': instance.version,
-    };
+Map<String, dynamic> _$ApiStorageObjectAckToJson(
+  ApiStorageObjectAck instance,
+) => <String, dynamic>{
+  'collection': instance.collection,
+  'key': instance.key,
+  'user_id': instance.userId,
+  'version': instance.version,
+};
 
-ApiStorageObjectAcks _$ApiStorageObjectAcksFromJson(Map<String, dynamic> json) => ApiStorageObjectAcks(
-      acks: (json['acks'] as List<dynamic>?)
-          ?.map((e) => ApiStorageObjectAck.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+ApiStorageObjectAcks _$ApiStorageObjectAcksFromJson(
+  Map<String, dynamic> json,
+) => ApiStorageObjectAcks(
+  acks: (json['acks'] as List<dynamic>?)
+      ?.map((e) => ApiStorageObjectAck.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiStorageObjectAcksToJson(ApiStorageObjectAcks instance) => <String, dynamic>{
-      'acks': instance.acks?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiStorageObjectAcksToJson(
+  ApiStorageObjectAcks instance,
+) => <String, dynamic>{'acks': instance.acks?.map((e) => e.toJson()).toList()};
 
-ApiStorageObjectList _$ApiStorageObjectListFromJson(Map<String, dynamic> json) => ApiStorageObjectList(
-      cursor: json['cursor'] as String?,
+ApiStorageObjectList _$ApiStorageObjectListFromJson(
+  Map<String, dynamic> json,
+) => ApiStorageObjectList(
+  cursor: json['cursor'] as String?,
+  objects: (json['objects'] as List<dynamic>?)
+      ?.map((e) => ApiStorageObject.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
+
+Map<String, dynamic> _$ApiStorageObjectListToJson(
+  ApiStorageObjectList instance,
+) => <String, dynamic>{
+  'cursor': instance.cursor,
+  'objects': instance.objects?.map((e) => e.toJson()).toList(),
+};
+
+ApiStorageObjects _$ApiStorageObjectsFromJson(Map<String, dynamic> json) =>
+    ApiStorageObjects(
       objects: (json['objects'] as List<dynamic>?)
           ?.map((e) => ApiStorageObject.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$ApiStorageObjectListToJson(ApiStorageObjectList instance) => <String, dynamic>{
-      'cursor': instance.cursor,
+Map<String, dynamic> _$ApiStorageObjectsToJson(ApiStorageObjects instance) =>
+    <String, dynamic>{
       'objects': instance.objects?.map((e) => e.toJson()).toList(),
     };
 
-ApiStorageObjects _$ApiStorageObjectsFromJson(Map<String, dynamic> json) => ApiStorageObjects(
-      objects: (json['objects'] as List<dynamic>?)
-          ?.map((e) => ApiStorageObject.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+ApiSubscriptionList _$ApiSubscriptionListFromJson(
+  Map<String, dynamic> json,
+) => ApiSubscriptionList(
+  cursor: json['cursor'] as String?,
+  prevCursor: json['prev_cursor'] as String?,
+  validatedSubscriptions: (json['validated_subscriptions'] as List<dynamic>?)
+      ?.map((e) => ApiValidatedSubscription.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiStorageObjectsToJson(ApiStorageObjects instance) => <String, dynamic>{
-      'objects': instance.objects?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiSubscriptionListToJson(
+  ApiSubscriptionList instance,
+) => <String, dynamic>{
+  'cursor': instance.cursor,
+  'prev_cursor': instance.prevCursor,
+  'validated_subscriptions': instance.validatedSubscriptions
+      ?.map((e) => e.toJson())
+      .toList(),
+};
 
-ApiSubscriptionList _$ApiSubscriptionListFromJson(Map<String, dynamic> json) => ApiSubscriptionList(
-      cursor: json['cursor'] as String?,
-      prevCursor: json['prev_cursor'] as String?,
-      validatedSubscriptions: (json['validated_subscriptions'] as List<dynamic>?)
-          ?.map((e) => ApiValidatedSubscription.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
-
-Map<String, dynamic> _$ApiSubscriptionListToJson(ApiSubscriptionList instance) => <String, dynamic>{
-      'cursor': instance.cursor,
-      'prev_cursor': instance.prevCursor,
-      'validated_subscriptions': instance.validatedSubscriptions?.map((e) => e.toJson()).toList(),
-    };
-
-ApiTournament _$ApiTournamentFromJson(Map<String, dynamic> json) => ApiTournament(
+ApiTournament _$ApiTournamentFromJson(Map<String, dynamic> json) =>
+    ApiTournament(
       canEnter: json['can_enter'] as bool?,
-      category: json['category'] as int?,
+      category: (json['category'] as num?)?.toInt(),
       createTime: json['create_time'] as String?,
       description: json['description'] as String?,
-      duration: json['duration'] as int?,
-      endActive: json['end_active'] as int?,
+      duration: (json['duration'] as num?)?.toInt(),
+      endActive: (json['end_active'] as num?)?.toInt(),
       endTime: json['end_time'] as String?,
       id: json['id'] as String?,
-      maxNumScore: json['max_num_score'] as int?,
-      maxSize: json['max_size'] as int?,
+      maxNumScore: (json['max_num_score'] as num?)?.toInt(),
+      maxSize: (json['max_size'] as num?)?.toInt(),
       metadata: json['metadata'] as String?,
-      nextReset: json['next_reset'] as int?,
+      nextReset: (json['next_reset'] as num?)?.toInt(),
       operator: $enumDecodeNullable(_$ApiOperatorEnumMap, json['operator']),
-      prevReset: json['prev_reset'] as int?,
-      size: json['size'] as int?,
-      sortOrder: json['sort_order'] as int?,
-      startActive: json['start_active'] as int?,
+      prevReset: (json['prev_reset'] as num?)?.toInt(),
+      size: (json['size'] as num?)?.toInt(),
+      sortOrder: (json['sort_order'] as num?)?.toInt(),
+      startActive: (json['start_active'] as num?)?.toInt(),
       startTime: json['start_time'] as String?,
       title: json['title'] as String?,
     );
 
-Map<String, dynamic> _$ApiTournamentToJson(ApiTournament instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiTournamentToJson(ApiTournament instance) =>
+    <String, dynamic>{
       'can_enter': instance.canEnter,
       'category': instance.category,
       'create_time': instance.createTime,
@@ -717,242 +822,288 @@ Map<String, dynamic> _$ApiTournamentToJson(ApiTournament instance) => <String, d
       'title': instance.title,
     };
 
-ApiTournamentList _$ApiTournamentListFromJson(Map<String, dynamic> json) => ApiTournamentList(
+ApiTournamentList _$ApiTournamentListFromJson(Map<String, dynamic> json) =>
+    ApiTournamentList(
       cursor: json['cursor'] as String?,
       tournaments: (json['tournaments'] as List<dynamic>?)
           ?.map((e) => ApiTournament.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$ApiTournamentListToJson(ApiTournamentList instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiTournamentListToJson(ApiTournamentList instance) =>
+    <String, dynamic>{
       'cursor': instance.cursor,
       'tournaments': instance.tournaments?.map((e) => e.toJson()).toList(),
     };
 
-ApiTournamentRecordList _$ApiTournamentRecordListFromJson(Map<String, dynamic> json) => ApiTournamentRecordList(
-      nextCursor: json['next_cursor'] as String?,
-      ownerRecords: (json['owner_records'] as List<dynamic>?)
-          ?.map((e) => ApiLeaderboardRecord.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      prevCursor: json['prev_cursor'] as String?,
-      records: (json['records'] as List<dynamic>?)
-          ?.map((e) => ApiLeaderboardRecord.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+ApiTournamentRecordList _$ApiTournamentRecordListFromJson(
+  Map<String, dynamic> json,
+) => ApiTournamentRecordList(
+  nextCursor: json['next_cursor'] as String?,
+  ownerRecords: (json['owner_records'] as List<dynamic>?)
+      ?.map((e) => ApiLeaderboardRecord.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  prevCursor: json['prev_cursor'] as String?,
+  records: (json['records'] as List<dynamic>?)
+      ?.map((e) => ApiLeaderboardRecord.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiTournamentRecordListToJson(ApiTournamentRecordList instance) => <String, dynamic>{
-      'next_cursor': instance.nextCursor,
-      'owner_records': instance.ownerRecords?.map((e) => e.toJson()).toList(),
-      'prev_cursor': instance.prevCursor,
-      'records': instance.records?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiTournamentRecordListToJson(
+  ApiTournamentRecordList instance,
+) => <String, dynamic>{
+  'next_cursor': instance.nextCursor,
+  'owner_records': instance.ownerRecords?.map((e) => e.toJson()).toList(),
+  'prev_cursor': instance.prevCursor,
+  'records': instance.records?.map((e) => e.toJson()).toList(),
+};
 
-ApiUpdateAccountRequest _$ApiUpdateAccountRequestFromJson(Map<String, dynamic> json) => ApiUpdateAccountRequest(
-      avatarUrl: json['avatar_url'] as String?,
-      displayName: json['display_name'] as String?,
-      langTag: json['lang_tag'] as String?,
-      location: json['location'] as String?,
-      timezone: json['timezone'] as String?,
-      username: json['username'] as String?,
-    );
+ApiUpdateAccountRequest _$ApiUpdateAccountRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiUpdateAccountRequest(
+  avatarUrl: json['avatar_url'] as String?,
+  displayName: json['display_name'] as String?,
+  langTag: json['lang_tag'] as String?,
+  location: json['location'] as String?,
+  timezone: json['timezone'] as String?,
+  username: json['username'] as String?,
+);
 
-Map<String, dynamic> _$ApiUpdateAccountRequestToJson(ApiUpdateAccountRequest instance) => <String, dynamic>{
-      'avatar_url': instance.avatarUrl,
-      'display_name': instance.displayName,
-      'lang_tag': instance.langTag,
-      'location': instance.location,
-      'timezone': instance.timezone,
-      'username': instance.username,
-    };
+Map<String, dynamic> _$ApiUpdateAccountRequestToJson(
+  ApiUpdateAccountRequest instance,
+) => <String, dynamic>{
+  'avatar_url': instance.avatarUrl,
+  'display_name': instance.displayName,
+  'lang_tag': instance.langTag,
+  'location': instance.location,
+  'timezone': instance.timezone,
+  'username': instance.username,
+};
 
-ApiUpdateGroupRequest _$ApiUpdateGroupRequestFromJson(Map<String, dynamic> json) => ApiUpdateGroupRequest(
-      avatarUrl: json['avatar_url'] as String?,
-      description: json['description'] as String?,
-      groupId: json['group_id'] as String?,
-      langTag: json['lang_tag'] as String?,
-      name: json['name'] as String?,
-      open: json['open'] as bool?,
-    );
+ApiUpdateGroupRequest _$ApiUpdateGroupRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiUpdateGroupRequest(
+  avatarUrl: json['avatar_url'] as String?,
+  description: json['description'] as String?,
+  groupId: json['group_id'] as String?,
+  langTag: json['lang_tag'] as String?,
+  name: json['name'] as String?,
+  open: json['open'] as bool?,
+);
 
-Map<String, dynamic> _$ApiUpdateGroupRequestToJson(ApiUpdateGroupRequest instance) => <String, dynamic>{
-      'avatar_url': instance.avatarUrl,
-      'description': instance.description,
-      'group_id': instance.groupId,
-      'lang_tag': instance.langTag,
-      'name': instance.name,
-      'open': instance.open,
-    };
+Map<String, dynamic> _$ApiUpdateGroupRequestToJson(
+  ApiUpdateGroupRequest instance,
+) => <String, dynamic>{
+  'avatar_url': instance.avatarUrl,
+  'description': instance.description,
+  'group_id': instance.groupId,
+  'lang_tag': instance.langTag,
+  'name': instance.name,
+  'open': instance.open,
+};
 
 ApiUser _$ApiUserFromJson(Map<String, dynamic> json) => ApiUser(
-      appleId: json['apple_id'] as String?,
-      avatarUrl: json['avatar_url'] as String?,
-      createTime: json['create_time'] as String?,
-      displayName: json['display_name'] as String?,
-      edgeCount: json['edge_count'] as int?,
-      facebookId: json['facebook_id'] as String?,
-      facebookInstantGameId: json['facebook_instant_game_id'] as String?,
-      gamecenterId: json['gamecenter_id'] as String?,
-      googleId: json['google_id'] as String?,
-      id: json['id'] as String?,
-      langTag: json['lang_tag'] as String?,
-      location: json['location'] as String?,
-      metadata: json['metadata'] as String?,
-      online: json['online'] as bool?,
-      steamId: json['steam_id'] as String?,
-      timezone: json['timezone'] as String?,
-      updateTime: json['update_time'] as String?,
-      username: json['username'] as String?,
-    );
+  appleId: json['apple_id'] as String?,
+  avatarUrl: json['avatar_url'] as String?,
+  createTime: json['create_time'] as String?,
+  displayName: json['display_name'] as String?,
+  edgeCount: (json['edge_count'] as num?)?.toInt(),
+  facebookId: json['facebook_id'] as String?,
+  facebookInstantGameId: json['facebook_instant_game_id'] as String?,
+  gamecenterId: json['gamecenter_id'] as String?,
+  googleId: json['google_id'] as String?,
+  id: json['id'] as String?,
+  langTag: json['lang_tag'] as String?,
+  location: json['location'] as String?,
+  metadata: json['metadata'] as String?,
+  online: json['online'] as bool?,
+  steamId: json['steam_id'] as String?,
+  timezone: json['timezone'] as String?,
+  updateTime: json['update_time'] as String?,
+  username: json['username'] as String?,
+);
 
 Map<String, dynamic> _$ApiUserToJson(ApiUser instance) => <String, dynamic>{
-      'apple_id': instance.appleId,
-      'avatar_url': instance.avatarUrl,
-      'create_time': instance.createTime,
-      'display_name': instance.displayName,
-      'edge_count': instance.edgeCount,
-      'facebook_id': instance.facebookId,
-      'facebook_instant_game_id': instance.facebookInstantGameId,
-      'gamecenter_id': instance.gamecenterId,
-      'google_id': instance.googleId,
-      'id': instance.id,
-      'lang_tag': instance.langTag,
-      'location': instance.location,
-      'metadata': instance.metadata,
-      'online': instance.online,
-      'steam_id': instance.steamId,
-      'timezone': instance.timezone,
-      'update_time': instance.updateTime,
-      'username': instance.username,
-    };
+  'apple_id': instance.appleId,
+  'avatar_url': instance.avatarUrl,
+  'create_time': instance.createTime,
+  'display_name': instance.displayName,
+  'edge_count': instance.edgeCount,
+  'facebook_id': instance.facebookId,
+  'facebook_instant_game_id': instance.facebookInstantGameId,
+  'gamecenter_id': instance.gamecenterId,
+  'google_id': instance.googleId,
+  'id': instance.id,
+  'lang_tag': instance.langTag,
+  'location': instance.location,
+  'metadata': instance.metadata,
+  'online': instance.online,
+  'steam_id': instance.steamId,
+  'timezone': instance.timezone,
+  'update_time': instance.updateTime,
+  'username': instance.username,
+};
 
-ApiUserGroupList _$ApiUserGroupListFromJson(Map<String, dynamic> json) => ApiUserGroupList(
+ApiUserGroupList _$ApiUserGroupListFromJson(Map<String, dynamic> json) =>
+    ApiUserGroupList(
       cursor: json['cursor'] as String?,
       userGroups: (json['user_groups'] as List<dynamic>?)
-          ?.map((e) => UserGroupListUserGroup.fromJson(e as Map<String, dynamic>))
+          ?.map(
+            (e) => UserGroupListUserGroup.fromJson(e as Map<String, dynamic>),
+          )
           .toList(),
     );
 
-Map<String, dynamic> _$ApiUserGroupListToJson(ApiUserGroupList instance) => <String, dynamic>{
+Map<String, dynamic> _$ApiUserGroupListToJson(ApiUserGroupList instance) =>
+    <String, dynamic>{
       'cursor': instance.cursor,
       'user_groups': instance.userGroups?.map((e) => e.toJson()).toList(),
     };
 
 ApiUsers _$ApiUsersFromJson(Map<String, dynamic> json) => ApiUsers(
-      users: (json['users'] as List<dynamic>?)?.map((e) => ApiUser.fromJson(e as Map<String, dynamic>)).toList(),
-    );
+  users: (json['users'] as List<dynamic>?)
+      ?.map((e) => ApiUser.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
 Map<String, dynamic> _$ApiUsersToJson(ApiUsers instance) => <String, dynamic>{
-      'users': instance.users?.map((e) => e.toJson()).toList(),
-    };
+  'users': instance.users?.map((e) => e.toJson()).toList(),
+};
 
-ApiValidatePurchaseAppleRequest _$ApiValidatePurchaseAppleRequestFromJson(Map<String, dynamic> json) =>
-    ApiValidatePurchaseAppleRequest(
-      persist: json['persist'] as bool?,
-      receipt: json['receipt'] as String?,
-    );
+ApiValidatePurchaseAppleRequest _$ApiValidatePurchaseAppleRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiValidatePurchaseAppleRequest(
+  persist: json['persist'] as bool?,
+  receipt: json['receipt'] as String?,
+);
 
-Map<String, dynamic> _$ApiValidatePurchaseAppleRequestToJson(ApiValidatePurchaseAppleRequest instance) =>
-    <String, dynamic>{
-      'persist': instance.persist,
-      'receipt': instance.receipt,
-    };
+Map<String, dynamic> _$ApiValidatePurchaseAppleRequestToJson(
+  ApiValidatePurchaseAppleRequest instance,
+) => <String, dynamic>{
+  'persist': instance.persist,
+  'receipt': instance.receipt,
+};
 
-ApiValidatePurchaseGoogleRequest _$ApiValidatePurchaseGoogleRequestFromJson(Map<String, dynamic> json) =>
-    ApiValidatePurchaseGoogleRequest(
-      persist: json['persist'] as bool?,
-      purchase: json['purchase'] as String?,
-    );
+ApiValidatePurchaseGoogleRequest _$ApiValidatePurchaseGoogleRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiValidatePurchaseGoogleRequest(
+  persist: json['persist'] as bool?,
+  purchase: json['purchase'] as String?,
+);
 
-Map<String, dynamic> _$ApiValidatePurchaseGoogleRequestToJson(ApiValidatePurchaseGoogleRequest instance) =>
-    <String, dynamic>{
-      'persist': instance.persist,
-      'purchase': instance.purchase,
-    };
+Map<String, dynamic> _$ApiValidatePurchaseGoogleRequestToJson(
+  ApiValidatePurchaseGoogleRequest instance,
+) => <String, dynamic>{
+  'persist': instance.persist,
+  'purchase': instance.purchase,
+};
 
-ApiValidatePurchaseHuaweiRequest _$ApiValidatePurchaseHuaweiRequestFromJson(Map<String, dynamic> json) =>
-    ApiValidatePurchaseHuaweiRequest(
-      persist: json['persist'] as bool?,
-      purchase: json['purchase'] as String?,
-      signature: json['signature'] as String?,
-    );
+ApiValidatePurchaseHuaweiRequest _$ApiValidatePurchaseHuaweiRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiValidatePurchaseHuaweiRequest(
+  persist: json['persist'] as bool?,
+  purchase: json['purchase'] as String?,
+  signature: json['signature'] as String?,
+);
 
-Map<String, dynamic> _$ApiValidatePurchaseHuaweiRequestToJson(ApiValidatePurchaseHuaweiRequest instance) =>
-    <String, dynamic>{
-      'persist': instance.persist,
-      'purchase': instance.purchase,
-      'signature': instance.signature,
-    };
+Map<String, dynamic> _$ApiValidatePurchaseHuaweiRequestToJson(
+  ApiValidatePurchaseHuaweiRequest instance,
+) => <String, dynamic>{
+  'persist': instance.persist,
+  'purchase': instance.purchase,
+  'signature': instance.signature,
+};
 
-ApiValidatePurchaseResponse _$ApiValidatePurchaseResponseFromJson(Map<String, dynamic> json) =>
-    ApiValidatePurchaseResponse(
-      validatedPurchases: (json['validated_purchases'] as List<dynamic>?)
-          ?.map((e) => ApiValidatedPurchase.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+ApiValidatePurchaseResponse _$ApiValidatePurchaseResponseFromJson(
+  Map<String, dynamic> json,
+) => ApiValidatePurchaseResponse(
+  validatedPurchases: (json['validated_purchases'] as List<dynamic>?)
+      ?.map((e) => ApiValidatedPurchase.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiValidatePurchaseResponseToJson(ApiValidatePurchaseResponse instance) => <String, dynamic>{
-      'validated_purchases': instance.validatedPurchases?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiValidatePurchaseResponseToJson(
+  ApiValidatePurchaseResponse instance,
+) => <String, dynamic>{
+  'validated_purchases': instance.validatedPurchases
+      ?.map((e) => e.toJson())
+      .toList(),
+};
 
-ApiValidateSubscriptionAppleRequest _$ApiValidateSubscriptionAppleRequestFromJson(Map<String, dynamic> json) =>
+ApiValidateSubscriptionAppleRequest
+_$ApiValidateSubscriptionAppleRequestFromJson(Map<String, dynamic> json) =>
     ApiValidateSubscriptionAppleRequest(
       persist: json['persist'] as bool?,
       receipt: json['receipt'] as String?,
     );
 
-Map<String, dynamic> _$ApiValidateSubscriptionAppleRequestToJson(ApiValidateSubscriptionAppleRequest instance) =>
-    <String, dynamic>{
-      'persist': instance.persist,
-      'receipt': instance.receipt,
-    };
+Map<String, dynamic> _$ApiValidateSubscriptionAppleRequestToJson(
+  ApiValidateSubscriptionAppleRequest instance,
+) => <String, dynamic>{
+  'persist': instance.persist,
+  'receipt': instance.receipt,
+};
 
-ApiValidateSubscriptionGoogleRequest _$ApiValidateSubscriptionGoogleRequestFromJson(Map<String, dynamic> json) =>
+ApiValidateSubscriptionGoogleRequest
+_$ApiValidateSubscriptionGoogleRequestFromJson(Map<String, dynamic> json) =>
     ApiValidateSubscriptionGoogleRequest(
       persist: json['persist'] as bool?,
       receipt: json['receipt'] as String?,
     );
 
-Map<String, dynamic> _$ApiValidateSubscriptionGoogleRequestToJson(ApiValidateSubscriptionGoogleRequest instance) =>
-    <String, dynamic>{
-      'persist': instance.persist,
-      'receipt': instance.receipt,
-    };
+Map<String, dynamic> _$ApiValidateSubscriptionGoogleRequestToJson(
+  ApiValidateSubscriptionGoogleRequest instance,
+) => <String, dynamic>{
+  'persist': instance.persist,
+  'receipt': instance.receipt,
+};
 
-ApiValidateSubscriptionResponse _$ApiValidateSubscriptionResponseFromJson(Map<String, dynamic> json) =>
-    ApiValidateSubscriptionResponse(
-      validatedSubscription: json['validated_subscription'] == null
-          ? null
-          : ApiValidatedSubscription.fromJson(json['validated_subscription'] as Map<String, dynamic>),
-    );
+ApiValidateSubscriptionResponse _$ApiValidateSubscriptionResponseFromJson(
+  Map<String, dynamic> json,
+) => ApiValidateSubscriptionResponse(
+  validatedSubscription: json['validated_subscription'] == null
+      ? null
+      : ApiValidatedSubscription.fromJson(
+          json['validated_subscription'] as Map<String, dynamic>,
+        ),
+);
 
-Map<String, dynamic> _$ApiValidateSubscriptionResponseToJson(ApiValidateSubscriptionResponse instance) =>
-    <String, dynamic>{
-      'validated_subscription': instance.validatedSubscription?.toJson(),
-    };
+Map<String, dynamic> _$ApiValidateSubscriptionResponseToJson(
+  ApiValidateSubscriptionResponse instance,
+) => <String, dynamic>{
+  'validated_subscription': instance.validatedSubscription?.toJson(),
+};
 
-ApiValidatedPurchase _$ApiValidatedPurchaseFromJson(Map<String, dynamic> json) => ApiValidatedPurchase(
-      createTime: json['create_time'] as String?,
-      environment: $enumDecodeNullable(_$ApiStoreEnvironmentEnumMap, json['environment']),
-      productId: json['product_id'] as String?,
-      providerResponse: json['provider_response'] as String?,
-      purchaseTime: json['purchase_time'] as String?,
-      seenBefore: json['seen_before'] as bool?,
-      store: $enumDecodeNullable(_$ApiStoreProviderEnumMap, json['store']),
-      transactionId: json['transaction_id'] as String?,
-      updateTime: json['update_time'] as String?,
-    );
+ApiValidatedPurchase _$ApiValidatedPurchaseFromJson(
+  Map<String, dynamic> json,
+) => ApiValidatedPurchase(
+  createTime: json['create_time'] as String?,
+  environment: $enumDecodeNullable(
+    _$ApiStoreEnvironmentEnumMap,
+    json['environment'],
+  ),
+  productId: json['product_id'] as String?,
+  providerResponse: json['provider_response'] as String?,
+  purchaseTime: json['purchase_time'] as String?,
+  seenBefore: json['seen_before'] as bool?,
+  store: $enumDecodeNullable(_$ApiStoreProviderEnumMap, json['store']),
+  transactionId: json['transaction_id'] as String?,
+  updateTime: json['update_time'] as String?,
+);
 
-Map<String, dynamic> _$ApiValidatedPurchaseToJson(ApiValidatedPurchase instance) => <String, dynamic>{
-      'create_time': instance.createTime,
-      'environment': _$ApiStoreEnvironmentEnumMap[instance.environment],
-      'product_id': instance.productId,
-      'provider_response': instance.providerResponse,
-      'purchase_time': instance.purchaseTime,
-      'seen_before': instance.seenBefore,
-      'store': _$ApiStoreProviderEnumMap[instance.store],
-      'transaction_id': instance.transactionId,
-      'update_time': instance.updateTime,
-    };
+Map<String, dynamic> _$ApiValidatedPurchaseToJson(
+  ApiValidatedPurchase instance,
+) => <String, dynamic>{
+  'create_time': instance.createTime,
+  'environment': _$ApiStoreEnvironmentEnumMap[instance.environment],
+  'product_id': instance.productId,
+  'provider_response': instance.providerResponse,
+  'purchase_time': instance.purchaseTime,
+  'seen_before': instance.seenBefore,
+  'store': _$ApiStoreProviderEnumMap[instance.store],
+  'transaction_id': instance.transactionId,
+  'update_time': instance.updateTime,
+};
 
 const _$ApiStoreEnvironmentEnumMap = {
   ApiStoreEnvironment.unknown: 'UNKNOWN',
@@ -966,97 +1117,111 @@ const _$ApiStoreProviderEnumMap = {
   ApiStoreProvider.huaweiAppGallery: 'HUAWEI_APP_GALLERY',
 };
 
-ApiValidatedSubscription _$ApiValidatedSubscriptionFromJson(Map<String, dynamic> json) => ApiValidatedSubscription(
-      active: json['active'] as bool?,
-      createTime: json['create_time'] as String?,
-      environment: $enumDecodeNullable(_$ApiStoreEnvironmentEnumMap, json['environment']),
-      expiryTime: json['expiry_time'] as String?,
-      originalTransactionId: json['original_transaction_id'] as String?,
-      productId: json['product_id'] as String?,
-      purchaseTime: json['purchase_time'] as String?,
-      store: $enumDecodeNullable(_$ApiStoreProviderEnumMap, json['store']),
-      updateTime: json['update_time'] as String?,
-    );
+ApiValidatedSubscription _$ApiValidatedSubscriptionFromJson(
+  Map<String, dynamic> json,
+) => ApiValidatedSubscription(
+  active: json['active'] as bool?,
+  createTime: json['create_time'] as String?,
+  environment: $enumDecodeNullable(
+    _$ApiStoreEnvironmentEnumMap,
+    json['environment'],
+  ),
+  expiryTime: json['expiry_time'] as String?,
+  originalTransactionId: json['original_transaction_id'] as String?,
+  productId: json['product_id'] as String?,
+  purchaseTime: json['purchase_time'] as String?,
+  store: $enumDecodeNullable(_$ApiStoreProviderEnumMap, json['store']),
+  updateTime: json['update_time'] as String?,
+);
 
-Map<String, dynamic> _$ApiValidatedSubscriptionToJson(ApiValidatedSubscription instance) => <String, dynamic>{
-      'active': instance.active,
-      'create_time': instance.createTime,
-      'environment': _$ApiStoreEnvironmentEnumMap[instance.environment],
-      'expiry_time': instance.expiryTime,
-      'original_transaction_id': instance.originalTransactionId,
-      'product_id': instance.productId,
-      'purchase_time': instance.purchaseTime,
-      'store': _$ApiStoreProviderEnumMap[instance.store],
-      'update_time': instance.updateTime,
-    };
+Map<String, dynamic> _$ApiValidatedSubscriptionToJson(
+  ApiValidatedSubscription instance,
+) => <String, dynamic>{
+  'active': instance.active,
+  'create_time': instance.createTime,
+  'environment': _$ApiStoreEnvironmentEnumMap[instance.environment],
+  'expiry_time': instance.expiryTime,
+  'original_transaction_id': instance.originalTransactionId,
+  'product_id': instance.productId,
+  'purchase_time': instance.purchaseTime,
+  'store': _$ApiStoreProviderEnumMap[instance.store],
+  'update_time': instance.updateTime,
+};
 
-ApiWriteStorageObject _$ApiWriteStorageObjectFromJson(Map<String, dynamic> json) => ApiWriteStorageObject(
-      collection: json['collection'] as String?,
-      key: json['key'] as String?,
-      permissionRead: json['permission_read'] as int?,
-      permissionWrite: json['permission_write'] as int?,
-      value: json['value'] as String?,
-      version: json['version'] as String?,
-    );
+ApiWriteStorageObject _$ApiWriteStorageObjectFromJson(
+  Map<String, dynamic> json,
+) => ApiWriteStorageObject(
+  collection: json['collection'] as String?,
+  key: json['key'] as String?,
+  permissionRead: (json['permission_read'] as num?)?.toInt(),
+  permissionWrite: (json['permission_write'] as num?)?.toInt(),
+  value: json['value'] as String?,
+  version: json['version'] as String?,
+);
 
-Map<String, dynamic> _$ApiWriteStorageObjectToJson(ApiWriteStorageObject instance) => <String, dynamic>{
-      'collection': instance.collection,
-      'key': instance.key,
-      'permission_read': instance.permissionRead,
-      'permission_write': instance.permissionWrite,
-      'value': instance.value,
-      'version': instance.version,
-    };
+Map<String, dynamic> _$ApiWriteStorageObjectToJson(
+  ApiWriteStorageObject instance,
+) => <String, dynamic>{
+  'collection': instance.collection,
+  'key': instance.key,
+  'permission_read': instance.permissionRead,
+  'permission_write': instance.permissionWrite,
+  'value': instance.value,
+  'version': instance.version,
+};
 
-ApiWriteStorageObjectsRequest _$ApiWriteStorageObjectsRequestFromJson(Map<String, dynamic> json) =>
-    ApiWriteStorageObjectsRequest(
-      objects: (json['objects'] as List<dynamic>?)
-          ?.map((e) => ApiWriteStorageObject.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+ApiWriteStorageObjectsRequest _$ApiWriteStorageObjectsRequestFromJson(
+  Map<String, dynamic> json,
+) => ApiWriteStorageObjectsRequest(
+  objects: (json['objects'] as List<dynamic>?)
+      ?.map((e) => ApiWriteStorageObject.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
-Map<String, dynamic> _$ApiWriteStorageObjectsRequestToJson(ApiWriteStorageObjectsRequest instance) => <String, dynamic>{
-      'objects': instance.objects?.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$ApiWriteStorageObjectsRequestToJson(
+  ApiWriteStorageObjectsRequest instance,
+) => <String, dynamic>{
+  'objects': instance.objects?.map((e) => e.toJson()).toList(),
+};
 
 ProtobufAny _$ProtobufAnyFromJson(Map<String, dynamic> json) => ProtobufAny(
-      typeUrl: json['type_url'] as String?,
-      value: json['value'] as String?,
-    );
+  typeUrl: json['type_url'] as String?,
+  value: json['value'] as String?,
+);
 
-Map<String, dynamic> _$ProtobufAnyToJson(ProtobufAny instance) => <String, dynamic>{
-      'type_url': instance.typeUrl,
-      'value': instance.value,
-    };
+Map<String, dynamic> _$ProtobufAnyToJson(ProtobufAny instance) =>
+    <String, dynamic>{'type_url': instance.typeUrl, 'value': instance.value};
 
 RpcStatus _$RpcStatusFromJson(Map<String, dynamic> json) => RpcStatus(
-      code: json['code'] as int?,
-      details:
-          (json['details'] as List<dynamic>?)?.map((e) => ProtobufAny.fromJson(e as Map<String, dynamic>)).toList(),
-      message: json['message'] as String?,
-    );
+  code: (json['code'] as num?)?.toInt(),
+  details: (json['details'] as List<dynamic>?)
+      ?.map((e) => ProtobufAny.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  message: json['message'] as String?,
+);
 
 Map<String, dynamic> _$RpcStatusToJson(RpcStatus instance) => <String, dynamic>{
-      'code': instance.code,
-      'details': instance.details?.map((e) => e.toJson()).toList(),
-      'message': instance.message,
-    };
+  'code': instance.code,
+  'details': instance.details?.map((e) => e.toJson()).toList(),
+  'message': instance.message,
+};
+
+// dart format off
 
 // **************************************************************************
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
 
 class _ApiClient implements ApiClient {
-  _ApiClient(
-    this._dio, {
-    this.baseUrl,
-  });
+  _ApiClient(this._dio, {this.baseUrl, this.errorLogger});
 
   final Dio _dio;
 
   String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
 
   @override
   Future<void> healthcheck({String? bearerToken}) async {
@@ -1065,22 +1230,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/healthcheck',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/healthcheck',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1090,24 +1250,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiAccount>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiAccount.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiAccount>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiAccount _value;
+    try {
+      _value = ApiAccount.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1121,22 +1282,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'PUT',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1157,24 +1313,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/apple',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/apple',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1195,24 +1352,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/custom',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/custom',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1233,24 +1391,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/device',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/device',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1271,24 +1430,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/email',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/email',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1311,24 +1471,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/facebook',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/facebook',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1349,24 +1510,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/facebookinstantgame',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/facebookinstantgame',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1387,24 +1549,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/gamecenter',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/gamecenter',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1425,24 +1588,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/google',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/google',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1465,24 +1629,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/authenticate/steam',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/authenticate/steam',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1496,22 +1661,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/apple',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/apple',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1525,22 +1685,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/custom',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/custom',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1554,22 +1709,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/device',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/device',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1583,22 +1733,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/email',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/email',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1613,22 +1758,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/facebook',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/facebook',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1642,22 +1782,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/facebookinstantgame',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/facebookinstantgame',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1671,22 +1806,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/gamecenter',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/gamecenter',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1700,22 +1830,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/google',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/google',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1729,22 +1854,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/link/steam',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/link/steam',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1760,24 +1880,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSession>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/session/refresh',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSession.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSession>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/session/refresh',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSession _value;
+    try {
+      _value = ApiSession.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -1791,22 +1912,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/apple',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/apple',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1820,22 +1936,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/custom',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/custom',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1849,22 +1960,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/device',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/device',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1878,22 +1984,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/email',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/email',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1907,22 +2008,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/facebook',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/facebook',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1936,22 +2032,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/facebookinstantgame',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/facebookinstantgame',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1965,22 +2056,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/gamecenter',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/gamecenter',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -1994,22 +2080,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/google',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/google',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2023,22 +2104,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/account/unlink/steam',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/account/unlink/steam',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2058,53 +2134,46 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiChannelMessageList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/channel/${channelId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiChannelMessageList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiChannelMessageList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/channel/${channelId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiChannelMessageList _value;
+    try {
+      _value = ApiChannelMessageList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
-  Future<void> event({
-    String? bearerToken,
-    required ApiEvent body,
-  }) async {
+  Future<void> event({String? bearerToken, required ApiEvent body}) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/event',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/event',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2121,22 +2190,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'DELETE',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/friend',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/friend',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2155,24 +2219,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiFriendList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/friend',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiFriendList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiFriendList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/friend',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiFriendList _value;
+    try {
+      _value = ApiFriendList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2189,22 +2254,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/friend',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/friend',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2221,22 +2281,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/friend/block',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/friend/block',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2251,22 +2306,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/friend/facebook',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/friend/facebook',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2281,22 +2331,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/friend/steam',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/friend/steam',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2321,24 +2366,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiGroupList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiGroupList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiGroupList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiGroupList _value;
+    try {
+      _value = ApiGroupList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2352,24 +2398,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiGroup>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiGroup.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiGroup>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiGroup _value;
+    try {
+      _value = ApiGroup.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2382,22 +2429,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'DELETE',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2412,22 +2454,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'PUT',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2441,22 +2478,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}/add',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}/add',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2470,22 +2502,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}/ban',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}/ban',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2499,50 +2526,37 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}/demote',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}/demote',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
-  Future<void> joinGroup({
-    String? bearerToken,
-    required String groupId,
-  }) async {
+  Future<void> joinGroup({String? bearerToken, required String groupId}) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}/join',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}/join',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2556,22 +2570,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}/kick',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}/kick',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2584,22 +2593,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}/leave',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}/leave',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2613,22 +2617,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}/promote',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}/promote',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2648,24 +2647,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiGroupUserList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/group/${groupId}/user',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiGroupUserList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiGroupUserList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/group/${groupId}/user',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiGroupUserList _value;
+    try {
+      _value = ApiGroupUserList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2679,24 +2679,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiValidatePurchaseResponse>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/iap/purchase/apple',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiValidatePurchaseResponse.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiValidatePurchaseResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/iap/purchase/apple',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiValidatePurchaseResponse _value;
+    try {
+      _value = ApiValidatePurchaseResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2710,24 +2711,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiValidatePurchaseResponse>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/iap/purchase/google',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiValidatePurchaseResponse.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiValidatePurchaseResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/iap/purchase/google',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiValidatePurchaseResponse _value;
+    try {
+      _value = ApiValidatePurchaseResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2741,24 +2743,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiValidatePurchaseResponse>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/iap/purchase/huawei',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiValidatePurchaseResponse.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiValidatePurchaseResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/iap/purchase/huawei',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiValidatePurchaseResponse _value;
+    try {
+      _value = ApiValidatePurchaseResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2772,24 +2775,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiSubscriptionList>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/iap/subscription',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiSubscriptionList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiSubscriptionList>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/iap/subscription',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiSubscriptionList _value;
+    try {
+      _value = ApiSubscriptionList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2803,24 +2807,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiValidateSubscriptionResponse>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/iap/subscription/apple',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiValidateSubscriptionResponse.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiValidateSubscriptionResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/iap/subscription/apple',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiValidateSubscriptionResponse _value;
+    try {
+      _value = ApiValidateSubscriptionResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2834,24 +2839,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiValidateSubscriptionResponse>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/iap/subscription/google',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiValidateSubscriptionResponse.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiValidateSubscriptionResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/iap/subscription/google',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiValidateSubscriptionResponse _value;
+    try {
+      _value = ApiValidateSubscriptionResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2864,24 +2870,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiValidatedSubscription>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/iap/subscription/${productId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiValidatedSubscription.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiValidatedSubscription>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/iap/subscription/${productId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiValidatedSubscription _value;
+    try {
+      _value = ApiValidatedSubscription.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2894,22 +2901,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'DELETE',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/leaderboard/${leaderboardId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/leaderboard/${leaderboardId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -2931,24 +2933,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiLeaderboardRecordList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/leaderboard/${leaderboardId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiLeaderboardRecordList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiLeaderboardRecordList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/leaderboard/${leaderboardId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiLeaderboardRecordList _value;
+    try {
+      _value = ApiLeaderboardRecordList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2963,24 +2966,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiLeaderboardRecord>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/leaderboard/${leaderboardId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiLeaderboardRecord.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiLeaderboardRecord>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/leaderboard/${leaderboardId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiLeaderboardRecord _value;
+    try {
+      _value = ApiLeaderboardRecord.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -2999,24 +3003,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiLeaderboardRecordList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/leaderboard/${leaderboardId}/owner/${ownerId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiLeaderboardRecordList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiLeaderboardRecordList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/leaderboard/${leaderboardId}/owner/${ownerId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiLeaderboardRecordList _value;
+    try {
+      _value = ApiLeaderboardRecordList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3041,24 +3046,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiMatchList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/match',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiMatchList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiMatchList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/match',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiMatchList _value;
+    try {
+      _value = ApiMatchList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3071,22 +3077,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'DELETE',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/notification',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/notification',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -3103,24 +3104,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiNotificationList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/notification',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiNotificationList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiNotificationList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/notification',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiNotificationList _value;
+    try {
+      _value = ApiNotificationList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3140,24 +3142,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiRpc>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/rpc/${id}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiRpc.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiRpc>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/rpc/${id}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiRpc _value;
+    try {
+      _value = ApiRpc.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3174,24 +3177,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     final _data = body;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiRpc>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/rpc/${id}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiRpc.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiRpc>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/rpc/${id}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiRpc _value;
+    try {
+      _value = ApiRpc.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3205,22 +3209,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/session/logout',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/session/logout',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -3234,24 +3233,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiStorageObjects>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/storage',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiStorageObjects.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiStorageObjects>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/storage',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiStorageObjects _value;
+    try {
+      _value = ApiStorageObjects.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3265,24 +3265,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiStorageObjectAcks>(Options(
-      method: 'PUT',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/storage',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiStorageObjectAcks.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiStorageObjectAcks>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/storage',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiStorageObjectAcks _value;
+    try {
+      _value = ApiStorageObjectAcks.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3296,22 +3297,17 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'PUT',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/storage/delete',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/storage/delete',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -3331,24 +3327,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiStorageObjectList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/storage/${collection}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiStorageObjectList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiStorageObjectList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/storage/${collection}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiStorageObjectList _value;
+    try {
+      _value = ApiStorageObjectList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3367,24 +3364,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiStorageObjectList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/storage/${collection}/${userId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiStorageObjectList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiStorageObjectList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/storage/${collection}/${userId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiStorageObjectList _value;
+    try {
+      _value = ApiStorageObjectList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3409,24 +3407,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiTournamentList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/tournament',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiTournamentList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiTournamentList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/tournament',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiTournamentList _value;
+    try {
+      _value = ApiTournamentList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3448,24 +3447,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiTournamentRecordList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/tournament/${tournamentId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiTournamentRecordList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiTournamentRecordList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/tournament/${tournamentId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiTournamentRecordList _value;
+    try {
+      _value = ApiTournamentRecordList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3480,24 +3480,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiLeaderboardRecord>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/tournament/${tournamentId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiLeaderboardRecord.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiLeaderboardRecord>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/tournament/${tournamentId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiLeaderboardRecord _value;
+    try {
+      _value = ApiLeaderboardRecord.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3512,24 +3513,25 @@ class _ApiClient implements ApiClient {
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiLeaderboardRecord>(Options(
-      method: 'PUT',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/tournament/${tournamentId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiLeaderboardRecord.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiLeaderboardRecord>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/tournament/${tournamentId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiLeaderboardRecord _value;
+    try {
+      _value = ApiLeaderboardRecord.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3542,22 +3544,17 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    await _dio.fetch<void>(_setStreamType<void>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/tournament/${tournamentId}/join',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/tournament/${tournamentId}/join',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   @override
@@ -3576,24 +3573,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiTournamentRecordList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/tournament/${tournamentId}/owner/${ownerId}',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiTournamentRecordList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiTournamentRecordList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/tournament/${tournamentId}/owner/${ownerId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiTournamentRecordList _value;
+    try {
+      _value = ApiTournamentRecordList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3612,24 +3610,25 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiUsers>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/user',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiUsers.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiUsers>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/user',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiUsers _value;
+    try {
+      _value = ApiUsers.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   @override
@@ -3649,29 +3648,31 @@ class _ApiClient implements ApiClient {
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<ApiUserGroupList>(Options(
-      method: 'GET',
-      headers: _headers,
-      extra: _extra,
-    )
-        .compose(
-          _dio.options,
-          '/v2/user/${userId}/group',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        ))));
-    final value = ApiUserGroupList.fromJson(_result.data!);
-    return value;
+    final _options = _setStreamType<ApiUserGroupList>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/user/${userId}/group',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiUserGroupList _value;
+    try {
+      _value = ApiUserGroupList.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
   }
 
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
-        !(requestOptions.responseType == ResponseType.bytes || requestOptions.responseType == ResponseType.stream)) {
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
       if (T == String) {
         requestOptions.responseType = ResponseType.plain;
       } else {
@@ -3681,10 +3682,7 @@ class _ApiClient implements ApiClient {
     return requestOptions;
   }
 
-  String _combineBaseUrls(
-    String dioBaseUrl,
-    String? baseUrl,
-  ) {
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }
@@ -3698,3 +3696,5 @@ class _ApiClient implements ApiClient {
     return Uri.parse(dioBaseUrl).resolveUri(url).toString();
   }
 }
+
+// dart format on

--- a/nakama/pubspec.lock
+++ b/nakama/pubspec.lock
@@ -5,18 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: f0bb5d1648339c8308cc0b9838d8456b3cfe5c91f9dc1a735b4d003269e5da9a
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "88.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "3394478cd571a8dbbe130a35e10bd365a2a8e7a867308142f7fd20336a08c3be"
+      sha256: "0b7b9c329d2879f8f05d6c05b32ee9ec025f39b077864bdb5ac9a7b63418a98f"
       url: "https://pub.dev"
     source: hosted
-    version: "7.5.1"
+    version: "8.1.1"
+  ansicolor:
+    dependency: transitive
+    description:
+      name: ansicolor
+      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   args:
     dependency: transitive
     description:
@@ -45,50 +53,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: dfb67ccc9a78c642193e0c2d94cb9e48c2c818b3178a86097d644acdcde6a8d9
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "4.0.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.4"
+    version: "4.1.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: "04f69b1502f66e22ae7990bbd01eb552b7f12793c4d3ea6e715d0ac5e98bcdac"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.2"
+    version: "2.10.2"
   built_collection:
     dependency: transitive
     description:
@@ -101,18 +93,18 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
       url: "https://pub.dev"
     source: hosted
-    version: "8.10.1"
+    version: "8.12.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   cli_config:
     dependency: transitive
     description:
@@ -133,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.0"
   collection:
     dependency: transitive
     description:
@@ -157,34 +149,34 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.1"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.9.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -221,26 +213,26 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   freezed:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "6022db4c7bfa626841b2a10f34dd1e1b68e8f8f9650db6112dcdeeca45ca793c"
+      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.2.3"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -285,18 +277,26 @@ packages:
     dependency: "direct main"
     description:
       name: grpc
-      sha256: "2dde469ddd8bbd7a33a0765da417abe1ad2142813efce3a86c512041294e2b26"
+      sha256: "807a4da90fc1ba94dccc3a44653d3ff7bcf26818f030259d6a8f9fab405cb880"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.1"
+  hotreloader:
+    dependency: transitive
+    description:
+      name: hotreloader
+      sha256: bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.6.0"
   http2:
     dependency: transitive
     description:
@@ -349,10 +349,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: "33a040668b31b320aafa4822b7b1e177e163fc3c1e835c6750319d4ab23aa6fe"
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.11.1"
   jwt_decoder:
     dependency: "direct main"
     description:
@@ -361,14 +361,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  lean_builder:
+    dependency: transitive
+    description:
+      name: lean_builder
+      sha256: ef5cd5f907157eb7aa87d1704504b5a6386d2cbff88a3c2b3344477bab323ee9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.0.0"
   logging:
     dependency: "direct main"
     description:
@@ -429,18 +437,18 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   protobuf:
     dependency: "direct main"
     description:
       name: protobuf
-      sha256: "579fe5557eae58e3adca2e999e38f02441d8aa908703854a9e0a0f47fa857731"
+      sha256: "2fcc8a202ca7ec17dab7c97d6b6d91cf03aa07fe6f65f8afbb6dfa52cc5bd902"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.1.0"
   pub_semver:
     dependency: transitive
     description:
@@ -461,18 +469,18 @@ packages:
     dependency: "direct main"
     description:
       name: retrofit
-      sha256: c6cc9ad3374e6d07008343140a67afffaaa34cdf6bf08d4847d91417a99dcf45
+      sha256: "7d78824afa6eeeaf6ac58220910ee7a97597b39e93360d4bda230b7c6df45089"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.2"
+    version: "4.9.0"
   retrofit_generator:
     dependency: "direct dev"
     description:
       name: retrofit_generator
-      sha256: "65d28d3a7b4db485f1c73fee8ee32f552ef23ee4ecb68ba491f39d80b73bdcbf"
+      sha256: "56df50afab95199dada9e1afbfe5ec228612d03859b250e5e4846c3ebfe50bf7"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.0"
+    version: "10.1.4"
   shelf:
     dependency: transitive
     description:
@@ -509,18 +517,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: "9098ab86015c4f1d8af6486b547b11100e73b193e1899015033cb3e14ad20243"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "4.0.2"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.5"
+    version: "1.3.8"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -589,34 +597,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "8f0eb7fa76b7d05a4f3707e0dbd581babef5b0915ca508b757cf15d0cabb56cb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.27.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: bad9916601a4f2ef6e4dbc466fb712e4b42cf4917c3fd428b018f51984fce13b
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
+    version: "0.6.13"
   typed_data:
     dependency: transitive
     description:
@@ -637,10 +637,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.4"
   web:
     dependency: transitive
     description:
@@ -673,6 +673,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  xxh3:
+    dependency: transitive
+    description:
+      name: xxh3
+      sha256: "399a0438f5d426785723c99da6b16e136f4953fb1e9db0bf270bd41dd4619916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -682,4 +690,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"

--- a/nakama/pubspec.yaml
+++ b/nakama/pubspec.yaml
@@ -6,26 +6,26 @@ repository: https://github.com/heroiclabs/nakama-dart
 homepage: https://heroiclabs.com/docs/nakama/client-libraries/dart
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
+  sdk: ^3.8.0
 
 dependencies:
-  dio: ^5.7.0
+  dio: ^5.9.0
   fixnum: ^1.1.0
-  freezed_annotation: ^3.0.0
+  freezed_annotation: ^3.1.0
   grpc: ^4.1.0
-  json_annotation: ^4.8.1
+  json_annotation: ^4.9.0
   jwt_decoder: ^2.0.1
   logging: ^1.1.0
   meta: ^1.8.0
-  protobuf: ^4.1.0
+  protobuf: ^5.1.0
   retrofit: ^4.4.2
   web_socket_channel: ^3.0.1
 
 dev_dependencies:
-  build_runner: ^2.3.2
+  build_runner: ^2.10.2
   faker: ^2.0.0
-  flutter_lints: ^5.0.0
-  freezed: ^3.0.6
+  flutter_lints: ^6.0.0
+  freezed: ^3.2.3
   json_serializable: ^6.7.1
-  retrofit_generator: ^9.2.0
-  test: ^1.22.0
+  retrofit_generator: ^10.1.4
+  test: ^1.27.0

--- a/nakama/regenerate.sh
+++ b/nakama/regenerate.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+# Nakama Dart Code Generation Script
+# 
+# This script orchestrates all three code generation systems:
+# 1. Protocol Buffers (via build-protobuf.sh)
+# 2. OpenAPI/REST API (via main.go)
+# 3. Freezed & json_serializable (via build_runner)
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=========================================="
+echo "1. Regenerating Protocol Buffers (if applicable)"
+echo "=========================================="
+cd "$SCRIPT_DIR/tool"
+if [ -f build-protobuf.sh ]; then
+    bash build-protobuf.sh
+    echo "✓ Protocol Buffers regenerated"
+fi
+
+echo ""
+echo "=========================================="
+echo "2. Generating OpenAPI Code (main.go)"
+echo "=========================================="
+OPENAPI_SPEC="$SCRIPT_DIR/lib/swaggers/apigrpc.swagger"
+
+if [ ! -f "$OPENAPI_SPEC" ]; then
+    echo "✗ ERROR: OpenAPI spec not found at: $OPENAPI_SPEC"
+    exit 1
+fi
+
+echo "Found OpenAPI spec: $OPENAPI_SPEC"
+
+# Run main.go
+cd "$SCRIPT_DIR/tool"
+go run main.go "$OPENAPI_SPEC" "nakama" -output "$SCRIPT_DIR/lib/src/rest/api_client.gen.dart"
+echo "✓ main.go code generation completed"
+
+echo ""
+echo "=========================================="
+echo "3. Regenerating Freezed & json_serializable"
+echo "=========================================="
+cd "$SCRIPT_DIR"
+flutter pub get
+
+echo "Cleaning build cache to ensure fresh generation..."
+dart run build_runner clean > /dev/null 2>&1
+
+echo "Running build_runner..."
+# Suppress verbose json_serializable warnings about conflicting JsonKey.name annotations
+# These warnings are expected with freezed patterns and don't indicate actual errors
+dart run build_runner build --delete-conflicting-outputs 2>&1 | \
+  grep -v "has conflicting .JsonKey.name. annotations" | \
+  grep -v "W json_serializable on" | \
+  grep -v "W retrofit_generator on" || true
+
+echo "✓ Freezed and json_serializable regenerated"
+
+echo ""
+echo "=========================================="
+echo "4. Verifying generated files exist"
+echo "=========================================="
+files_to_check=(
+    "$SCRIPT_DIR/lib/src/rest/api_client.gen.dart"
+    "$SCRIPT_DIR/lib/src/rest/api_client.gen.g.dart"
+    "$SCRIPT_DIR/lib/src/models/account.freezed.dart"
+    "$SCRIPT_DIR/lib/src/models/account.g.dart"
+)
+
+for file in "${files_to_check[@]}"; do
+    if [ -f "$file" ]; then
+        echo "✓ $(basename "$file") exists"
+    else
+        echo "✗ MISSING: $file"
+    fi
+done
+
+echo ""
+echo "=========================================="
+echo "5. Running analysis"
+echo "=========================================="
+cd "$SCRIPT_DIR"
+
+# Run analysis and handle exit codes properly
+# Use --no-fatal-infos and --no-fatal-warnings to only fail on actual errors
+if flutter analyze --no-fatal-infos --no-fatal-warnings 2>&1 | tee /tmp/flutter_analyze.log; then
+    echo ""
+    echo "✓ Analysis complete - no errors found"
+    ANALYSIS_OK=true
+else
+    # Check if there are actual errors (not just warnings/infos)
+    if grep -q "^error •" /tmp/flutter_analyze.log 2>/dev/null; then
+        echo ""
+        echo "✗ Analysis found errors - see output above"
+        rm -f /tmp/flutter_analyze.log
+        exit 1
+    else
+        echo ""
+        echo "✓ Analysis complete (warnings/info are non-blocking)"
+        ANALYSIS_OK=true
+    fi
+fi
+
+# Cleanup
+rm -f /tmp/flutter_analyze.log
+
+if [ "$ANALYSIS_OK" = true ]; then
+    echo ""
+    echo "=========================================="
+    echo "✓ Code generation completed successfully!"
+    echo "=========================================="
+    exit 0
+fi

--- a/nakama/test/grpc/leaderboard_test.dart
+++ b/nakama/test/grpc/leaderboard_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('[gRPC] Test Leaderboard', () {
     late final NakamaBaseClient client;
     late final Session session;
-    late final String leaderboardName = "test";
+    late final String leaderboardName = 'test';
 
     setUpAll(() async {
       client = getNakamaClient(

--- a/nakama/test/rest/leaderboard_test.dart
+++ b/nakama/test/rest/leaderboard_test.dart
@@ -8,7 +8,7 @@ void main() {
   group('[REST] Test Leaderboard', () {
     late final NakamaBaseClient client;
     late final Session session;
-    late final String leaderboardName = "test";
+    late final String leaderboardName = 'test';
 
     setUpAll(() async {
       client = NakamaRestApiClient.init(

--- a/nakama/tool/build-protobuf.sh
+++ b/nakama/tool/build-protobuf.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
+set -e
+
+# Get the absolute path to the tool directory
+TOOL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAKAMA_DIR="$(cd "$TOOL_DIR/.." && pwd)"
+
+echo "[*] Cleaning up old build directory..."
+rm -rf "$TOOL_DIR/.proto-build"
+
 echo "[*] Creating tmp build folder"
-mkdir -p .proto-build/src .proto-build/build .proto-build/dist
-cd .proto-build/src
+mkdir -p "$TOOL_DIR/.proto-build/src" "$TOOL_DIR/.proto-build/build" "$TOOL_DIR/.proto-build/dist"
+cd "$TOOL_DIR/.proto-build/src"
 
 echo "[*] Downloading and preparing dependencies ..."
-git clone https://github.com/heroiclabs/nakama.git
-git clone https://github.com/heroiclabs/nakama-common.git
-git clone https://github.com/grpc-ecosystem/grpc-gateway.git
-git clone https://github.com/googleapis/api-common-protos.git
-git clone https://github.com/protocolbuffers/protobuf.git
+git clone --depth 1 https://github.com/heroiclabs/nakama.git
+git clone --depth 1 https://github.com/heroiclabs/nakama-common.git
+git clone --depth 1 https://github.com/grpc-ecosystem/grpc-gateway.git
+git clone --depth 1 https://github.com/googleapis/api-common-protos.git
+git clone --depth 1 https://github.com/protocolbuffers/protobuf.git
 cd ..
 
 echo "[*] Organizing sources to compile..."
@@ -19,7 +28,7 @@ cp -r src/nakama-common/api build
 cp -r src/nakama-common/rtapi build
 
 mkdir -p build/protoc-gen-openapiv2/options
-cp -r src/grpc-gateway/protoc-gen-openapiv2/options/ build/protoc-gen-openapiv2/options/
+cp src/grpc-gateway/protoc-gen-openapiv2/options/*.proto build/protoc-gen-openapiv2/options/
 
 mkdir -p build/google/api
 cp -r src/api-common-protos/google/api build/google
@@ -53,16 +62,16 @@ rm -f google/protobuf/*.pbserver.dart
 cd ..
 
 echo "[*] Copy files..."
-rm -rf ../lib/src/api/proto
-mkdir ../lib/src/api/proto
-cp -r dist/* ../lib/src/api/proto
+rm -rf "$NAKAMA_DIR/lib/src/api/proto"
+mkdir -p "$NAKAMA_DIR/lib/src/api/proto"
+cp -r dist/* "$NAKAMA_DIR/lib/src/api/proto/"
 
 echo "[*] Cleanup..."
-cd ..
+cd "$TOOL_DIR"
 rm -rf .proto-build
 
 echo "[*] Format dart files"
-cd ../lib/src/api/proto
+cd "$NAKAMA_DIR/lib/src/api/proto"
 dart format --set-exit-if-changed .
 
 echo "[+] Done"

--- a/satori/lib/src/rest/satori.enums.swagger.dart
+++ b/satori/lib/src/rest/satori.enums.swagger.dart
@@ -1,5 +1,4 @@
 import 'package:json_annotation/json_annotation.dart';
-import 'package:collection/collection.dart';
 
 enum FlagValueChangeReasonType {
   @JsonValue(null)

--- a/satori/lib/src/rest/satori.swagger.dart
+++ b/satori/lib/src/rest/satori.swagger.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: type=lint
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:json_annotation/json_annotation.dart' as json;
 import 'package:collection/collection.dart';
 import 'dart:convert';
 
@@ -10,7 +9,6 @@ import 'package:chopper/chopper.dart';
 import 'client_mapping.dart';
 import 'dart:async';
 import 'package:http/http.dart' as http;
-import 'package:http/http.dart' show MultipartFile;
 import 'package:chopper/chopper.dart' as chopper;
 import 'satori.enums.swagger.dart' as enums;
 export 'satori.enums.swagger.dart';


### PR DESCRIPTION
- Updated Dart SDK constraint to ^3.8.0 in pubspec.yaml
- Bumped various dependencies in pubspec.yaml including dio, freezed_annotation, json_annotation, protobuf, retrofit, flutter_lints, and test.
- Added a new script `regenerate.sh` for orchestrating code generation for Protocol Buffers, OpenAPI, and Freezed/json_serializable.
- Fixed broken code generation
- Updated pubspec.lock with new dependency versions and checksums.
- Refactored leaderboard test files to use single quotes for string literals.
- Removed unused import from satori.enums.swagger.dart and satori.swagger.dart.