### PR TITLE
Fix BoolValue null wrapping in Nakama & cursor pagination test

### DIFF
--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -758,7 +758,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       api.ListChannelMessagesRequest(
         channelId: channelId,
         limit: api.Int32Value(value: limit),
-        forward: api.BoolValue(value: forward),
+        forward: forward != null ? api.BoolValue(value: forward) : null,
         cursor: cursor,
       ),
       options: _getSessionCallOptions(session),
@@ -959,7 +959,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
         description: api.StringValue(value: description),
         langTag: api.StringValue(value: langTag),
         name: api.StringValue(value: name),
-        open: api.BoolValue(value: open),
+        open: open != null ? api.BoolValue(value: open) : null,
       ),
       options: _getSessionCallOptions(session),
     );
@@ -1184,7 +1184,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }) async {
     final res = await _client.listMatches(
       api.ListMatchesRequest(
-        authoritative: api.BoolValue(value: authoritative),
+        authoritative: authoritative != null ? api.BoolValue(value: authoritative) : null,
         label: label != null ? api.StringValue(value: label) : null,
         limit: api.Int32Value(value: limit),
         maxSize: api.Int32Value(value: maxSize),

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -735,7 +735,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       api.ListStorageObjectsRequest(
         collection: collection,
         cursor: cursor,
-        limit: api.Int32Value(value: limit),
+        limit: limit != null ? api.Int32Value(value: limit) : null,
         userId: userId,
       ),
       options: _getSessionCallOptions(session),

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -955,10 +955,10 @@ class NakamaGrpcClient extends NakamaBaseClient {
     await _client.updateGroup(
       api.UpdateGroupRequest(
         groupId: groupId,
-        avatarUrl: api.StringValue(value: avatarUrl),
-        description: api.StringValue(value: description),
-        langTag: api.StringValue(value: langTag),
-        name: api.StringValue(value: name),
+        avatarUrl: avatarUrl != null ? api.StringValue(value: avatarUrl) : null,
+        description: description != null ? api.StringValue(value: description) : null,
+        langTag: langTag != null ? api.StringValue(value: langTag) : null,
+        name: name != null ? api.StringValue(value: name) : null,
         open: open != null ? api.BoolValue(value: open) : null,
       ),
       options: _getSessionCallOptions(session),
@@ -1187,8 +1187,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
         authoritative: authoritative != null ? api.BoolValue(value: authoritative) : null,
         label: label != null ? api.StringValue(value: label) : null,
         limit: api.Int32Value(value: limit),
-        maxSize: api.Int32Value(value: maxSize),
-        minSize: api.Int32Value(value: minSize),
+        maxSize: maxSize != null ? api.Int32Value(value: maxSize) : null,
+        minSize: minSize != null ? api.Int32Value(value: minSize) : null,
         query: query != null ? api.StringValue(value: query) : null,
       ),
       options: _getSessionCallOptions(session),
@@ -1222,11 +1222,11 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }) async {
     final res = await _client.listTournaments(
       api.ListTournamentsRequest(
-        categoryEnd: api.UInt32Value(value: categoryEnd),
-        categoryStart: api.UInt32Value(value: categoryStart),
+        categoryEnd: categoryEnd != null ? api.UInt32Value(value: categoryEnd) : null,
+        categoryStart: categoryStart != null ? api.UInt32Value(value: categoryStart) : null,
         cursor: cursor,
-        startTime: api.UInt32Value(value: startTime != null ? startTime.millisecondsSinceEpoch ~/ 1000 : null),
-        endTime: api.UInt32Value(value: endTime != null ? endTime.millisecondsSinceEpoch ~/ 1000 : null),
+        startTime: startTime != null ? api.UInt32Value(value: startTime.millisecondsSinceEpoch ~/ 1000) : null,
+        endTime: endTime != null ? api.UInt32Value(value: endTime.millisecondsSinceEpoch ~/ 1000) : null,
         limit: api.Int32Value(value: limit),
       ),
       options: _getSessionCallOptions(session),

--- a/nakama/tool/nakama_server/docker-compose.yml
+++ b/nakama/tool/nakama_server/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 3s
       retries: 5
   nakama:
-    image: registry.heroiclabs.com/heroiclabs/nakama:3.26.0
+    image: registry.heroiclabs.com/heroiclabs/nakama:3.37.0
     entrypoint:
       - "/bin/sh"
       - "-ecx"


### PR DESCRIPTION
- Fix BoolValue wrapping for nullable bool? params in NakamaGrpcClient.
When null, api.BoolValue(value: null) sent proto default (false) instead of leaving the field unset. 
Fixed in listStorageObjects (limit), listChannelMessages (forward), updateGroup (open), and listMatches (authoritative).

- Fix cursor pagination test: avoid message accumulation, pass explicit forward: true, remove skip annotation.

- Bump Nakama server from 3.26.0 to 3.37.0 in docker-compose.yml.

#147