### PR TITLE
Enhance serialization and deserialization for leaderboard, group, channel message, notification, storage, and tournament models

### DIFF
--- a/nakama/example/lib/features/chat/widgets/chat_room.dart
+++ b/nakama/example/lib/features/chat/widgets/chat_room.dart
@@ -45,12 +45,12 @@ class ChatRoom extends StatelessWidget {
           const Text('Messages:'),
           const SizedBox(height: 10),
           Expanded(
-            child: chat.messages?.messages?.isEmpty ?? true
+            child: chat.messages?.messages.isEmpty ?? true
                 ? const Text('No messages yet.')
                 : ListView.builder(
-                    itemCount: chat.messages!.messages!.length,
+                    itemCount: chat.messages!.messages.length,
                     itemBuilder: (context, index) {
-                      final message = chat.messages!.messages![index];
+                      final message = chat.messages!.messages[index];
                       return ListTile(
                         title: Text(message.username),
                         subtitle: Text(message.content),

--- a/nakama/example/lib/features/group/providers/groups_provider.dart
+++ b/nakama/example/lib/features/group/providers/groups_provider.dart
@@ -15,9 +15,8 @@ class GroupsNotifier extends StateNotifier<List<Group>> {
 
     // https://heroiclabs.com/docs/nakama/concepts/groups/#list-a-users-groups
     final groups = (await NakamaClient.instance!
-                .listUserGroups(session: session, userId: session.userId))
-            .userGroups ??
-        [];
+            .listUserGroups(session: session, userId: session.userId))
+        .userGroups;
     final groupNames = groups.map((group) => group.group).toList();
     state = groupNames;
     return state;

--- a/nakama/example/lib/features/leaderboard/providers/leaderboard_provider.dart
+++ b/nakama/example/lib/features/leaderboard/providers/leaderboard_provider.dart
@@ -21,7 +21,7 @@ class LeaderboardNotifier extends StateNotifier<List<LeaderboardRecord>> {
               session: session,
               leaderboardName: leaderboardName,
               cursor: cursor);
-      allRecords.addAll(leaderboardRecordsList.records ?? []);
+      allRecords.addAll(leaderboardRecordsList.records);
       cursor = leaderboardRecordsList.nextCursor;
     } while (cursor != null);
 
@@ -43,7 +43,7 @@ class LeaderboardNotifier extends StateNotifier<List<LeaderboardRecord>> {
         leaderboardName: leaderboardName,
         ownerId: session.userId,
       );
-      allRecords.addAll(leaderboardRecordsList.records ?? []);
+      allRecords.addAll(leaderboardRecordsList.records);
       cursor = leaderboardRecordsList.nextCursor;
     } while (cursor != null);
 

--- a/nakama/lib/src/models/channel_message.dart
+++ b/nakama/lib/src/models/channel_message.dart
@@ -49,7 +49,7 @@ sealed class ChannelMessageList with _$ChannelMessageList {
   const ChannelMessageList._();
 
   const factory ChannelMessageList({
-    @JsonKey(name: 'messages') required List<ChannelMessage>? messages,
+    @JsonKey(name: 'messages') @Default(<ChannelMessage>[]) List<ChannelMessage> messages,
     @JsonKey(name: 'next_cursor') required String? nextCursor,
     @JsonKey(name: 'prev_cursor') required String? prevCursor,
     @JsonKey(name: 'cacheable_cursor') required String? cacheableCursor,

--- a/nakama/lib/src/models/channel_message.freezed.dart
+++ b/nakama/lib/src/models/channel_message.freezed.dart
@@ -308,7 +308,7 @@ as String?,
 /// @nodoc
 mixin _$ChannelMessageList {
 
-@JsonKey(name: 'messages') List<ChannelMessage>? get messages;@JsonKey(name: 'next_cursor') String? get nextCursor;@JsonKey(name: 'prev_cursor') String? get prevCursor;@JsonKey(name: 'cacheable_cursor') String? get cacheableCursor;
+@JsonKey(name: 'messages') List<ChannelMessage> get messages;@JsonKey(name: 'next_cursor') String? get nextCursor;@JsonKey(name: 'prev_cursor') String? get prevCursor;@JsonKey(name: 'cacheable_cursor') String? get cacheableCursor;
 /// Create a copy of ChannelMessageList
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -341,7 +341,7 @@ abstract mixin class $ChannelMessageListCopyWith<$Res>  {
   factory $ChannelMessageListCopyWith(ChannelMessageList value, $Res Function(ChannelMessageList) _then) = _$ChannelMessageListCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'messages') List<ChannelMessage>? messages,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor,@JsonKey(name: 'cacheable_cursor') String? cacheableCursor
+@JsonKey(name: 'messages') List<ChannelMessage> messages,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor,@JsonKey(name: 'cacheable_cursor') String? cacheableCursor
 });
 
 
@@ -358,10 +358,10 @@ class _$ChannelMessageListCopyWithImpl<$Res>
 
 /// Create a copy of ChannelMessageList
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? messages = freezed,Object? nextCursor = freezed,Object? prevCursor = freezed,Object? cacheableCursor = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? messages = null,Object? nextCursor = freezed,Object? prevCursor = freezed,Object? cacheableCursor = freezed,}) {
   return _then(_self.copyWith(
-messages: freezed == messages ? _self.messages : messages // ignore: cast_nullable_to_non_nullable
-as List<ChannelMessage>?,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+messages: null == messages ? _self.messages : messages // ignore: cast_nullable_to_non_nullable
+as List<ChannelMessage>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
 as String?,prevCursor: freezed == prevCursor ? _self.prevCursor : prevCursor // ignore: cast_nullable_to_non_nullable
 as String?,cacheableCursor: freezed == cacheableCursor ? _self.cacheableCursor : cacheableCursor // ignore: cast_nullable_to_non_nullable
 as String?,
@@ -446,7 +446,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'messages')  List<ChannelMessage>? messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'messages')  List<ChannelMessage> messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ChannelMessageList() when $default != null:
 return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheableCursor);case _:
@@ -467,7 +467,7 @@ return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheable
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'messages')  List<ChannelMessage>? messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'messages')  List<ChannelMessage> messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)  $default,) {final _that = this;
 switch (_that) {
 case _ChannelMessageList():
 return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheableCursor);}
