### PR TITLE
Expose realtime party events

### DIFF
--- a/nakama/lib/src/models/party.dart
+++ b/nakama/lib/src/models/party.dart
@@ -69,31 +69,34 @@ sealed class PartyLeader with _$PartyLeader {
       );
 }
 
-class PartyClose {
-  const PartyClose({required this.partyId});
+@freezed
+sealed class PartyClose with _$PartyClose {
+  const PartyClose._();
 
-  /// The ID of the party that was closed.
-  final String partyId;
+  const factory PartyClose({
+    /// The ID of the party that was closed.
+    @JsonKey(name: 'party_id') required String partyId,
+  }) = _PartyClose;
 
   factory PartyClose.fromDto(rtpb.PartyClose dto) => PartyClose(
         partyId: dto.partyId,
       );
 }
 
-class PartyJoinRequest {
-  const PartyJoinRequest({
-    required this.partyId,
-    required this.presences,
-  });
+@freezed
+sealed class PartyJoinRequest with _$PartyJoinRequest {
+  const PartyJoinRequest._();
 
-  /// The ID of the party these presences are attempting to join.
-  final String partyId;
+  const factory PartyJoinRequest({
+    /// The ID of the party these presences are attempting to join.
+    @JsonKey(name: 'party_id') required String partyId,
 
-  /// Presences attempting to join the party.
-  final List<UserPresence> presences;
+    /// Presences attempting to join the party.
+    @JsonKey(name: 'presences') required List<UserPresence> presences,
+  }) = _PartyJoinRequest;
 
   factory PartyJoinRequest.fromDto(rtpb.PartyJoinRequest dto) => PartyJoinRequest(
         partyId: dto.partyId,
-        presences: dto.presences.map(UserPresence.fromDto).toList(growable: false),
+        presences: dto.presences.map((e) => UserPresence.fromDto(e)).toList(growable: false),
       );
 }

--- a/nakama/lib/src/models/party.dart
+++ b/nakama/lib/src/models/party.dart
@@ -68,3 +68,32 @@ sealed class PartyLeader with _$PartyLeader {
         newLeader: UserPresence.fromDto(dto.presence),
       );
 }
+
+class PartyClose {
+  const PartyClose({required this.partyId});
+
+  /// The ID of the party that was closed.
+  final String partyId;
+
+  factory PartyClose.fromDto(rtpb.PartyClose dto) => PartyClose(
+        partyId: dto.partyId,
+      );
+}
+
+class PartyJoinRequest {
+  const PartyJoinRequest({
+    required this.partyId,
+    required this.presences,
+  });
+
+  /// The ID of the party these presences are attempting to join.
+  final String partyId;
+
+  /// Presences attempting to join the party.
+  final List<UserPresence> presences;
+
+  factory PartyJoinRequest.fromDto(rtpb.PartyJoinRequest dto) => PartyJoinRequest(
+        partyId: dto.partyId,
+        presences: dto.presences.map(UserPresence.fromDto).toList(growable: false),
+      );
+}

--- a/nakama/lib/src/models/party.freezed.dart
+++ b/nakama/lib/src/models/party.freezed.dart
@@ -875,4 +875,522 @@ $UserPresenceCopyWith<$Res>? get newLeader {
 }
 }
 