@@ -484,7 +484,7 @@ return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheable
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'messages')  List<ChannelMessage>? messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'messages')  List<ChannelMessage> messages, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor, @JsonKey(name: 'cacheable_cursor')  String? cacheableCursor)?  $default,) {final _that = this;
 switch (_that) {
 case _ChannelMessageList() when $default != null:
 return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheableCursor);case _:
@@ -499,16 +499,14 @@ return $default(_that.messages,_that.nextCursor,_that.prevCursor,_that.cacheable
 @JsonSerializable()
 
 class _ChannelMessageList extends ChannelMessageList {
-  const _ChannelMessageList({@JsonKey(name: 'messages') required final  List<ChannelMessage>? messages, @JsonKey(name: 'next_cursor') required this.nextCursor, @JsonKey(name: 'prev_cursor') required this.prevCursor, @JsonKey(name: 'cacheable_cursor') required this.cacheableCursor}): _messages = messages,super._();
+  const _ChannelMessageList({@JsonKey(name: 'messages') final  List<ChannelMessage> messages = const <ChannelMessage>[], @JsonKey(name: 'next_cursor') required this.nextCursor, @JsonKey(name: 'prev_cursor') required this.prevCursor, @JsonKey(name: 'cacheable_cursor') required this.cacheableCursor}): _messages = messages,super._();
   factory _ChannelMessageList.fromJson(Map<String, dynamic> json) => _$ChannelMessageListFromJson(json);
 
- final  List<ChannelMessage>? _messages;
-@override@JsonKey(name: 'messages') List<ChannelMessage>? get messages {
-  final value = _messages;
-  if (value == null) return null;
+ final  List<ChannelMessage> _messages;
+@override@JsonKey(name: 'messages') List<ChannelMessage> get messages {
   if (_messages is EqualUnmodifiableListView) return _messages;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
+  return EqualUnmodifiableListView(_messages);
 }
 
 @override@JsonKey(name: 'next_cursor') final  String? nextCursor;
@@ -548,7 +546,7 @@ abstract mixin class _$ChannelMessageListCopyWith<$Res> implements $ChannelMessa
   factory _$ChannelMessageListCopyWith(_ChannelMessageList value, $Res Function(_ChannelMessageList) _then) = __$ChannelMessageListCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'messages') List<ChannelMessage>? messages,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor,@JsonKey(name: 'cacheable_cursor') String? cacheableCursor
+@JsonKey(name: 'messages') List<ChannelMessage> messages,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor,@JsonKey(name: 'cacheable_cursor') String? cacheableCursor
 });
 
 
@@ -565,10 +563,10 @@ class __$ChannelMessageListCopyWithImpl<$Res>
 
 /// Create a copy of ChannelMessageList
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? messages = freezed,Object? nextCursor = freezed,Object? prevCursor = freezed,Object? cacheableCursor = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? messages = null,Object? nextCursor = freezed,Object? prevCursor = freezed,Object? cacheableCursor = freezed,}) {
   return _then(_ChannelMessageList(
-messages: freezed == messages ? _self._messages : messages // ignore: cast_nullable_to_non_nullable
-as List<ChannelMessage>?,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+messages: null == messages ? _self._messages : messages // ignore: cast_nullable_to_non_nullable
+as List<ChannelMessage>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
 as String?,prevCursor: freezed == prevCursor ? _self.prevCursor : prevCursor // ignore: cast_nullable_to_non_nullable
 as String?,cacheableCursor: freezed == cacheableCursor ? _self.cacheableCursor : cacheableCursor // ignore: cast_nullable_to_non_nullable
 as String?,

--- a/nakama/lib/src/models/channel_message.g.dart
+++ b/nakama/lib/src/models/channel_message.g.dart
@@ -42,9 +42,11 @@ Map<String, dynamic> _$ChannelMessageToJson(_ChannelMessage instance) =>
 
 _ChannelMessageList _$ChannelMessageListFromJson(Map<String, dynamic> json) =>
     _ChannelMessageList(
-      messages: (json['messages'] as List<dynamic>?)
-          ?.map((e) => ChannelMessage.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      messages:
+          (json['messages'] as List<dynamic>?)
+              ?.map((e) => ChannelMessage.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <ChannelMessage>[],
       nextCursor: json['next_cursor'] as String?,
       prevCursor: json['prev_cursor'] as String?,
       cacheableCursor: json['cacheable_cursor'] as String?,

--- a/nakama/lib/src/models/friends.dart
+++ b/nakama/lib/src/models/friends.dart
@@ -13,7 +13,7 @@ sealed class FriendsList with _$FriendsList {
 
   const factory FriendsList({
     String? cursor,
-    required List<Friend>? friends,
+    @Default(<Friend>[]) List<Friend> friends,
   }) = _FriendsList;
 
   factory FriendsList.fromJson(Map<String, Object?> json) => _$FriendsListFromJson(json);

--- a/nakama/lib/src/models/friends.freezed.dart
+++ b/nakama/lib/src/models/friends.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$FriendsList {
 
- String? get cursor; List<Friend>? get friends;
+ String? get cursor; List<Friend> get friends;
 /// Create a copy of FriendsList
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $FriendsListCopyWith<$Res>  {
   factory $FriendsListCopyWith(FriendsList value, $Res Function(FriendsList) _then) = _$FriendsListCopyWithImpl;
 @useResult
 $Res call({
- String? cursor, List<Friend>? friends
+ String? cursor, List<Friend> friends
 });
 
 
@@ -65,11 +65,11 @@ class _$FriendsListCopyWithImpl<$Res>
 
 /// Create a copy of FriendsList
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? friends = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? friends = null,}) {
   return _then(_self.copyWith(
 cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
-as String?,friends: freezed == friends ? _self.friends : friends // ignore: cast_nullable_to_non_nullable
-as List<Friend>?,
+as String?,friends: null == friends ? _self.friends : friends // ignore: cast_nullable_to_non_nullable
+as List<Friend>,
   ));
 }
 
@@ -151,7 +151,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor,  List<Friend>? friends)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor,  List<Friend> friends)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _FriendsList() when $default != null:
 return $default(_that.cursor,_that.friends);case _:
@@ -172,7 +172,7 @@ return $default(_that.cursor,_that.friends);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor,  List<Friend>? friends)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor,  List<Friend> friends)  $default,) {final _that = this;
 switch (_that) {
 case _FriendsList():
 return $default(_that.cursor,_that.friends);}
@@ -189,7 +189,7 @@ return $default(_that.cursor,_that.friends);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor,  List<Friend>? friends)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor,  List<Friend> friends)?  $default,) {final _that = this;
 switch (_that) {
 case _FriendsList() when $default != null:
 return $default(_that.cursor,_that.friends);case _:
@@ -204,17 +204,15 @@ return $default(_that.cursor,_that.friends);case _:
 @JsonSerializable()
 
 class _FriendsList extends FriendsList {
-  const _FriendsList({this.cursor, required final  List<Friend>? friends}): _friends = friends,super._();
+  const _FriendsList({this.cursor, final  List<Friend> friends = const <Friend>[]}): _friends = friends,super._();
   factory _FriendsList.fromJson(Map<String, dynamic> json) => _$FriendsListFromJson(json);
 
 @override final  String? cursor;
- final  List<Friend>? _friends;
-@override List<Friend>? get friends {
-  final value = _friends;
-  if (value == null) return null;
+ final  List<Friend> _friends;
+@override@JsonKey() List<Friend> get friends {
   if (_friends is EqualUnmodifiableListView) return _friends;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
+  return EqualUnmodifiableListView(_friends);
 }
 
 
@@ -251,7 +249,7 @@ abstract mixin class _$FriendsListCopyWith<$Res> implements $FriendsListCopyWith
   factory _$FriendsListCopyWith(_FriendsList value, $Res Function(_FriendsList) _then) = __$FriendsListCopyWithImpl;
 @override @useResult
 $Res call({
- String? cursor, List<Friend>? friends
+ String? cursor, List<Friend> friends
 });
 
 
@@ -268,11 +266,11 @@ class __$FriendsListCopyWithImpl<$Res>
 
 /// Create a copy of FriendsList
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? friends = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? friends = null,}) {
   return _then(_FriendsList(
 cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
-as String?,friends: freezed == friends ? _self._friends : friends // ignore: cast_nullable_to_non_nullable
-as List<Friend>?,
+as String?,friends: null == friends ? _self._friends : friends // ignore: cast_nullable_to_non_nullable
+as List<Friend>,
   ));
 }
 

--- a/nakama/lib/src/models/friends.g.dart
+++ b/nakama/lib/src/models/friends.g.dart
@@ -8,9 +8,11 @@ part of 'friends.dart';
 
 _FriendsList _$FriendsListFromJson(Map<String, dynamic> json) => _FriendsList(
   cursor: json['cursor'] as String?,
-  friends: (json['friends'] as List<dynamic>?)
-      ?.map((e) => Friend.fromJson(e as Map<String, dynamic>))
-      .toList(),
+  friends:
+      (json['friends'] as List<dynamic>?)
+          ?.map((e) => Friend.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <Friend>[],
 );
 
 Map<String, dynamic> _$FriendsListToJson(_FriendsList instance) =>

--- a/nakama/lib/src/models/group.dart
+++ b/nakama/lib/src/models/group.dart
@@ -50,7 +50,7 @@ sealed class GroupList with _$GroupList {
 
   const factory GroupList({
     String? cursor,
-    required List<Group>? groups,
+    @Default(<Group>[]) List<Group> groups,
   }) = _GroupList;
 
   factory GroupList.fromJson(Map<String, Object?> json) => _$GroupListFromJson(json);
@@ -67,7 +67,7 @@ sealed class UserGroupList with _$UserGroupList {
 
   const factory UserGroupList({
     String? cursor,
-    @JsonKey(name: 'user_groups') required List<UserGroup>? userGroups,
+    @JsonKey(name: 'user_groups') @Default(<UserGroup>[]) List<UserGroup> userGroups,
   }) = _UserGroupList;
 
   factory UserGroupList.fromJson(Map<String, Object?> json) => _$UserGroupListFromJson(json);
@@ -101,7 +101,7 @@ sealed class GroupUserList with _$GroupUserList {
 
   const factory GroupUserList({
     String? cursor,
-    @JsonKey(name: 'group_users') required List<GroupUser> groupUsers,
+    @JsonKey(name: 'group_users') @Default(<GroupUser>[]) List<GroupUser> groupUsers,
   }) = _GroupUserList;
 
   factory GroupUserList.fromJson(Map<String, Object?> json) => _$GroupUserListFromJson(json);

--- a/nakama/lib/src/models/group.freezed.dart
+++ b/nakama/lib/src/models/group.freezed.dart
@@ -305,7 +305,7 @@ as DateTime?,
 /// @nodoc
 mixin _$GroupList {
 
- String? get cursor; List<Group>? get groups;
+ String? get cursor; List<Group> get groups;
 /// Create a copy of GroupList
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -338,7 +338,7 @@ abstract mixin class $GroupListCopyWith<$Res>  {
   factory $GroupListCopyWith(GroupList value, $Res Function(GroupList) _then) = _$GroupListCopyWithImpl;
 @useResult
 $Res call({
- String? cursor, List<Group>? groups
+ String? cursor, List<Group> groups
 });
 
 
@@ -355,11 +355,11 @@ class _$GroupListCopyWithImpl<$Res>
 
 /// Create a copy of GroupList
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? groups = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? groups = null,}) {
   return _then(_self.copyWith(
 cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
-as String?,groups: freezed == groups ? _self.groups : groups // ignore: cast_nullable_to_non_nullable
-as List<Group>?,
+as String?,groups: null == groups ? _self.groups : groups // ignore: cast_nullable_to_non_nullable
+as List<Group>,
   ));
 }
 
@@ -441,7 +441,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor,  List<Group>? groups)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor,  List<Group> groups)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GroupList() when $default != null:
 return $default(_that.cursor,_that.groups);case _:
@@ -462,7 +462,7 @@ return $default(_that.cursor,_that.groups);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor,  List<Group>? groups)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor,  List<Group> groups)  $default,) {final _that = this;
 switch (_that) {
 case _GroupList():
 return $default(_that.cursor,_that.groups);}
@@ -479,7 +479,7 @@ return $default(_that.cursor,_that.groups);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor,  List<Group>? groups)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor,  List<Group> groups)?  $default,) {final _that = this;
 switch (_that) {
 case _GroupList() when $default != null:
 return $default(_that.cursor,_that.groups);case _:
@@ -494,17 +494,15 @@ return $default(_that.cursor,_that.groups);case _:
 @JsonSerializable()
 
 class _GroupList extends GroupList {
-  const _GroupList({this.cursor, required final  List<Group>? groups}): _groups = groups,super._();
+  const _GroupList({this.cursor, final  List<Group> groups = const <Group>[]}): _groups = groups,super._();
   factory _GroupList.fromJson(Map<String, dynamic> json) => _$GroupListFromJson(json);
 
 @override final  String? cursor;
- final  List<Group>? _groups;
-@override List<Group>? get groups {
-  final value = _groups;
-  if (value == null) return null;
+ final  List<Group> _groups;
+@override@JsonKey() List<Group> get groups {
   if (_groups is EqualUnmodifiableListView) return _groups;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
+  return EqualUnmodifiableListView(_groups);
 }
 
 
@@ -541,7 +539,7 @@ abstract mixin class _$GroupListCopyWith<$Res> implements $GroupListCopyWith<$Re
   factory _$GroupListCopyWith(_GroupList value, $Res Function(_GroupList) _then) = __$GroupListCopyWithImpl;
 @override @useResult
 $Res call({
- String? cursor, List<Group>? groups
+ String? cursor, List<Group> groups
 });
 
 
@@ -558,11 +556,11 @@ class __$GroupListCopyWithImpl<$Res>
 
 /// Create a copy of GroupList
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? groups = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? groups = null,}) {
   return _then(_GroupList(
 cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
-as String?,groups: freezed == groups ? _self._groups : groups // ignore: cast_nullable_to_non_nullable
-as List<Group>?,
+as String?,groups: null == groups ? _self._groups : groups // ignore: cast_nullable_to_non_nullable
+as List<Group>,
   ));
 }
 
@@ -573,7 +571,7 @@ as List<Group>?,
 /// @nodoc
 mixin _$UserGroupList {
 
- String? get cursor;@JsonKey(name: 'user_groups') List<UserGroup>? get userGroups;
+ String? get cursor;@JsonKey(name: 'user_groups') List<UserGroup> get userGroups;
 /// Create a copy of UserGroupList
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -606,7 +604,7 @@ abstract mixin class $UserGroupListCopyWith<$Res>  {
   factory $UserGroupListCopyWith(UserGroupList value, $Res Function(UserGroupList) _then) = _$UserGroupListCopyWithImpl;
 @useResult
 $Res call({
- String? cursor,@JsonKey(name: 'user_groups') List<UserGroup>? userGroups
+ String? cursor,@JsonKey(name: 'user_groups') List<UserGroup> userGroups
 });
 
 
@@ -623,11 +621,11 @@ class _$UserGroupListCopyWithImpl<$Res>
 
 /// Create a copy of UserGroupList
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? userGroups = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? userGroups = null,}) {
   return _then(_self.copyWith(
 cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
-as String?,userGroups: freezed == userGroups ? _self.userGroups : userGroups // ignore: cast_nullable_to_non_nullable
-as List<UserGroup>?,
+as String?,userGroups: null == userGroups ? _self.userGroups : userGroups // ignore: cast_nullable_to_non_nullable
+as List<UserGroup>,
   ));
 }
 
@@ -709,7 +707,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup>? userGroups)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup> userGroups)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _UserGroupList() when $default != null:
 return $default(_that.cursor,_that.userGroups);case _:
@@ -730,7 +728,7 @@ return $default(_that.cursor,_that.userGroups);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup>? userGroups)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup> userGroups)  $default,) {final _that = this;
 switch (_that) {
 case _UserGroupList():
 return $default(_that.cursor,_that.userGroups);}
@@ -747,7 +745,7 @@ return $default(_that.cursor,_that.userGroups);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup>? userGroups)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor, @JsonKey(name: 'user_groups')  List<UserGroup> userGroups)?  $default,) {final _that = this;
 switch (_that) {
 case _UserGroupList() when $default != null:
 return $default(_that.cursor,_that.userGroups);case _:
@@ -762,17 +760,15 @@ return $default(_that.cursor,_that.userGroups);case _:
 @JsonSerializable()
 
 class _UserGroupList extends UserGroupList {
-  const _UserGroupList({this.cursor, @JsonKey(name: 'user_groups') required final  List<UserGroup>? userGroups}): _userGroups = userGroups,super._();
+  const _UserGroupList({this.cursor, @JsonKey(name: 'user_groups') final  List<UserGroup> userGroups = const <UserGroup>[]}): _userGroups = userGroups,super._();
   factory _UserGroupList.fromJson(Map<String, dynamic> json) => _$UserGroupListFromJson(json);
 
 @override final  String? cursor;
- final  List<UserGroup>? _userGroups;
-@override@JsonKey(name: 'user_groups') List<UserGroup>? get userGroups {
-  final value = _userGroups;
-  if (value == null) return null;
+ final  List<UserGroup> _userGroups;
+@override@JsonKey(name: 'user_groups') List<UserGroup> get userGroups {
   if (_userGroups is EqualUnmodifiableListView) return _userGroups;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
+  return EqualUnmodifiableListView(_userGroups);
 }
 
 
@@ -809,7 +805,7 @@ abstract mixin class _$UserGroupListCopyWith<$Res> implements $UserGroupListCopy
   factory _$UserGroupListCopyWith(_UserGroupList value, $Res Function(_UserGroupList) _then) = __$UserGroupListCopyWithImpl;
 @override @useResult
 $Res call({
- String? cursor,@JsonKey(name: 'user_groups') List<UserGroup>? userGroups
+ String? cursor,@JsonKey(name: 'user_groups') List<UserGroup> userGroups
 });
 
 
@@ -826,11 +822,11 @@ class __$UserGroupListCopyWithImpl<$Res>
 
 /// Create a copy of UserGroupList
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? userGroups = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? userGroups = null,}) {
   return _then(_UserGroupList(
 cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
-as String?,userGroups: freezed == userGroups ? _self._userGroups : userGroups // ignore: cast_nullable_to_non_nullable
-as List<UserGroup>?,
+as String?,userGroups: null == userGroups ? _self._userGroups : userGroups // ignore: cast_nullable_to_non_nullable
+as List<UserGroup>,
   ));
 }
 
@@ -1308,7 +1304,7 @@ return $default(_that.cursor,_that.groupUsers);case _:
 @JsonSerializable()
 
 class _GroupUserList extends GroupUserList {
-  const _GroupUserList({this.cursor, @JsonKey(name: 'group_users') required final  List<GroupUser> groupUsers}): _groupUsers = groupUsers,super._();
+  const _GroupUserList({this.cursor, @JsonKey(name: 'group_users') final  List<GroupUser> groupUsers = const <GroupUser>[]}): _groupUsers = groupUsers,super._();
   factory _GroupUserList.fromJson(Map<String, dynamic> json) => _$GroupUserListFromJson(json);
 
 @override final  String? cursor;

--- a/nakama/lib/src/models/group.g.dart
+++ b/nakama/lib/src/models/group.g.dart
@@ -42,9 +42,11 @@ Map<String, dynamic> _$GroupToJson(_Group instance) => <String, dynamic>{
 
 _GroupList _$GroupListFromJson(Map<String, dynamic> json) => _GroupList(
   cursor: json['cursor'] as String?,
-  groups: (json['groups'] as List<dynamic>?)
-      ?.map((e) => Group.fromJson(e as Map<String, dynamic>))
-      .toList(),
+  groups:
+      (json['groups'] as List<dynamic>?)
+          ?.map((e) => Group.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <Group>[],
 );
 
 Map<String, dynamic> _$GroupListToJson(_GroupList instance) =>
@@ -53,9 +55,11 @@ Map<String, dynamic> _$GroupListToJson(_GroupList instance) =>
 _UserGroupList _$UserGroupListFromJson(Map<String, dynamic> json) =>
     _UserGroupList(
       cursor: json['cursor'] as String?,
-      userGroups: (json['user_groups'] as List<dynamic>?)
-          ?.map((e) => UserGroup.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      userGroups:
+          (json['user_groups'] as List<dynamic>?)
+              ?.map((e) => UserGroup.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <UserGroup>[],
     );
 
 Map<String, dynamic> _$UserGroupListToJson(_UserGroupList instance) =>
@@ -85,9 +89,11 @@ const _$GroupMembershipStateEnumMap = {
 _GroupUserList _$GroupUserListFromJson(Map<String, dynamic> json) =>
     _GroupUserList(
       cursor: json['cursor'] as String?,
-      groupUsers: (json['group_users'] as List<dynamic>)
-          .map((e) => GroupUser.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      groupUsers:
+          (json['group_users'] as List<dynamic>?)
+              ?.map((e) => GroupUser.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <GroupUser>[],
     );
 
 Map<String, dynamic> _$GroupUserListToJson(_GroupUserList instance) =>

--- a/nakama/lib/src/models/leaderboard.dart
+++ b/nakama/lib/src/models/leaderboard.dart
@@ -51,14 +51,14 @@ sealed class LeaderboardRecord with _$LeaderboardRecord {
     @JsonKey(name: 'leaderboard_id') String? leaderboardId,
     @JsonKey(name: 'owner_id') String? ownerId,
     @JsonKey(name: 'username') String? username,
-    @JsonKey(name: 'score') String? score,
+    @JsonKey(name: 'score') int? score,
     @JsonKey(name: 'subscore') int? subscore,
     @JsonKey(name: 'num_score') int? numScore,
     @JsonKey(name: 'metadata') String? metadata,
     @JsonKey(name: 'create_time') DateTime? createTime,
     @JsonKey(name: 'update_time') DateTime? updateTime,
     @JsonKey(name: 'expiry_time') DateTime? expiryTime,
-    @JsonKey(name: 'rank') String? rank,
+    @JsonKey(name: 'rank') int? rank,
     @JsonKey(name: 'max_num_score') int? maxNumScore,
   }) = _LeaderboardRecord;
 
@@ -68,14 +68,14 @@ sealed class LeaderboardRecord with _$LeaderboardRecord {
         leaderboardId: PlatformNormalizer.normalizeNullableString(dto.leaderboardId),
         ownerId: PlatformNormalizer.normalizeNullableString(dto.ownerId),
         username: PlatformNormalizer.normalizeNullableString(dto.username.value),
-        score: dto.score.toString(),
+        score: dto.score.toInt(),
         subscore: dto.subscore.toInt(),
         numScore: dto.numScore.toInt(),
         metadata: PlatformNormalizer.normalizeNullableString(dto.metadata),
         createTime: dto.createTime.hasNanos() ? dto.createTime.toDateTime() : null,
         updateTime: dto.updateTime.hasNanos() ? dto.updateTime.toDateTime() : null,
         expiryTime: dto.expiryTime.hasNanos() ? dto.expiryTime.toDateTime() : null,
-        rank: dto.rank.toString(),
+        rank: dto.rank.toInt(),
         maxNumScore: dto.maxNumScore.toInt(),
       );
 }

--- a/nakama/lib/src/models/leaderboard.dart
+++ b/nakama/lib/src/models/leaderboard.dart
@@ -51,15 +51,15 @@ sealed class LeaderboardRecord with _$LeaderboardRecord {
     @JsonKey(name: 'leaderboard_id') String? leaderboardId,
     @JsonKey(name: 'owner_id') String? ownerId,
     @JsonKey(name: 'username') String? username,
-    @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int? score,
-    @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int? subscore,
-    @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int? numScore,
+    @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int score,
+    @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int subscore,
+    @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int numScore,
     @JsonKey(name: 'metadata') String? metadata,
     @JsonKey(name: 'create_time') DateTime? createTime,
     @JsonKey(name: 'update_time') DateTime? updateTime,
     @JsonKey(name: 'expiry_time') DateTime? expiryTime,
-    @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int? rank,
-    @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int? maxNumScore,
+    @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int rank,
+    @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int maxNumScore,
   }) = _LeaderboardRecord;
 
   factory LeaderboardRecord.fromJson(Map<String, Object?> json) => _$LeaderboardRecordFromJson(json);

--- a/nakama/lib/src/models/leaderboard.dart
+++ b/nakama/lib/src/models/leaderboard.dart
@@ -27,8 +27,8 @@ sealed class LeaderboardRecordList with _$LeaderboardRecordList {
   const LeaderboardRecordList._();
 
   const factory LeaderboardRecordList({
-    @JsonKey(name: 'records') required List<LeaderboardRecord>? records,
-    @JsonKey(name: 'owner_records') required List<LeaderboardRecord>? ownerRecords,
+    @JsonKey(name: 'records') @Default(<LeaderboardRecord>[]) List<LeaderboardRecord> records,
+    @JsonKey(name: 'owner_records') @Default(<LeaderboardRecord>[]) List<LeaderboardRecord> ownerRecords,
     @JsonKey(name: 'next_cursor') String? nextCursor,
     @JsonKey(name: 'prev_cursor') String? prevCursor,
   }) = _LeaderboardRecordList;
@@ -51,15 +51,15 @@ sealed class LeaderboardRecord with _$LeaderboardRecord {
     @JsonKey(name: 'leaderboard_id') String? leaderboardId,
     @JsonKey(name: 'owner_id') String? ownerId,
     @JsonKey(name: 'username') String? username,
-    @JsonKey(name: 'score') int? score,
-    @JsonKey(name: 'subscore') int? subscore,
-    @JsonKey(name: 'num_score') int? numScore,
+    @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int? score,
+    @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int? subscore,
+    @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int? numScore,
     @JsonKey(name: 'metadata') String? metadata,
     @JsonKey(name: 'create_time') DateTime? createTime,
     @JsonKey(name: 'update_time') DateTime? updateTime,
     @JsonKey(name: 'expiry_time') DateTime? expiryTime,
-    @JsonKey(name: 'rank') int? rank,
-    @JsonKey(name: 'max_num_score') int? maxNumScore,
+    @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int? rank,
+    @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int? maxNumScore,
   }) = _LeaderboardRecord;
 
   factory LeaderboardRecord.fromJson(Map<String, Object?> json) => _$LeaderboardRecordFromJson(json);

--- a/nakama/lib/src/models/leaderboard.freezed.dart
+++ b/nakama/lib/src/models/leaderboard.freezed.dart
@@ -293,7 +293,7 @@ as String?,
 /// @nodoc
 mixin _$LeaderboardRecord {
 
-@JsonKey(name: 'leaderboard_id') String? get leaderboardId;@JsonKey(name: 'owner_id') String? get ownerId;@JsonKey(name: 'username') String? get username;@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int? get score;@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int? get subscore;@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int? get numScore;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;@JsonKey(name: 'expiry_time') DateTime? get expiryTime;@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int? get rank;@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int? get maxNumScore;
+@JsonKey(name: 'leaderboard_id') String? get leaderboardId;@JsonKey(name: 'owner_id') String? get ownerId;@JsonKey(name: 'username') String? get username;@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int get score;@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int get subscore;@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int get numScore;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;@JsonKey(name: 'expiry_time') DateTime? get expiryTime;@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int get rank;@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int get maxNumScore;
 /// Create a copy of LeaderboardRecord
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -326,7 +326,7 @@ abstract mixin class $LeaderboardRecordCopyWith<$Res>  {
   factory $LeaderboardRecordCopyWith(LeaderboardRecord value, $Res Function(LeaderboardRecord) _then) = _$LeaderboardRecordCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int? score,@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int? subscore,@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int? rank,@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int? maxNumScore
+@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int score,@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int subscore,@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int rank,@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int maxNumScore
 });
 
 
@@ -343,21 +343,21 @@ class _$LeaderboardRecordCopyWithImpl<$Res>
 
 /// Create a copy of LeaderboardRecord
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? leaderboardId = freezed,Object? ownerId = freezed,Object? username = freezed,Object? score = freezed,Object? subscore = freezed,Object? numScore = freezed,Object? metadata = freezed,Object? createTime = freezed,Object? updateTime = freezed,Object? expiryTime = freezed,Object? rank = freezed,Object? maxNumScore = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? leaderboardId = freezed,Object? ownerId = freezed,Object? username = freezed,Object? score = null,Object? subscore = null,Object? numScore = null,Object? metadata = freezed,Object? createTime = freezed,Object? updateTime = freezed,Object? expiryTime = freezed,Object? rank = null,Object? maxNumScore = null,}) {
   return _then(_self.copyWith(
 leaderboardId: freezed == leaderboardId ? _self.leaderboardId : leaderboardId // ignore: cast_nullable_to_non_nullable
 as String?,ownerId: freezed == ownerId ? _self.ownerId : ownerId // ignore: cast_nullable_to_non_nullable
 as String?,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
-as String?,score: freezed == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
-as int?,subscore: freezed == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
-as int?,numScore: freezed == numScore ? _self.numScore : numScore // ignore: cast_nullable_to_non_nullable
-as int?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,score: null == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as int,subscore: null == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
+as int,numScore: null == numScore ? _self.numScore : numScore // ignore: cast_nullable_to_non_nullable
+as int,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
 as String?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,expiryTime: freezed == expiryTime ? _self.expiryTime : expiryTime // ignore: cast_nullable_to_non_nullable
-as DateTime?,rank: freezed == rank ? _self.rank : rank // ignore: cast_nullable_to_non_nullable
-as int?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
-as int?,
+as DateTime?,rank: null == rank ? _self.rank : rank // ignore: cast_nullable_to_non_nullable
+as int,maxNumScore: null == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 
@@ -439,7 +439,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int? score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int? subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int? rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int? maxNumScore)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int maxNumScore)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord() when $default != null:
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);case _:
@@ -460,7 +460,7 @@ return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int? score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int? subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int? rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int? maxNumScore)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int maxNumScore)  $default,) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord():
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);}
@@ -477,7 +477,7 @@ return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int? score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int? subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int? rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int? maxNumScore)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int maxNumScore)?  $default,) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord() when $default != null:
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);case _:
@@ -492,21 +492,21 @@ return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_th
 @JsonSerializable()
 
 class _LeaderboardRecord extends LeaderboardRecord {
-  const _LeaderboardRecord({@JsonKey(name: 'leaderboard_id') this.leaderboardId, @JsonKey(name: 'owner_id') this.ownerId, @JsonKey(name: 'username') this.username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) this.score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) this.subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) this.numScore, @JsonKey(name: 'metadata') this.metadata, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'update_time') this.updateTime, @JsonKey(name: 'expiry_time') this.expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) this.rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) this.maxNumScore}): super._();
+  const _LeaderboardRecord({@JsonKey(name: 'leaderboard_id') this.leaderboardId, @JsonKey(name: 'owner_id') this.ownerId, @JsonKey(name: 'username') this.username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) this.score = 0, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) this.subscore = 0, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) this.numScore = 0, @JsonKey(name: 'metadata') this.metadata, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'update_time') this.updateTime, @JsonKey(name: 'expiry_time') this.expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) this.rank = 0, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) this.maxNumScore = 0}): super._();
   factory _LeaderboardRecord.fromJson(Map<String, dynamic> json) => _$LeaderboardRecordFromJson(json);
 
 @override@JsonKey(name: 'leaderboard_id') final  String? leaderboardId;
 @override@JsonKey(name: 'owner_id') final  String? ownerId;
 @override@JsonKey(name: 'username') final  String? username;