+/// @nodoc
+mixin _$PartyClose {
+
+/// The ID of the party that was closed.
+@JsonKey(name: 'party_id') String get partyId;
+/// Create a copy of PartyClose
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartyCloseCopyWith<PartyClose> get copyWith => _$PartyCloseCopyWithImpl<PartyClose>(this as PartyClose, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartyClose&&(identical(other.partyId, partyId) || other.partyId == partyId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId);
+
+@override
+String toString() {
+  return 'PartyClose(partyId: $partyId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PartyCloseCopyWith<$Res>  {
+  factory $PartyCloseCopyWith(PartyClose value, $Res Function(PartyClose) _then) = _$PartyCloseCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId
+});
+
+
+
+
+}
+/// @nodoc
+class _$PartyCloseCopyWithImpl<$Res>
+    implements $PartyCloseCopyWith<$Res> {
+  _$PartyCloseCopyWithImpl(this._self, this._then);
+
+  final PartyClose _self;
+  final $Res Function(PartyClose) _then;
+
+/// Create a copy of PartyClose
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,}) {
+  return _then(_self.copyWith(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PartyClose].
+extension PartyClosePatterns on PartyClose {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PartyClose value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PartyClose() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PartyClose value)  $default,){
+final _that = this;
+switch (_that) {
+case _PartyClose():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PartyClose value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PartyClose() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PartyClose() when $default != null:
+return $default(_that.partyId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId)  $default,) {final _that = this;
+switch (_that) {
+case _PartyClose():
+return $default(_that.partyId);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'party_id')  String partyId)?  $default,) {final _that = this;
+switch (_that) {
+case _PartyClose() when $default != null:
+return $default(_that.partyId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _PartyClose extends PartyClose {
+  const _PartyClose({@JsonKey(name: 'party_id') required this.partyId}): super._();
+  
+
+/// The ID of the party that was closed.
+@override@JsonKey(name: 'party_id') final  String partyId;
+
+/// Create a copy of PartyClose
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartyCloseCopyWith<_PartyClose> get copyWith => __$PartyCloseCopyWithImpl<_PartyClose>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartyClose&&(identical(other.partyId, partyId) || other.partyId == partyId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId);
+
+@override
+String toString() {
+  return 'PartyClose(partyId: $partyId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PartyCloseCopyWith<$Res> implements $PartyCloseCopyWith<$Res> {
+  factory _$PartyCloseCopyWith(_PartyClose value, $Res Function(_PartyClose) _then) = __$PartyCloseCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId
+});
+
+
+
+
+}
+/// @nodoc
+class __$PartyCloseCopyWithImpl<$Res>
+    implements _$PartyCloseCopyWith<$Res> {
+  __$PartyCloseCopyWithImpl(this._self, this._then);
+
+  final _PartyClose _self;
+  final $Res Function(_PartyClose) _then;
+
+/// Create a copy of PartyClose
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,}) {
+  return _then(_PartyClose(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$PartyJoinRequest {
+
+/// The ID of the party these presences are attempting to join.
+@JsonKey(name: 'party_id') String get partyId;/// Presences attempting to join the party.
+@JsonKey(name: 'presences') List<UserPresence> get presences;
+/// Create a copy of PartyJoinRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartyJoinRequestCopyWith<PartyJoinRequest> get copyWith => _$PartyJoinRequestCopyWithImpl<PartyJoinRequest>(this as PartyJoinRequest, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartyJoinRequest&&(identical(other.partyId, partyId) || other.partyId == partyId)&&const DeepCollectionEquality().equals(other.presences, presences));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,const DeepCollectionEquality().hash(presences));
+
+@override
+String toString() {
+  return 'PartyJoinRequest(partyId: $partyId, presences: $presences)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PartyJoinRequestCopyWith<$Res>  {
+  factory $PartyJoinRequestCopyWith(PartyJoinRequest value, $Res Function(PartyJoinRequest) _then) = _$PartyJoinRequestCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'presences') List<UserPresence> presences
+});
+
+
+
+
+}
+/// @nodoc
+class _$PartyJoinRequestCopyWithImpl<$Res>
+    implements $PartyJoinRequestCopyWith<$Res> {
+  _$PartyJoinRequestCopyWithImpl(this._self, this._then);
+
+  final PartyJoinRequest _self;
+  final $Res Function(PartyJoinRequest) _then;
+
+/// Create a copy of PartyJoinRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? partyId = null,Object? presences = null,}) {
+  return _then(_self.copyWith(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,presences: null == presences ? _self.presences : presences // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PartyJoinRequest].
+extension PartyJoinRequestPatterns on PartyJoinRequest {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PartyJoinRequest value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PartyJoinRequest() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PartyJoinRequest value)  $default,){
+final _that = this;
+switch (_that) {
+case _PartyJoinRequest():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PartyJoinRequest value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PartyJoinRequest() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presences')  List<UserPresence> presences)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PartyJoinRequest() when $default != null:
+return $default(_that.partyId,_that.presences);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presences')  List<UserPresence> presences)  $default,) {final _that = this;
+switch (_that) {
+case _PartyJoinRequest():
+return $default(_that.partyId,_that.presences);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'presences')  List<UserPresence> presences)?  $default,) {final _that = this;
+switch (_that) {
+case _PartyJoinRequest() when $default != null:
+return $default(_that.partyId,_that.presences);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _PartyJoinRequest extends PartyJoinRequest {
+  const _PartyJoinRequest({@JsonKey(name: 'party_id') required this.partyId, @JsonKey(name: 'presences') required final  List<UserPresence> presences}): _presences = presences,super._();
+  
+
+/// The ID of the party these presences are attempting to join.
+@override@JsonKey(name: 'party_id') final  String partyId;
+/// Presences attempting to join the party.
+ final  List<UserPresence> _presences;
+/// Presences attempting to join the party.
+@override@JsonKey(name: 'presences') List<UserPresence> get presences {
+  if (_presences is EqualUnmodifiableListView) return _presences;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_presences);
+}
+
+
+/// Create a copy of PartyJoinRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartyJoinRequestCopyWith<_PartyJoinRequest> get copyWith => __$PartyJoinRequestCopyWithImpl<_PartyJoinRequest>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartyJoinRequest&&(identical(other.partyId, partyId) || other.partyId == partyId)&&const DeepCollectionEquality().equals(other._presences, _presences));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,partyId,const DeepCollectionEquality().hash(_presences));
+
+@override
+String toString() {
+  return 'PartyJoinRequest(partyId: $partyId, presences: $presences)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PartyJoinRequestCopyWith<$Res> implements $PartyJoinRequestCopyWith<$Res> {
+  factory _$PartyJoinRequestCopyWith(_PartyJoinRequest value, $Res Function(_PartyJoinRequest) _then) = __$PartyJoinRequestCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'presences') List<UserPresence> presences
+});
+
+
+
+
+}
+/// @nodoc
+class __$PartyJoinRequestCopyWithImpl<$Res>
+    implements _$PartyJoinRequestCopyWith<$Res> {
+  __$PartyJoinRequestCopyWithImpl(this._self, this._then);
+
+  final _PartyJoinRequest _self;
+  final $Res Function(_PartyJoinRequest) _then;
+
+/// Create a copy of PartyJoinRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? partyId = null,Object? presences = null,}) {
+  return _then(_PartyJoinRequest(
+partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,presences: null == presences ? _self._presences : presences // ignore: cast_nullable_to_non_nullable
+as List<UserPresence>,
+  ));
+}
+
+
+}
+
 // dart format on

--- a/nakama/lib/src/nakama_websocket_client.dart
+++ b/nakama/lib/src/nakama_websocket_client.dart
@@ -34,11 +34,27 @@ class NakamaWebsocketClient {
 
   Stream<MatchmakerMatched> get onMatchmakerMatched => _onMatchmakerMatchedController.stream;
 
+  final _onMatchmakerTicketController = StreamController<MatchmakerTicket>.broadcast();
+
+  Stream<MatchmakerTicket> get onMatchmakerTicket => _onMatchmakerTicketController.stream;
+
   final _onMatchDataController = StreamController<MatchData>.broadcast();
 
   Stream<MatchData> get onMatchData => _onMatchDataController.stream;
 
   final _onPartyDataController = StreamController<PartyData>.broadcast();
+
+  final _onPartyController = StreamController<Party>.broadcast();
+  Stream<Party> get onParty => _onPartyController.stream;
+
+  final _onPartyCloseController = StreamController<PartyClose>.broadcast();
+  Stream<PartyClose> get onPartyClose => _onPartyCloseController.stream;
+
+  final _onPartyJoinRequestController = StreamController<PartyJoinRequest>.broadcast();
+  Stream<PartyJoinRequest> get onPartyJoinRequest => _onPartyJoinRequestController.stream;
+
+  final _onPartyMatchmakerTicketController = StreamController<PartyMatchmakerTicket>.broadcast();
+  Stream<PartyMatchmakerTicket> get onPartyMatchmakerTicket => _onPartyMatchmakerTicketController.stream;
 
   final _onPartyPresenceController = StreamController<PartyPresenceEvent>.broadcast();
   Stream<PartyPresenceEvent> get onPartyPresence => _onPartyPresenceController.stream;
@@ -158,7 +174,12 @@ class NakamaWebsocketClient {
     return Future.wait([
       _onChannelPresenceController.close(),
       _onMatchmakerMatchedController.close(),
+      _onMatchmakerTicketController.close(),
       _onMatchDataController.close(),
+      _onPartyController.close(),
+      _onPartyCloseController.close(),
+      _onPartyJoinRequestController.close(),
+      _onPartyMatchmakerTicketController.close(),
       _onPartyPresenceController.close(),
       _onPartyLeaderController.close(),
       _onPartyDataController.close(),
@@ -209,6 +230,8 @@ class NakamaWebsocketClient {
                 .add(ChannelPresenceEvent.fromDto(receivedEnvelope.channelPresenceEvent));
           case rtpb.Envelope_Message.matchmakerMatched:
             return _onMatchmakerMatchedController.add(MatchmakerMatched.fromDto(receivedEnvelope.matchmakerMatched));
+          case rtpb.Envelope_Message.matchmakerTicket:
+            return _onMatchmakerTicketController.add(MatchmakerTicket.fromDto(receivedEnvelope.matchmakerTicket));
           case rtpb.Envelope_Message.matchData:
             return _onMatchDataController.add(MatchData.fromDto(receivedEnvelope.matchData));
           case rtpb.Envelope_Message.partyData:
@@ -217,6 +240,14 @@ class NakamaWebsocketClient {
             return _onPartyPresenceController.add(PartyPresenceEvent.fromDto(receivedEnvelope.partyPresenceEvent));
           case rtpb.Envelope_Message.partyLeader:
             return _onPartyLeaderController.add(PartyLeader.fromDto(receivedEnvelope.partyLeader));
+          case rtpb.Envelope_Message.party:
+            return _onPartyController.add(Party.fromDto(receivedEnvelope.party));
+          case rtpb.Envelope_Message.partyClose:
+            return _onPartyCloseController.add(PartyClose.fromDto(receivedEnvelope.partyClose));
+          case rtpb.Envelope_Message.partyJoinRequest:
+            return _onPartyJoinRequestController.add(PartyJoinRequest.fromDto(receivedEnvelope.partyJoinRequest));
+          case rtpb.Envelope_Message.partyMatchmakerTicket:
+            return _onPartyMatchmakerTicketController.add(PartyMatchmakerTicket.fromDto(receivedEnvelope.partyMatchmakerTicket));
           case rtpb.Envelope_Message.matchPresenceEvent:
             return _onMatchPresenceController.add(MatchPresenceEvent.fromDto(receivedEnvelope.matchPresenceEvent));
           case rtpb.Envelope_Message.notifications:
@@ -279,10 +310,8 @@ class NakamaWebsocketClient {
     return Party.fromDto(res);
   }
 
-  Future<Party> joinParty(String partyId) async {
-    final res = await _send<rtpb.Party>(rtpb.Envelope(partyJoin: rtpb.PartyJoin(partyId: partyId)));
-
-    return Party.fromDto(res);
+  Future<void> joinParty(String partyId) async {
+    await _send<void>(rtpb.Envelope(partyJoin: rtpb.PartyJoin(partyId: partyId)));
   }
 
   Future<void> promotePartyMember({

--- a/nakama/lib/src/nakama_websocket_client.dart
+++ b/nakama/lib/src/nakama_websocket_client.dart
@@ -27,22 +27,16 @@ class NakamaWebsocketClient {
   late final WebSocketChannel _channel;
 
   final _onChannelPresenceController = StreamController<ChannelPresenceEvent>.broadcast();
-
   Stream<ChannelPresenceEvent> get onChannelPresence => _onChannelPresenceController.stream;
 
   final _onMatchmakerMatchedController = StreamController<MatchmakerMatched>.broadcast();
-
   Stream<MatchmakerMatched> get onMatchmakerMatched => _onMatchmakerMatchedController.stream;
 
   final _onMatchmakerTicketController = StreamController<MatchmakerTicket>.broadcast();
-
   Stream<MatchmakerTicket> get onMatchmakerTicket => _onMatchmakerTicketController.stream;
 
   final _onMatchDataController = StreamController<MatchData>.broadcast();
-
   Stream<MatchData> get onMatchData => _onMatchDataController.stream;
-
-  final _onPartyDataController = StreamController<PartyData>.broadcast();
 
   final _onPartyController = StreamController<Party>.broadcast();
   Stream<Party> get onParty => _onPartyController.stream;
@@ -62,30 +56,25 @@ class NakamaWebsocketClient {
   final _onPartyLeaderController = StreamController<PartyLeader>.broadcast();
   Stream<PartyLeader> get onPartyLeader => _onPartyLeaderController.stream;
 
+  final _onPartyDataController = StreamController<PartyData>.broadcast();
   Stream<PartyData> get onPartyData => _onPartyDataController.stream;
 
   final _onMatchPresenceController = StreamController<MatchPresenceEvent>.broadcast();
-
   Stream<MatchPresenceEvent> get onMatchPresence => _onMatchPresenceController.stream;
 
   final _onNotificationsController = StreamController<Notification>.broadcast();
-
   Stream<Notification> get onNotifications => _onNotificationsController.stream;
 
   final _onStatusPresenceController = StreamController<StatusPresenceEvent>.broadcast();
-
   Stream<StatusPresenceEvent> get onStatusPresence => _onStatusPresenceController.stream;
 
   final _onStreamPresenceController = StreamController<StreamPresenceEvent>.broadcast();
-
   Stream<StreamPresenceEvent> get onStreamPresence => _onStreamPresenceController.stream;
 
   final _onStreamDataController = StreamController<RealtimeStreamData>.broadcast();
-
   Stream<RealtimeStreamData> get onStreamData => _onStreamDataController.stream;
 
   final _onChannelMessageController = StreamController<api.ChannelMessage>.broadcast();
-
   Stream<api.ChannelMessage> get onChannelMessage => _onChannelMessageController.stream;
 
   final List<Completer> _futures = [];

--- a/nakama/test/rt/party_test.dart
+++ b/nakama/test/rt/party_test.dart
@@ -1,0 +1,145 @@
+import 'package:faker/faker.dart';
+import 'package:nakama/nakama.dart';
+import 'package:test/test.dart';
+
+import '../config.dart';
+
+void main() {
+  late final Session sessionA;
+  late final Session sessionB;
+  late final NakamaWebsocketClient clientA;
+  late final NakamaWebsocketClient clientB;
+
+  setUpAll(() async {
+    final client = getNakamaClient(
+      host: kTestHost,
+      ssl: false,
+      serverKey: kTestServerKey,
+    );
+
+    sessionA = await client.authenticateEmail(
+      email: faker.internet.freeEmail(),
+      password: faker.internet.password(),
+      create: true,
+    );
+
+    clientA = NakamaWebsocketClient.init(
+      key: 'party-client-a',
+      host: kTestHost,
+      ssl: false,
+      token: sessionA.token,
+    );
+
+    sessionB = await client.authenticateEmail(
+      email: faker.internet.freeEmail(),
+      password: faker.internet.password(),
+      create: true,
+    );
+
+    clientB = NakamaWebsocketClient.init(
+      key: 'party-client-b',
+      host: kTestHost,
+      ssl: false,
+      token: sessionB.token,
+    );
+  });
+
+  tearDownAll(() async {
+    await clientB.close();
+    await clientA.close();
+  });
+
+  group('[RT] Party Test', () {
+    test('can create a party', () async {
+      final party = await clientA.createParty(open: true, maxSize: 8);
+
+      expect(party.partyId, isNotEmpty);
+      expect(party.open, isTrue);
+      expect(party.maxSize, equals(8));
+      expect(
+        party.self.userId,
+        equals(sessionA.userId),
+        reason: 'Created party should include the current socket as self.',
+      );
+      expect(
+        party.leader.userId,
+        equals(sessionA.userId),
+        reason: 'Created party should identify the creating socket as leader.',
+      );
+      expect(
+        party.presences.map((presence) => presence.userId),
+        contains(sessionA.userId),
+      );
+
+      await clientA.closeParty(party.partyId);
+    });
+
+    test('receives full party state when joining a party', () async {
+      final party = await clientA.createParty(open: true, maxSize: 8);
+
+      final joinedPartyFuture = clientB.onParty.firstWhere(
+        (joinedParty) => joinedParty.partyId == party.partyId,
+      );
+
+      await clientB.joinParty(party.partyId);
+      final joinedParty = await joinedPartyFuture;
+
+      expect(joinedParty.partyId, equals(party.partyId));
+      expect(joinedParty.open, isTrue);
+      expect(joinedParty.maxSize, equals(8));
+      expect(
+        joinedParty.self.userId,
+        equals(sessionB.userId),
+        reason: 'Joined party event should identify the joining socket as self.',
+      );
+      expect(
+        joinedParty.leader.userId,
+        equals(sessionA.userId),
+        reason: 'Joined party event should preserve the original party leader.',
+      );
+      expect(
+        joinedParty.presences.map((presence) => presence.userId),
+        contains(sessionA.userId),
+      );
+      expect(
+        joinedParty.presences.map((presence) => presence.userId),
+        contains(sessionB.userId),
+      );
+
+      await clientB.leaveParty(party.partyId);
+      await clientA.closeParty(party.partyId);
+    });
+
+    test('receives party close events', () async {
+      final party = await clientA.createParty(open: true, maxSize: 8);
+      await clientB.joinParty(party.partyId);
+
+      final closedPartyFuture = clientB.onPartyClose.firstWhere(
+        (closedParty) => closedParty.partyId == party.partyId,
+      );
+
+      await clientA.closeParty(party.partyId);
+      final closedParty = await closedPartyFuture;
+
+      expect(closedParty.partyId, equals(party.partyId));
+    });
+
+    test('receives party join requests', () async {
+      final party = await clientA.createParty(open: false, maxSize: 8);
+      final joinRequestFuture = clientA.onPartyJoinRequest.firstWhere(
+        (joinRequest) => joinRequest.partyId == party.partyId,
+      );
+
+      await clientB.joinParty(party.partyId);
+      final joinRequest = await joinRequestFuture;
+
+      expect(joinRequest.partyId, equals(party.partyId));
+      expect(
+        joinRequest.presences.map((presence) => presence.userId),
+        contains(sessionB.userId),
+      );
+
+      await clientA.closeParty(party.partyId);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds missing realtime streams to `NakamaWebsocketClient` and dispatches unsolicited realtime envelopes into them.

This matches the behavior exposed by other Nakama SDKs, such as the JavaScript SDK's `socket.onparty`, and gives Dart/Flutter clients access to the full party state snapshot after party create/join flows.

## Details

- Adds public realtime streams for event parity with the JavaScript SDK:
  - `Stream<MatchmakerTicket> get onMatchmakerTicket`
  - `Stream<Party> get onParty`
  - `Stream<PartyClose> get onPartyClose`
  - `Stream<PartyJoinRequest> get onPartyJoinRequest`
  - `Stream<PartyMatchmakerTicket> get onPartyMatchmakerTicket`
- Closes the added stream controllers when the websocket client is closed.
- Changes `joinParty` to return `Future<void>` because the server responds with an ACK-like empty response; the full party state is delivered through `onParty`.
- Handles `rtpb.Envelope_Message.party` in `_onData`.
- Handles `rtpb.Envelope_Message.partyClose` in `_onData`.
- Handles `rtpb.Envelope_Message.partyJoinRequest` in `_onData`.
- Handles `rtpb.Envelope_Message.partyMatchmakerTicket` in `_onData`.
- Handles `rtpb.Envelope_Message.matchmakerTicket` in `_onData`.
- Adds realtime party tests covering:
  - creating an open party with the expected party state,
  - receiving full joined party state through `onParty` when another client joins.
  - preserving the leader on the joining client,
  - preserving `maxSize`,
  - populating `self` for both create and join event flows.
  - receiving party close events through `onPartyClose`.
  - receiving closed-party join requests through `onPartyJoinRequest`.

## Why

Party joins can emit the full party state as an unsolicited realtime `Party` envelope. Party closure can emit an unsolicited realtime `PartyClose` envelope. Closed party joins can emit `PartyJoinRequest` events to leaders, and matchmaker ticket envelopes can also arrive as unsolicited events. Without exposed streams for these messages, Dart clients can receive some party updates but miss the full snapshot and notifications needed to keep client party state accurate.

The regression tests also guard against stale realtime Party protobuf decoding, where `leader`, `maxSize`, and `self` can be decoded incorrectly if the generated field numbers do not match the current Nakama realtime API.

## Verification

Ran from `nakama/`:

```sh
dart analyze
dart test test/rt/party_test.dart
```

Both passed.