-@override@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) final  int? score;
-@override@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) final  int? subscore;
-@override@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) final  int? numScore;
+@override@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) final  int score;
+@override@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) final  int subscore;
+@override@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) final  int numScore;
 @override@JsonKey(name: 'metadata') final  String? metadata;
 @override@JsonKey(name: 'create_time') final  DateTime? createTime;
 @override@JsonKey(name: 'update_time') final  DateTime? updateTime;
 @override@JsonKey(name: 'expiry_time') final  DateTime? expiryTime;
-@override@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) final  int? rank;
-@override@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) final  int? maxNumScore;
+@override@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) final  int rank;
+@override@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) final  int maxNumScore;
 
 /// Create a copy of LeaderboardRecord
 /// with the given fields replaced by the non-null parameter values.
@@ -541,7 +541,7 @@ abstract mixin class _$LeaderboardRecordCopyWith<$Res> implements $LeaderboardRe
   factory _$LeaderboardRecordCopyWith(_LeaderboardRecord value, $Res Function(_LeaderboardRecord) _then) = __$LeaderboardRecordCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int? score,@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int? subscore,@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int? rank,@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int? maxNumScore
+@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int score,@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int subscore,@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int rank,@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int maxNumScore
 });
 
 
@@ -558,21 +558,21 @@ class __$LeaderboardRecordCopyWithImpl<$Res>
 
 /// Create a copy of LeaderboardRecord
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? leaderboardId = freezed,Object? ownerId = freezed,Object? username = freezed,Object? score = freezed,Object? subscore = freezed,Object? numScore = freezed,Object? metadata = freezed,Object? createTime = freezed,Object? updateTime = freezed,Object? expiryTime = freezed,Object? rank = freezed,Object? maxNumScore = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? leaderboardId = freezed,Object? ownerId = freezed,Object? username = freezed,Object? score = null,Object? subscore = null,Object? numScore = null,Object? metadata = freezed,Object? createTime = freezed,Object? updateTime = freezed,Object? expiryTime = freezed,Object? rank = null,Object? maxNumScore = null,}) {
   return _then(_LeaderboardRecord(
 leaderboardId: freezed == leaderboardId ? _self.leaderboardId : leaderboardId // ignore: cast_nullable_to_non_nullable
 as String?,ownerId: freezed == ownerId ? _self.ownerId : ownerId // ignore: cast_nullable_to_non_nullable
 as String?,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
-as String?,score: freezed == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
-as int?,subscore: freezed == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
-as int?,numScore: freezed == numScore ? _self.numScore : numScore // ignore: cast_nullable_to_non_nullable
-as int?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as String?,score: null == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as int,subscore: null == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
+as int,numScore: null == numScore ? _self.numScore : numScore // ignore: cast_nullable_to_non_nullable
+as int,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
 as String?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,expiryTime: freezed == expiryTime ? _self.expiryTime : expiryTime // ignore: cast_nullable_to_non_nullable
-as DateTime?,rank: freezed == rank ? _self.rank : rank // ignore: cast_nullable_to_non_nullable
-as int?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
-as int?,
+as DateTime?,rank: null == rank ? _self.rank : rank // ignore: cast_nullable_to_non_nullable
+as int,maxNumScore: null == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 

--- a/nakama/lib/src/models/leaderboard.freezed.dart
+++ b/nakama/lib/src/models/leaderboard.freezed.dart
@@ -297,7 +297,7 @@ as String?,
 /// @nodoc
 mixin _$LeaderboardRecord {
 
-@JsonKey(name: 'leaderboard_id') String? get leaderboardId;@JsonKey(name: 'owner_id') String? get ownerId;@JsonKey(name: 'username') String? get username;@JsonKey(name: 'score') String? get score;@JsonKey(name: 'subscore') int? get subscore;@JsonKey(name: 'num_score') int? get numScore;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;@JsonKey(name: 'expiry_time') DateTime? get expiryTime;@JsonKey(name: 'rank') String? get rank;@JsonKey(name: 'max_num_score') int? get maxNumScore;
+@JsonKey(name: 'leaderboard_id') String? get leaderboardId;@JsonKey(name: 'owner_id') String? get ownerId;@JsonKey(name: 'username') String? get username;@JsonKey(name: 'score') int? get score;@JsonKey(name: 'subscore') int? get subscore;@JsonKey(name: 'num_score') int? get numScore;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;@JsonKey(name: 'expiry_time') DateTime? get expiryTime;@JsonKey(name: 'rank') int? get rank;@JsonKey(name: 'max_num_score') int? get maxNumScore;
 /// Create a copy of LeaderboardRecord
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -330,7 +330,7 @@ abstract mixin class $LeaderboardRecordCopyWith<$Res>  {
   factory $LeaderboardRecordCopyWith(LeaderboardRecord value, $Res Function(LeaderboardRecord) _then) = _$LeaderboardRecordCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score') String? score,@JsonKey(name: 'subscore') int? subscore,@JsonKey(name: 'num_score') int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank') String? rank,@JsonKey(name: 'max_num_score') int? maxNumScore
+@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score') int? score,@JsonKey(name: 'subscore') int? subscore,@JsonKey(name: 'num_score') int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank') int? rank,@JsonKey(name: 'max_num_score') int? maxNumScore
 });
 
 
@@ -353,14 +353,14 @@ leaderboardId: freezed == leaderboardId ? _self.leaderboardId : leaderboardId //
 as String?,ownerId: freezed == ownerId ? _self.ownerId : ownerId // ignore: cast_nullable_to_non_nullable
 as String?,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
 as String?,score: freezed == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
-as String?,subscore: freezed == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
+as int?,subscore: freezed == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
 as int?,numScore: freezed == numScore ? _self.numScore : numScore // ignore: cast_nullable_to_non_nullable
 as int?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
 as String?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,expiryTime: freezed == expiryTime ? _self.expiryTime : expiryTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,rank: freezed == rank ? _self.rank : rank // ignore: cast_nullable_to_non_nullable
-as String?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
+as int?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
 as int?,
   ));
 }
@@ -443,7 +443,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  String? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  String? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  int? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  int? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord() when $default != null:
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);case _:
@@ -464,7 +464,7 @@ return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  String? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  String? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  int? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  int? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)  $default,) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord():
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);}
@@ -481,7 +481,7 @@ return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  String? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  String? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  int? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  int? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)?  $default,) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord() when $default != null:
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);case _:
@@ -502,14 +502,14 @@ class _LeaderboardRecord extends LeaderboardRecord {
 @override@JsonKey(name: 'leaderboard_id') final  String? leaderboardId;
 @override@JsonKey(name: 'owner_id') final  String? ownerId;
 @override@JsonKey(name: 'username') final  String? username;
-@override@JsonKey(name: 'score') final  String? score;
+@override@JsonKey(name: 'score') final  int? score;
 @override@JsonKey(name: 'subscore') final  int? subscore;
 @override@JsonKey(name: 'num_score') final  int? numScore;
 @override@JsonKey(name: 'metadata') final  String? metadata;
 @override@JsonKey(name: 'create_time') final  DateTime? createTime;
 @override@JsonKey(name: 'update_time') final  DateTime? updateTime;
 @override@JsonKey(name: 'expiry_time') final  DateTime? expiryTime;
-@override@JsonKey(name: 'rank') final  String? rank;
+@override@JsonKey(name: 'rank') final  int? rank;
 @override@JsonKey(name: 'max_num_score') final  int? maxNumScore;
 
 /// Create a copy of LeaderboardRecord
@@ -545,7 +545,7 @@ abstract mixin class _$LeaderboardRecordCopyWith<$Res> implements $LeaderboardRe
   factory _$LeaderboardRecordCopyWith(_LeaderboardRecord value, $Res Function(_LeaderboardRecord) _then) = __$LeaderboardRecordCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score') String? score,@JsonKey(name: 'subscore') int? subscore,@JsonKey(name: 'num_score') int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank') String? rank,@JsonKey(name: 'max_num_score') int? maxNumScore
+@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score') int? score,@JsonKey(name: 'subscore') int? subscore,@JsonKey(name: 'num_score') int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank') int? rank,@JsonKey(name: 'max_num_score') int? maxNumScore
 });
 
 
@@ -568,14 +568,14 @@ leaderboardId: freezed == leaderboardId ? _self.leaderboardId : leaderboardId //
 as String?,ownerId: freezed == ownerId ? _self.ownerId : ownerId // ignore: cast_nullable_to_non_nullable
 as String?,username: freezed == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
 as String?,score: freezed == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
-as String?,subscore: freezed == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
+as int?,subscore: freezed == subscore ? _self.subscore : subscore // ignore: cast_nullable_to_non_nullable
 as int?,numScore: freezed == numScore ? _self.numScore : numScore // ignore: cast_nullable_to_non_nullable
 as int?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
 as String?,createTime: freezed == createTime ? _self.createTime : createTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,updateTime: freezed == updateTime ? _self.updateTime : updateTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,expiryTime: freezed == expiryTime ? _self.expiryTime : expiryTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,rank: freezed == rank ? _self.rank : rank // ignore: cast_nullable_to_non_nullable
-as String?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
+as int?,maxNumScore: freezed == maxNumScore ? _self.maxNumScore : maxNumScore // ignore: cast_nullable_to_non_nullable
 as int?,
   ));
 }

--- a/nakama/lib/src/models/leaderboard.freezed.dart
+++ b/nakama/lib/src/models/leaderboard.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$LeaderboardRecordList {
 
-@JsonKey(name: 'records') List<LeaderboardRecord>? get records;@JsonKey(name: 'owner_records') List<LeaderboardRecord>? get ownerRecords;@JsonKey(name: 'next_cursor') String? get nextCursor;@JsonKey(name: 'prev_cursor') String? get prevCursor;
+@JsonKey(name: 'records') List<LeaderboardRecord> get records;@JsonKey(name: 'owner_records') List<LeaderboardRecord> get ownerRecords;@JsonKey(name: 'next_cursor') String? get nextCursor;@JsonKey(name: 'prev_cursor') String? get prevCursor;
 /// Create a copy of LeaderboardRecordList
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $LeaderboardRecordListCopyWith<$Res>  {
   factory $LeaderboardRecordListCopyWith(LeaderboardRecordList value, $Res Function(LeaderboardRecordList) _then) = _$LeaderboardRecordListCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'records') List<LeaderboardRecord>? records,@JsonKey(name: 'owner_records') List<LeaderboardRecord>? ownerRecords,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor
+@JsonKey(name: 'records') List<LeaderboardRecord> records,@JsonKey(name: 'owner_records') List<LeaderboardRecord> ownerRecords,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor
 });
 
 
@@ -65,11 +65,11 @@ class _$LeaderboardRecordListCopyWithImpl<$Res>
 
 /// Create a copy of LeaderboardRecordList
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? records = freezed,Object? ownerRecords = freezed,Object? nextCursor = freezed,Object? prevCursor = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? records = null,Object? ownerRecords = null,Object? nextCursor = freezed,Object? prevCursor = freezed,}) {
   return _then(_self.copyWith(
-records: freezed == records ? _self.records : records // ignore: cast_nullable_to_non_nullable
-as List<LeaderboardRecord>?,ownerRecords: freezed == ownerRecords ? _self.ownerRecords : ownerRecords // ignore: cast_nullable_to_non_nullable
-as List<LeaderboardRecord>?,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+records: null == records ? _self.records : records // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>,ownerRecords: null == ownerRecords ? _self.ownerRecords : ownerRecords // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
 as String?,prevCursor: freezed == prevCursor ? _self.prevCursor : prevCursor // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -153,7 +153,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'records')  List<LeaderboardRecord>? records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord>? ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'records')  List<LeaderboardRecord> records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord> ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _LeaderboardRecordList() when $default != null:
 return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCursor);case _:
@@ -174,7 +174,7 @@ return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCurs
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'records')  List<LeaderboardRecord>? records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord>? ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'records')  List<LeaderboardRecord> records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord> ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)  $default,) {final _that = this;
 switch (_that) {
 case _LeaderboardRecordList():
 return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCursor);}
@@ -191,7 +191,7 @@ return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCurs
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'records')  List<LeaderboardRecord>? records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord>? ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'records')  List<LeaderboardRecord> records, @JsonKey(name: 'owner_records')  List<LeaderboardRecord> ownerRecords, @JsonKey(name: 'next_cursor')  String? nextCursor, @JsonKey(name: 'prev_cursor')  String? prevCursor)?  $default,) {final _that = this;
 switch (_that) {
 case _LeaderboardRecordList() when $default != null:
 return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCursor);case _:
@@ -206,25 +206,21 @@ return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.prevCurs
 @JsonSerializable()
 
 class _LeaderboardRecordList extends LeaderboardRecordList {
-  const _LeaderboardRecordList({@JsonKey(name: 'records') required final  List<LeaderboardRecord>? records, @JsonKey(name: 'owner_records') required final  List<LeaderboardRecord>? ownerRecords, @JsonKey(name: 'next_cursor') this.nextCursor, @JsonKey(name: 'prev_cursor') this.prevCursor}): _records = records,_ownerRecords = ownerRecords,super._();
+  const _LeaderboardRecordList({@JsonKey(name: 'records') final  List<LeaderboardRecord> records = const <LeaderboardRecord>[], @JsonKey(name: 'owner_records') final  List<LeaderboardRecord> ownerRecords = const <LeaderboardRecord>[], @JsonKey(name: 'next_cursor') this.nextCursor, @JsonKey(name: 'prev_cursor') this.prevCursor}): _records = records,_ownerRecords = ownerRecords,super._();
   factory _LeaderboardRecordList.fromJson(Map<String, dynamic> json) => _$LeaderboardRecordListFromJson(json);
 
- final  List<LeaderboardRecord>? _records;
-@override@JsonKey(name: 'records') List<LeaderboardRecord>? get records {
-  final value = _records;
-  if (value == null) return null;
+ final  List<LeaderboardRecord> _records;
+@override@JsonKey(name: 'records') List<LeaderboardRecord> get records {
   if (_records is EqualUnmodifiableListView) return _records;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
+  return EqualUnmodifiableListView(_records);
 }
 
- final  List<LeaderboardRecord>? _ownerRecords;
-@override@JsonKey(name: 'owner_records') List<LeaderboardRecord>? get ownerRecords {
-  final value = _ownerRecords;
-  if (value == null) return null;
+ final  List<LeaderboardRecord> _ownerRecords;
+@override@JsonKey(name: 'owner_records') List<LeaderboardRecord> get ownerRecords {
   if (_ownerRecords is EqualUnmodifiableListView) return _ownerRecords;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
+  return EqualUnmodifiableListView(_ownerRecords);
 }
 
 @override@JsonKey(name: 'next_cursor') final  String? nextCursor;
@@ -263,7 +259,7 @@ abstract mixin class _$LeaderboardRecordListCopyWith<$Res> implements $Leaderboa
   factory _$LeaderboardRecordListCopyWith(_LeaderboardRecordList value, $Res Function(_LeaderboardRecordList) _then) = __$LeaderboardRecordListCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'records') List<LeaderboardRecord>? records,@JsonKey(name: 'owner_records') List<LeaderboardRecord>? ownerRecords,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor
+@JsonKey(name: 'records') List<LeaderboardRecord> records,@JsonKey(name: 'owner_records') List<LeaderboardRecord> ownerRecords,@JsonKey(name: 'next_cursor') String? nextCursor,@JsonKey(name: 'prev_cursor') String? prevCursor
 });
 
 
@@ -280,11 +276,11 @@ class __$LeaderboardRecordListCopyWithImpl<$Res>
 
 /// Create a copy of LeaderboardRecordList
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? records = freezed,Object? ownerRecords = freezed,Object? nextCursor = freezed,Object? prevCursor = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? records = null,Object? ownerRecords = null,Object? nextCursor = freezed,Object? prevCursor = freezed,}) {
   return _then(_LeaderboardRecordList(
-records: freezed == records ? _self._records : records // ignore: cast_nullable_to_non_nullable
-as List<LeaderboardRecord>?,ownerRecords: freezed == ownerRecords ? _self._ownerRecords : ownerRecords // ignore: cast_nullable_to_non_nullable
-as List<LeaderboardRecord>?,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+records: null == records ? _self._records : records // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>,ownerRecords: null == ownerRecords ? _self._ownerRecords : ownerRecords // ignore: cast_nullable_to_non_nullable
+as List<LeaderboardRecord>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
 as String?,prevCursor: freezed == prevCursor ? _self.prevCursor : prevCursor // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -297,7 +293,7 @@ as String?,
 /// @nodoc
 mixin _$LeaderboardRecord {
 
-@JsonKey(name: 'leaderboard_id') String? get leaderboardId;@JsonKey(name: 'owner_id') String? get ownerId;@JsonKey(name: 'username') String? get username;@JsonKey(name: 'score') int? get score;@JsonKey(name: 'subscore') int? get subscore;@JsonKey(name: 'num_score') int? get numScore;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;@JsonKey(name: 'expiry_time') DateTime? get expiryTime;@JsonKey(name: 'rank') int? get rank;@JsonKey(name: 'max_num_score') int? get maxNumScore;
+@JsonKey(name: 'leaderboard_id') String? get leaderboardId;@JsonKey(name: 'owner_id') String? get ownerId;@JsonKey(name: 'username') String? get username;@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int? get score;@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int? get subscore;@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int? get numScore;@JsonKey(name: 'metadata') String? get metadata;@JsonKey(name: 'create_time') DateTime? get createTime;@JsonKey(name: 'update_time') DateTime? get updateTime;@JsonKey(name: 'expiry_time') DateTime? get expiryTime;@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int? get rank;@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int? get maxNumScore;
 /// Create a copy of LeaderboardRecord
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -330,7 +326,7 @@ abstract mixin class $LeaderboardRecordCopyWith<$Res>  {
   factory $LeaderboardRecordCopyWith(LeaderboardRecord value, $Res Function(LeaderboardRecord) _then) = _$LeaderboardRecordCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score') int? score,@JsonKey(name: 'subscore') int? subscore,@JsonKey(name: 'num_score') int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank') int? rank,@JsonKey(name: 'max_num_score') int? maxNumScore
+@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int? score,@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int? subscore,@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int? rank,@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int? maxNumScore
 });
 
 
@@ -443,7 +439,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  int? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  int? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int? score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int? subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int? rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int? maxNumScore)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord() when $default != null:
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);case _:
@@ -464,7 +460,7 @@ return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  int? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  int? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int? score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int? subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int? rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int? maxNumScore)  $default,) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord():
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);}
@@ -481,7 +477,7 @@ return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score')  int? score, @JsonKey(name: 'subscore')  int? subscore, @JsonKey(name: 'num_score')  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank')  int? rank, @JsonKey(name: 'max_num_score')  int? maxNumScore)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'leaderboard_id')  String? leaderboardId, @JsonKey(name: 'owner_id')  String? ownerId, @JsonKey(name: 'username')  String? username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)  int? score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)  int? subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)  int? numScore, @JsonKey(name: 'metadata')  String? metadata, @JsonKey(name: 'create_time')  DateTime? createTime, @JsonKey(name: 'update_time')  DateTime? updateTime, @JsonKey(name: 'expiry_time')  DateTime? expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)  int? rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)  int? maxNumScore)?  $default,) {final _that = this;
 switch (_that) {
 case _LeaderboardRecord() when $default != null:
 return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_that.subscore,_that.numScore,_that.metadata,_that.createTime,_that.updateTime,_that.expiryTime,_that.rank,_that.maxNumScore);case _:
@@ -496,21 +492,21 @@ return $default(_that.leaderboardId,_that.ownerId,_that.username,_that.score,_th
 @JsonSerializable()
 
 class _LeaderboardRecord extends LeaderboardRecord {
-  const _LeaderboardRecord({@JsonKey(name: 'leaderboard_id') this.leaderboardId, @JsonKey(name: 'owner_id') this.ownerId, @JsonKey(name: 'username') this.username, @JsonKey(name: 'score') this.score, @JsonKey(name: 'subscore') this.subscore, @JsonKey(name: 'num_score') this.numScore, @JsonKey(name: 'metadata') this.metadata, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'update_time') this.updateTime, @JsonKey(name: 'expiry_time') this.expiryTime, @JsonKey(name: 'rank') this.rank, @JsonKey(name: 'max_num_score') this.maxNumScore}): super._();
+  const _LeaderboardRecord({@JsonKey(name: 'leaderboard_id') this.leaderboardId, @JsonKey(name: 'owner_id') this.ownerId, @JsonKey(name: 'username') this.username, @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) this.score, @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) this.subscore, @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) this.numScore, @JsonKey(name: 'metadata') this.metadata, @JsonKey(name: 'create_time') this.createTime, @JsonKey(name: 'update_time') this.updateTime, @JsonKey(name: 'expiry_time') this.expiryTime, @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) this.rank, @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) this.maxNumScore}): super._();
   factory _LeaderboardRecord.fromJson(Map<String, dynamic> json) => _$LeaderboardRecordFromJson(json);
 
 @override@JsonKey(name: 'leaderboard_id') final  String? leaderboardId;
 @override@JsonKey(name: 'owner_id') final  String? ownerId;
 @override@JsonKey(name: 'username') final  String? username;
-@override@JsonKey(name: 'score') final  int? score;
-@override@JsonKey(name: 'subscore') final  int? subscore;
-@override@JsonKey(name: 'num_score') final  int? numScore;
+@override@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) final  int? score;
+@override@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) final  int? subscore;
+@override@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) final  int? numScore;
 @override@JsonKey(name: 'metadata') final  String? metadata;
 @override@JsonKey(name: 'create_time') final  DateTime? createTime;
 @override@JsonKey(name: 'update_time') final  DateTime? updateTime;
 @override@JsonKey(name: 'expiry_time') final  DateTime? expiryTime;
-@override@JsonKey(name: 'rank') final  int? rank;
-@override@JsonKey(name: 'max_num_score') final  int? maxNumScore;
+@override@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) final  int? rank;
+@override@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) final  int? maxNumScore;
 
 /// Create a copy of LeaderboardRecord
 /// with the given fields replaced by the non-null parameter values.
@@ -545,7 +541,7 @@ abstract mixin class _$LeaderboardRecordCopyWith<$Res> implements $LeaderboardRe
   factory _$LeaderboardRecordCopyWith(_LeaderboardRecord value, $Res Function(_LeaderboardRecord) _then) = __$LeaderboardRecordCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score') int? score,@JsonKey(name: 'subscore') int? subscore,@JsonKey(name: 'num_score') int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank') int? rank,@JsonKey(name: 'max_num_score') int? maxNumScore
+@JsonKey(name: 'leaderboard_id') String? leaderboardId,@JsonKey(name: 'owner_id') String? ownerId,@JsonKey(name: 'username') String? username,@JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) int? score,@JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) int? subscore,@JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) int? numScore,@JsonKey(name: 'metadata') String? metadata,@JsonKey(name: 'create_time') DateTime? createTime,@JsonKey(name: 'update_time') DateTime? updateTime,@JsonKey(name: 'expiry_time') DateTime? expiryTime,@JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) int? rank,@JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) int? maxNumScore
 });
 
 

--- a/nakama/lib/src/models/leaderboard.g.dart
+++ b/nakama/lib/src/models/leaderboard.g.dart
@@ -33,7 +33,7 @@ _LeaderboardRecord _$LeaderboardRecordFromJson(Map<String, dynamic> json) =>
       leaderboardId: json['leaderboard_id'] as String?,
       ownerId: json['owner_id'] as String?,
       username: json['username'] as String?,
-      score: json['score'] as String?,
+      score: (json['score'] as num?)?.toInt(),
       subscore: (json['subscore'] as num?)?.toInt(),
       numScore: (json['num_score'] as num?)?.toInt(),
       metadata: json['metadata'] as String?,
@@ -46,7 +46,7 @@ _LeaderboardRecord _$LeaderboardRecordFromJson(Map<String, dynamic> json) =>
       expiryTime: json['expiry_time'] == null
           ? null
           : DateTime.parse(json['expiry_time'] as String),
-      rank: json['rank'] as String?,
+      rank: (json['rank'] as num?)?.toInt(),
       maxNumScore: (json['max_num_score'] as num?)?.toInt(),
     );
 

--- a/nakama/lib/src/models/leaderboard.g.dart
+++ b/nakama/lib/src/models/leaderboard.g.dart
@@ -37,9 +37,15 @@ _LeaderboardRecord _$LeaderboardRecordFromJson(Map<String, dynamic> json) =>
       leaderboardId: json['leaderboard_id'] as String?,
       ownerId: json['owner_id'] as String?,
       username: json['username'] as String?,
-      score: PlatformNormalizer.normalizeInt(json['score']),
-      subscore: PlatformNormalizer.normalizeInt(json['subscore']),
-      numScore: PlatformNormalizer.normalizeInt(json['num_score']),
+      score: json['score'] == null
+          ? 0
+          : PlatformNormalizer.normalizeInt(json['score']),
+      subscore: json['subscore'] == null
+          ? 0
+          : PlatformNormalizer.normalizeInt(json['subscore']),
+      numScore: json['num_score'] == null
+          ? 0
+          : PlatformNormalizer.normalizeInt(json['num_score']),
       metadata: json['metadata'] as String?,
       createTime: json['create_time'] == null
           ? null
@@ -50,8 +56,12 @@ _LeaderboardRecord _$LeaderboardRecordFromJson(Map<String, dynamic> json) =>
       expiryTime: json['expiry_time'] == null
           ? null
           : DateTime.parse(json['expiry_time'] as String),
-      rank: PlatformNormalizer.normalizeInt(json['rank']),
-      maxNumScore: PlatformNormalizer.normalizeInt(json['max_num_score']),
+      rank: json['rank'] == null
+          ? 0
+          : PlatformNormalizer.normalizeInt(json['rank']),
+      maxNumScore: json['max_num_score'] == null
+          ? 0
+          : PlatformNormalizer.normalizeInt(json['max_num_score']),
     );
 
 Map<String, dynamic> _$LeaderboardRecordToJson(_LeaderboardRecord instance) =>

--- a/nakama/lib/src/models/leaderboard.g.dart
+++ b/nakama/lib/src/models/leaderboard.g.dart
@@ -9,12 +9,16 @@ part of 'leaderboard.dart';
 _LeaderboardRecordList _$LeaderboardRecordListFromJson(
   Map<String, dynamic> json,
 ) => _LeaderboardRecordList(
-  records: (json['records'] as List<dynamic>?)
-      ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
-      .toList(),
-  ownerRecords: (json['owner_records'] as List<dynamic>?)
-      ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
-      .toList(),
+  records:
+      (json['records'] as List<dynamic>?)
+          ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <LeaderboardRecord>[],
+  ownerRecords:
+      (json['owner_records'] as List<dynamic>?)
+          ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <LeaderboardRecord>[],
   nextCursor: json['next_cursor'] as String?,
   prevCursor: json['prev_cursor'] as String?,
 );
@@ -33,9 +37,9 @@ _LeaderboardRecord _$LeaderboardRecordFromJson(Map<String, dynamic> json) =>
       leaderboardId: json['leaderboard_id'] as String?,
       ownerId: json['owner_id'] as String?,
       username: json['username'] as String?,
-      score: (json['score'] as num?)?.toInt(),
-      subscore: (json['subscore'] as num?)?.toInt(),
-      numScore: (json['num_score'] as num?)?.toInt(),
+      score: PlatformNormalizer.normalizeInt(json['score']),
+      subscore: PlatformNormalizer.normalizeInt(json['subscore']),
+      numScore: PlatformNormalizer.normalizeInt(json['num_score']),
       metadata: json['metadata'] as String?,
       createTime: json['create_time'] == null
           ? null
@@ -46,8 +50,8 @@ _LeaderboardRecord _$LeaderboardRecordFromJson(Map<String, dynamic> json) =>
       expiryTime: json['expiry_time'] == null
           ? null
           : DateTime.parse(json['expiry_time'] as String),
-      rank: (json['rank'] as num?)?.toInt(),
-      maxNumScore: (json['max_num_score'] as num?)?.toInt(),
+      rank: PlatformNormalizer.normalizeInt(json['rank']),
+      maxNumScore: PlatformNormalizer.normalizeInt(json['max_num_score']),
     );
 
 Map<String, dynamic> _$LeaderboardRecordToJson(_LeaderboardRecord instance) =>

--- a/nakama/lib/src/models/notification.dart
+++ b/nakama/lib/src/models/notification.dart
@@ -38,7 +38,7 @@ sealed class NotificationList with _$NotificationList {
 
   const factory NotificationList({
     @JsonKey(name: 'cacheable_cursor') String? cursor,
-    @JsonKey(name: 'notifications') required List<Notification> notifications,
+    @JsonKey(name: 'notifications') @Default(<Notification>[]) List<Notification> notifications,
   }) = _NotificationList;
 
   factory NotificationList.fromJson(Map<String, Object?> json) => _$NotificationListFromJson(json);

--- a/nakama/lib/src/models/notification.freezed.dart
+++ b/nakama/lib/src/models/notification.freezed.dart
@@ -479,7 +479,7 @@ return $default(_that.cursor,_that.notifications);case _:
 @JsonSerializable()
 
 class _NotificationList extends NotificationList {
-  const _NotificationList({@JsonKey(name: 'cacheable_cursor') this.cursor, @JsonKey(name: 'notifications') required final  List<Notification> notifications}): _notifications = notifications,super._();
+  const _NotificationList({@JsonKey(name: 'cacheable_cursor') this.cursor, @JsonKey(name: 'notifications') final  List<Notification> notifications = const <Notification>[]}): _notifications = notifications,super._();
   factory _NotificationList.fromJson(Map<String, dynamic> json) => _$NotificationListFromJson(json);
 
 @override@JsonKey(name: 'cacheable_cursor') final  String? cursor;

--- a/nakama/lib/src/models/notification.g.dart
+++ b/nakama/lib/src/models/notification.g.dart
@@ -31,9 +31,11 @@ Map<String, dynamic> _$NotificationToJson(_Notification instance) =>
 _NotificationList _$NotificationListFromJson(Map<String, dynamic> json) =>
     _NotificationList(
       cursor: json['cacheable_cursor'] as String?,
-      notifications: (json['notifications'] as List<dynamic>)
-          .map((e) => Notification.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      notifications:
+          (json['notifications'] as List<dynamic>?)
+              ?.map((e) => Notification.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <Notification>[],
     );
 
 Map<String, dynamic> _$NotificationListToJson(_NotificationList instance) =>

--- a/nakama/lib/src/models/storage.dart
+++ b/nakama/lib/src/models/storage.dart
@@ -44,7 +44,7 @@ sealed class StorageObjectList with _$StorageObjectList {
 
   const factory StorageObjectList({
     String? cursor,
-    required List<StorageObject> objects,
+    @Default(<StorageObject>[]) List<StorageObject> objects,
   }) = _StorageObjectList;
 
   factory StorageObjectList.fromJson(Map<String, Object?> json) => _$StorageObjectListFromJson(json);

--- a/nakama/lib/src/models/storage.freezed.dart
+++ b/nakama/lib/src/models/storage.freezed.dart
@@ -485,12 +485,12 @@ return $default(_that.cursor,_that.objects);case _:
 @JsonSerializable()
 
 class _StorageObjectList extends StorageObjectList {
-  const _StorageObjectList({this.cursor, required final  List<StorageObject> objects}): _objects = objects,super._();
+  const _StorageObjectList({this.cursor, final  List<StorageObject> objects = const <StorageObject>[]}): _objects = objects,super._();
   factory _StorageObjectList.fromJson(Map<String, dynamic> json) => _$StorageObjectListFromJson(json);
 
 @override final  String? cursor;
  final  List<StorageObject> _objects;
-@override List<StorageObject> get objects {
+@override@JsonKey() List<StorageObject> get objects {
   if (_objects is EqualUnmodifiableListView) return _objects;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(_objects);

--- a/nakama/lib/src/models/storage.g.dart
+++ b/nakama/lib/src/models/storage.g.dart
@@ -57,9 +57,11 @@ const _$StorageWritePermissionEnumMap = {
 _StorageObjectList _$StorageObjectListFromJson(Map<String, dynamic> json) =>
     _StorageObjectList(
       cursor: json['cursor'] as String?,
-      objects: (json['objects'] as List<dynamic>)
-          .map((e) => StorageObject.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      objects:
+          (json['objects'] as List<dynamic>?)
+              ?.map((e) => StorageObject.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <StorageObject>[],
     );
 
 Map<String, dynamic> _$StorageObjectListToJson(_StorageObjectList instance) =>

--- a/nakama/lib/src/models/tournament.dart
+++ b/nakama/lib/src/models/tournament.dart
@@ -61,7 +61,7 @@ sealed class TournamentList with _$TournamentList {
 
   const factory TournamentList({
     String? cursor,
-    required List<Tournament> tournaments,
+    @Default(<Tournament>[]) List<Tournament> tournaments,
   }) = _TournamentList;
 
   factory TournamentList.fromJson(Map<String, Object?> json) => _$TournamentListFromJson(json);
@@ -77,8 +77,8 @@ sealed class TournamentRecordList with _$TournamentRecordList {
   const TournamentRecordList._();
 
   const factory TournamentRecordList({
-    @JsonKey(name: 'records') required List<LeaderboardRecord> records,
-    @JsonKey(name: 'owner_records') required List<LeaderboardRecord> ownerRecords,
+    @JsonKey(name: 'records') @Default(<LeaderboardRecord>[]) List<LeaderboardRecord> records,
+    @JsonKey(name: 'owner_records') @Default(<LeaderboardRecord>[]) List<LeaderboardRecord> ownerRecords,
     @JsonKey(name: 'next_cursor') String? nextCursor,
     @JsonKey(name: 'previous_cursor') String? previousCursor,
   }) = _TournamentRecordList;

--- a/nakama/lib/src/models/tournament.freezed.dart
+++ b/nakama/lib/src/models/tournament.freezed.dart
@@ -512,12 +512,12 @@ return $default(_that.cursor,_that.tournaments);case _:
 @JsonSerializable()
 
 class _TournamentList extends TournamentList {
-  const _TournamentList({this.cursor, required final  List<Tournament> tournaments}): _tournaments = tournaments,super._();
+  const _TournamentList({this.cursor, final  List<Tournament> tournaments = const <Tournament>[]}): _tournaments = tournaments,super._();
   factory _TournamentList.fromJson(Map<String, dynamic> json) => _$TournamentListFromJson(json);
 
 @override final  String? cursor;
  final  List<Tournament> _tournaments;
-@override List<Tournament> get tournaments {
+@override@JsonKey() List<Tournament> get tournaments {
   if (_tournaments is EqualUnmodifiableListView) return _tournaments;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(_tournaments);
@@ -780,7 +780,7 @@ return $default(_that.records,_that.ownerRecords,_that.nextCursor,_that.previous
 @JsonSerializable()
 
 class _TournamentRecordList extends TournamentRecordList {
-  const _TournamentRecordList({@JsonKey(name: 'records') required final  List<LeaderboardRecord> records, @JsonKey(name: 'owner_records') required final  List<LeaderboardRecord> ownerRecords, @JsonKey(name: 'next_cursor') this.nextCursor, @JsonKey(name: 'previous_cursor') this.previousCursor}): _records = records,_ownerRecords = ownerRecords,super._();
+  const _TournamentRecordList({@JsonKey(name: 'records') final  List<LeaderboardRecord> records = const <LeaderboardRecord>[], @JsonKey(name: 'owner_records') final  List<LeaderboardRecord> ownerRecords = const <LeaderboardRecord>[], @JsonKey(name: 'next_cursor') this.nextCursor, @JsonKey(name: 'previous_cursor') this.previousCursor}): _records = records,_ownerRecords = ownerRecords,super._();
   factory _TournamentRecordList.fromJson(Map<String, dynamic> json) => _$TournamentRecordListFromJson(json);
 
  final  List<LeaderboardRecord> _records;

--- a/nakama/lib/src/models/tournament.g.dart
+++ b/nakama/lib/src/models/tournament.g.dart
@@ -58,9 +58,11 @@ Map<String, dynamic> _$TournamentToJson(_Tournament instance) =>
 _TournamentList _$TournamentListFromJson(Map<String, dynamic> json) =>
     _TournamentList(
       cursor: json['cursor'] as String?,
-      tournaments: (json['tournaments'] as List<dynamic>)
-          .map((e) => Tournament.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      tournaments:
+          (json['tournaments'] as List<dynamic>?)
+              ?.map((e) => Tournament.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <Tournament>[],
     );
 
 Map<String, dynamic> _$TournamentListToJson(_TournamentList instance) =>
@@ -72,12 +74,16 @@ Map<String, dynamic> _$TournamentListToJson(_TournamentList instance) =>
 _TournamentRecordList _$TournamentRecordListFromJson(
   Map<String, dynamic> json,
 ) => _TournamentRecordList(
-  records: (json['records'] as List<dynamic>)
-      .map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
-      .toList(),
-  ownerRecords: (json['owner_records'] as List<dynamic>)
-      .map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
-      .toList(),
+  records:
+      (json['records'] as List<dynamic>?)
+          ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <LeaderboardRecord>[],
+  ownerRecords:
+      (json['owner_records'] as List<dynamic>?)
+          ?.map((e) => LeaderboardRecord.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <LeaderboardRecord>[],
   nextCursor: json['next_cursor'] as String?,
   previousCursor: json['previous_cursor'] as String?,
 );

--- a/nakama/lib/src/utils/platform_normalizer.dart
+++ b/nakama/lib/src/utils/platform_normalizer.dart
@@ -11,4 +11,37 @@ class PlatformNormalizer {
     }
     return value;
   }
+
+  /// Parses an int from JSON, handling proto3's tendency to encode int64 as
+  /// strings and to omit zero-value fields entirely.
+  /// Returns 0 when the value is null (proto3 omits default values).
+  static int normalizeInt(dynamic value) {
+    if (value == null) return 0;
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value) ?? 0;
+    return 0;
+  }
+
+  /// Parses a nullable int from JSON, handling proto3's string-encoded int64.
+  /// Returns null when the value is null.
+  static int? normalizeNullableInt(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value);
+    return null;
+  }
+
+  /// Parses a JSON array into a typed list, returning an empty list when the
+  /// value is null. Handles proto3's tendency to omit empty arrays entirely.
+  static List<T> parseList<T>(
+    dynamic value,
+    T Function(Map<String, dynamic>) fromJson,
+  ) {
+    if (value == null) return const [];
+    return (value as List<dynamic>)
+        .map((e) => fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
 }

--- a/nakama/lib/src/utils/platform_normalizer.dart
+++ b/nakama/lib/src/utils/platform_normalizer.dart
@@ -32,16 +32,4 @@ class PlatformNormalizer {
     if (value is String) return int.tryParse(value);
     return null;
   }
-
-  /// Parses a JSON array into a typed list, returning an empty list when the
-  /// value is null. Handles proto3's tendency to omit empty arrays entirely.
-  static List<T> parseList<T>(
-    dynamic value,
-    T Function(Map<String, dynamic>) fromJson,
-  ) {
-    if (value == null) return const [];
-    return (value as List<dynamic>)
-        .map((e) => fromJson(e as Map<String, dynamic>))
-        .toList();
-  }
 }

--- a/nakama/test/grpc/leaderboard_test.dart
+++ b/nakama/test/grpc/leaderboard_test.dart
@@ -71,7 +71,7 @@ void main() {
         );
 
         expect(ourRecord.leaderboardId, equals(writtenRecord.leaderboardId));
-        expect(ourRecord.score, equals('100'));
+        expect(ourRecord.score, equals(100));
         expect(ourRecord.ownerId, equals(session.userId));
         expect(ourRecord.username, isNotNull);
       });
@@ -125,7 +125,7 @@ void main() {
         final result = await client.writeLeaderboardRecord(
             session: session, leaderboardName: leaderboardName, score: 0);
 
-        expect(result.score, equals('0'));
+        expect(result.score, equals(0));
         expect(result.ownerId, equals(session.userId));
       });
     });
@@ -149,7 +149,7 @@ void main() {
         final ourRecord = result.records!.firstWhere(
           (record) => record.ownerId == session.userId,
         );
-        expect(ourRecord.score, equals('500'));
+        expect(ourRecord.score, equals(500));
       });
 
       test('should handle limit parameter for records around owner', () async {

--- a/nakama/test/grpc/leaderboard_test.dart
+++ b/nakama/test/grpc/leaderboard_test.dart
@@ -63,10 +63,10 @@ void main() {
 
         expect(result, isA<LeaderboardRecordList>());
         expect(result.records, isNotEmpty);
-        expect(result.records!.length, greaterThanOrEqualTo(1));
+        expect(result.records.length, greaterThanOrEqualTo(1));
 
         // Find our record
-        final ourRecord = result.records!.firstWhere(
+        final ourRecord = result.records.firstWhere(
           (record) => record.ownerId == session.userId,
         );
 
@@ -146,7 +146,7 @@ void main() {
         expect(result.records, isNotEmpty);
 
         // Should contain our record
-        final ourRecord = result.records!.firstWhere(
+        final ourRecord = result.records.firstWhere(
           (record) => record.ownerId == session.userId,
         );
         expect(ourRecord.score, equals(500));
@@ -193,7 +193,7 @@ void main() {
           session: session,
           leaderboardName: leaderboardName,
         );
-        expect(beforeDelete.records!.any((r) => r.ownerId == session.userId),
+        expect(beforeDelete.records.any((r) => r.ownerId == session.userId),
             isTrue);
 
         // Delete the record
@@ -205,7 +205,7 @@ void main() {
           session: session,
           leaderboardName: leaderboardName,
         );
-        expect(afterDelete.records!.any((r) => r.ownerId == session.userId),
+        expect(afterDelete.records.any((r) => r.ownerId == session.userId),
             isFalse);
       });
     });

--- a/nakama/test/rest/leaderboard_test.dart
+++ b/nakama/test/rest/leaderboard_test.dart
@@ -114,7 +114,7 @@ void main() {
         expect(result.ownerId, equals(session.userId));
         expect(result.leaderboardId, equals(leaderboardName));
         expect(result.username, isNotNull);
-        expect(result.score, isNotNull);
+        expect(result.score, equals(150));
       });
 
       test('should handle zero score', () async {

--- a/nakama/test/rest/leaderboard_test.dart
+++ b/nakama/test/rest/leaderboard_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:faker/faker.dart';
 import 'package:nakama/nakama.dart';
 import 'package:test/test.dart';
@@ -8,7 +10,8 @@ void main() {
   group('[REST] Test Leaderboard', () {
     late final NakamaBaseClient client;
     late final Session session;
-    late final String leaderboardName = 'test';
+    late final String leaderboardName =
+        'test_leaderboard_${faker.randomGenerator.integer(999999)}';
 
     setUpAll(() async {
       client = NakamaRestApiClient.init(
@@ -16,25 +19,197 @@ void main() {
         ssl: false,
         serverKey: kTestServerKey,
       );
-
       session = await client.authenticateDevice(deviceId: faker.guid.guid());
+
+      // Create leaderboard via RPC
+      await client.rpc(
+          id: 'create_leaderboard_rpc',
+          session: session,
+          payload: jsonEncode({'id': leaderboardName}));
     });
 
-    test('list leaderboard records', () async {
-      final result = await client.listLeaderboardRecords(
-        session: session,
-        leaderboardName: leaderboardName,
-      );
-
-      expect(result, isA<LeaderboardRecordList>());
+    tearDown(() async {
+      // Clean up any records created during tests
+      try {
+        await client.deleteLeaderboardRecord(
+            session: session, leaderboardName: leaderboardName);
+      } catch (e) {
+        // Ignore errors if record doesn't exist
+      }
     });
 
-    test('write leaderboard record', () async {
-      final result = await client.writeLeaderboardRecord(session: session, leaderboardName: leaderboardName, score: 10);
+    group('List leaderboard records', () {
+      test('should return empty list when no records exist', () async {
+        final result = await client.listLeaderboardRecords(
+          session: session,
+          leaderboardName: leaderboardName,
+        );
 
-      expect(result, isA<LeaderboardRecord>());
-      expect(result.score, isNotNull);
-      expect(result.score, equals(10));
+        expect(result, isA<LeaderboardRecordList>());
+        expect(result.records, isEmpty);
+        expect(result.nextCursor, isNull);
+        expect(result.prevCursor, isNull);
+      });
+
+      test('should list leaderboard records with proper structure', () async {
+        final writtenRecord = await client.writeLeaderboardRecord(
+            session: session, leaderboardName: leaderboardName, score: 100);
+
+        final result = await client.listLeaderboardRecords(
+          session: session,
+          leaderboardName: leaderboardName,
+        );
+
+        expect(result, isA<LeaderboardRecordList>());
+        expect(result.records, isNotEmpty);
+        expect(result.records.length, greaterThanOrEqualTo(1));
+
+        final ourRecord = result.records.firstWhere(
+          (record) => record.ownerId == session.userId,
+        );
+
+        expect(ourRecord.leaderboardId, equals(writtenRecord.leaderboardId));
+        expect(ourRecord.score, equals(100));
+        expect(ourRecord.ownerId, equals(session.userId));
+        expect(ourRecord.username, isNotNull);
+      });
+
+      test('should handle pagination with limit parameter', () async {
+        final sessions = <Session>[];
+        for (int i = 0; i < 3; i++) {
+          final tempSession =
+              await client.authenticateDevice(deviceId: faker.guid.guid());
+          sessions.add(tempSession);
+          await client.writeLeaderboardRecord(
+              session: tempSession,
+              leaderboardName: leaderboardName,
+              score: 50 + i * 10);
+        }
+
+        final result = await client.listLeaderboardRecords(
+          session: session,
+          leaderboardName: leaderboardName,
+          limit: 2,
+        );
+
+        expect(result.records, hasLength(lessThanOrEqualTo(2)));
+
+        for (final tempSession in sessions) {
+          try {
+            await client.deleteLeaderboardRecord(
+                session: tempSession, leaderboardName: leaderboardName);
+          } catch (e) {
+            // Ignore cleanup errors
+          }
+        }
+      });
+    });
+
+    group('Write leaderboard record', () {
+      test('should write leaderboard record successfully', () async {
+        final result = await client.writeLeaderboardRecord(
+            session: session, leaderboardName: leaderboardName, score: 150);
+
+        expect(result, isA<LeaderboardRecord>());
+        expect(result.ownerId, equals(session.userId));
+        expect(result.leaderboardId, equals(leaderboardName));
+        expect(result.username, isNotNull);
+        expect(result.score, isNotNull);
+      });
+
+      test('should handle zero score', () async {
+        final result = await client.writeLeaderboardRecord(
+            session: session, leaderboardName: leaderboardName, score: 0);
+
+        expect(result.score, equals(0));
+        expect(result.ownerId, equals(session.userId));
+      });
+    });
+
+    group('List leaderboard records around owner', () {
+      test('should list records around specific owner', () async {
+        await client.writeLeaderboardRecord(
+            session: session, leaderboardName: leaderboardName, score: 500);
+
+        final result = await client.listLeaderboardRecordsAroundOwner(
+          session: session,
+          leaderboardName: leaderboardName,
+          ownerId: session.userId,
+        );
+
+        expect(result, isA<LeaderboardRecordList>());
+        expect(result.records, isNotEmpty);
+
+        final ourRecord = result.records.firstWhere(
+          (record) => record.ownerId == session.userId,
+        );
+        expect(ourRecord.score, equals(500));
+      });
+
+      test('should handle limit parameter for records around owner', () async {
+        await client.writeLeaderboardRecord(
+            session: session, leaderboardName: leaderboardName, score: 250);
+
+        final result = await client.listLeaderboardRecordsAroundOwner(
+          session: session,
+          leaderboardName: leaderboardName,
+          ownerId: session.userId,
+          limit: 1,
+        );
+
+        expect(result.records, hasLength(lessThanOrEqualTo(1)));
+      });
+
+      test('should return empty when owner has no records', () async {
+        final newSession =
+            await client.authenticateDevice(deviceId: faker.guid.guid());
+
+        final result = await client.listLeaderboardRecordsAroundOwner(
+          session: session,
+          leaderboardName: leaderboardName,
+          ownerId: newSession.userId,
+        );
+
+        expect(result, isA<LeaderboardRecordList>());
+        expect(result.records, isEmpty);
+      });
+    });
+
+    group('Delete leaderboard record', () {
+      test('should delete leaderboard record successfully', () async {
+        await client.writeLeaderboardRecord(
+            session: session, leaderboardName: leaderboardName, score: 75);
+
+        final beforeDelete = await client.listLeaderboardRecords(
+          session: session,
+          leaderboardName: leaderboardName,
+        );
+        expect(beforeDelete.records.any((r) => r.ownerId == session.userId),
+            isTrue);
+
+        await client.deleteLeaderboardRecord(
+            session: session, leaderboardName: leaderboardName);
+
+        final afterDelete = await client.listLeaderboardRecords(
+          session: session,
+          leaderboardName: leaderboardName,
+        );
+        expect(afterDelete.records.any((r) => r.ownerId == session.userId),
+            isFalse);
+      });
+    });
+
+    group('Error handling', () {
+      test('should throw error for invalid leaderboard name', () async {
+        expect(
+          () async => await client.listLeaderboardRecords(
+            session: session,
+            leaderboardName:
+                'non_existent_leaderboard_${faker.randomGenerator.integer(999999)}',
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
     });
   });
 }

--- a/nakama/test/rest/leaderboard_test.dart
+++ b/nakama/test/rest/leaderboard_test.dart
@@ -34,7 +34,7 @@ void main() {
 
       expect(result, isA<LeaderboardRecord>());
       expect(result.score, isNotNull);
-      expect(result.score, equals('10'));
+      expect(result.score, equals(10));
     });
   });
 }

--- a/nakama/test/utils/platform_normalizer_test.dart
+++ b/nakama/test/utils/platform_normalizer_test.dart
@@ -20,5 +20,63 @@ void main() {
         expect(PlatformNormalizer.normalizeNullableString(' '), equals(' '));
       });
     });
+
+    group('normalizeInt', () {
+      test('should return 0 for null input', () {
+        expect(PlatformNormalizer.normalizeInt(null), equals(0));
+      });
+
+      test('should return the int unchanged', () {
+        expect(PlatformNormalizer.normalizeInt(42), equals(42));
+        expect(PlatformNormalizer.normalizeInt(0), equals(0));
+        expect(PlatformNormalizer.normalizeInt(-1), equals(-1));
+      });
+
+      test('should truncate doubles to int', () {
+        expect(PlatformNormalizer.normalizeInt(3.7), equals(3));
+      });
+
+      test('should parse numeric strings (proto3 int64 encoding)', () {
+        expect(PlatformNormalizer.normalizeInt('100'), equals(100));
+        expect(PlatformNormalizer.normalizeInt('9223372036854775807'), equals(9223372036854775807));
+      });
+
+      test('should return 0 for invalid string', () {
+        expect(PlatformNormalizer.normalizeInt('abc'), equals(0));
+        expect(PlatformNormalizer.normalizeInt(''), equals(0));
+      });
+
+      test('should return 0 for unsupported types', () {
+        expect(PlatformNormalizer.normalizeInt(true), equals(0));
+        expect(PlatformNormalizer.normalizeInt([1, 2]), equals(0));
+      });
+    });
+
+    group('normalizeNullableInt', () {
+      test('should return null for null input', () {
+        expect(PlatformNormalizer.normalizeNullableInt(null), isNull);
+      });
+
+      test('should return the int unchanged', () {
+        expect(PlatformNormalizer.normalizeNullableInt(42), equals(42));
+        expect(PlatformNormalizer.normalizeNullableInt(0), equals(0));
+      });
+
+      test('should truncate doubles to int', () {
+        expect(PlatformNormalizer.normalizeNullableInt(3.7), equals(3));
+      });
+
+      test('should parse numeric strings (proto3 int64 encoding)', () {
+        expect(PlatformNormalizer.normalizeNullableInt('100'), equals(100));
+      });
+
+      test('should return null for invalid string', () {
+        expect(PlatformNormalizer.normalizeNullableInt('abc'), isNull);
+      });
+
+      test('should return null for unsupported types', () {
+        expect(PlatformNormalizer.normalizeNullableInt(true), isNull);
+      });
+    });
   });
 }


### PR DESCRIPTION
Enhance serialization and deserialization for leaderboard, group, channel message, notification, storage, and tournament models

- Modified leaderboard score and rank types from String to int
- Updated leaderboard models to provide default empty lists for records and ownerRecords.
- Introduced PlatformNormalizer utility for consistent integer parsing from JSON.
- Modified notification and storage models to use default empty lists for notifications and objects.
- Enhanced tournament models to ensure default empty lists for tournaments, records, and ownerRecords.

Additionally:
- Improved test cases for leaderboard functionality, including pagination and error handling.
- Added cleanup logic in tests to ensure no residual data affects subsequent tests.