### PR TITLE
Add quality workflows (nakama and satori)

### DIFF
--- a/.github/workflows/nakama-quality.yml
+++ b/.github/workflows/nakama-quality.yml
@@ -1,0 +1,24 @@
+name: Nakama Quality
+
+on:
+  pull_request:
+    paths:
+      - nakama/**
+      - .github/workflows/nakama-quality.yml
+      - .github/workflows/package-quality.yml
+  push:
+    branches:
+      - main
+    paths:
+      - nakama/**
+      - .github/workflows/nakama-quality.yml
+      - .github/workflows/package-quality.yml
+  workflow_dispatch:
+
+jobs:
+  quality:
+    uses: ./.github/workflows/package-quality.yml
+    with:
+      package_name: nakama
+      package_path: nakama
+      min_pub_points: 120

--- a/.github/workflows/nakama-quality.yml
+++ b/.github/workflows/nakama-quality.yml
@@ -15,6 +15,10 @@ on:
       - .github/workflows/package-quality.yml
   workflow_dispatch:
 
+concurrency:
+  group: nakama-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     uses: ./.github/workflows/package-quality.yml

--- a/.github/workflows/package-quality.yml
+++ b/.github/workflows/package-quality.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/package-quality.yml
+++ b/.github/workflows/package-quality.yml
@@ -14,10 +14,14 @@ on:
         default: 120
         type: number
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: ${{ inputs.package_name }} quality
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
     defaults:
       run:
         shell: bash
@@ -65,8 +69,10 @@ jobs:
           export PATH="$PATH:$HOME/.pub-cache/bin"
 
           set +e
+          set -o pipefail
           pana . | tee /tmp/pana-output.txt
           PANA_EXIT=$?
+          set +o pipefail
           set -e
 
           SCORE_LINE=$(grep -Eo 'Points: [0-9]+/[0-9]+' /tmp/pana-output.txt | tail -n1 || true)

--- a/.github/workflows/package-quality.yml
+++ b/.github/workflows/package-quality.yml
@@ -1,0 +1,95 @@
+name: Package Quality Checks
+
+on:
+  workflow_call:
+    inputs:
+      package_name:
+        required: true
+        type: string
+      package_path:
+        required: true
+        type: string
+      min_pub_points:
+        required: false
+        default: 120
+        type: number
+
+jobs:
+  quality:
+    name: ${{ inputs.package_name }} quality
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ inputs.package_path }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Toolchain versions
+        run: |
+          flutter --version
+          dart --version
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Static analysis
+        run: dart analyze
+
+      - name: WASM smoke check via example app
+        run: |
+          if [[ -d example ]]; then
+            pushd example
+            flutter pub get
+            flutter build web --wasm --release
+            popd
+          else
+            echo "No example directory found; skipping WASM smoke check."
+          fi
+
+      - name: Install pana
+        run: dart pub global activate pana
+
+      - name: Verify pub.dev score threshold
+        env:
+          MIN_POINTS: ${{ inputs.min_pub_points }}
+        run: |
+          export PATH="$PATH:$HOME/.pub-cache/bin"
+
+          set +e
+          pana . | tee /tmp/pana-output.txt
+          PANA_EXIT=$?
+          set -e
+
+          SCORE_LINE=$(grep -Eo 'Points: [0-9]+/[0-9]+' /tmp/pana-output.txt | tail -n1 || true)
+
+          if [[ -z "$SCORE_LINE" ]]; then
+            echo "Could not detect pana score in output."
+            echo "pana exit code: $PANA_EXIT"
+            exit 1
+          fi
+
+          SCORE=$(echo "$SCORE_LINE" | sed -E 's/Points: ([0-9]+)\/.*/\1/')
+          MAX_SCORE=$(echo "$SCORE_LINE" | sed -E 's/Points: [0-9]+\/([0-9]+)/\1/')
+
+          echo "Detected pana score: $SCORE/$MAX_SCORE"
+          echo "Required minimum: $MIN_POINTS"
+
+          if (( SCORE < MIN_POINTS )); then
+            echo "Score check failed: $SCORE < $MIN_POINTS"
+            exit 1
+          fi
+
+          if (( PANA_EXIT != 0 )); then
+            echo "pana returned non-zero exit code: $PANA_EXIT"
+            exit $PANA_EXIT
+          fi
+

--- a/.github/workflows/satori-quality.yml
+++ b/.github/workflows/satori-quality.yml
@@ -1,0 +1,24 @@
+name: Satori Quality
+
+on:
+  pull_request:
+    paths:
+      - satori/**
+      - .github/workflows/satori-quality.yml
+      - .github/workflows/package-quality.yml
+  push:
+    branches:
+      - main
+    paths:
+      - satori/**
+      - .github/workflows/satori-quality.yml
+      - .github/workflows/package-quality.yml
+  workflow_dispatch:
+
+jobs:
+  quality:
+    uses: ./.github/workflows/package-quality.yml
+    with:
+      package_name: satori
+      package_path: satori
+      min_pub_points: 120

--- a/.github/workflows/satori-quality.yml
+++ b/.github/workflows/satori-quality.yml
@@ -15,6 +15,10 @@ on:
       - .github/workflows/package-quality.yml
   workflow_dispatch:
 
+concurrency:
+  group: satori-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     uses: ./.github/workflows/package-quality.yml


### PR DESCRIPTION
- `dart analyze` no static errors or warnings
- `flutter build web --wasm --release` package compiles to WASM via the example app
- `pana` score gate pub.dev quality score stays above the minimum threshold (120 pts, soon to be increased as soon as existing score is improved)
- path-scoped triggers nakama changes only run the nakama workflow, satori changes only run satori's
- independent pipelines one package failing never blocks or pollutes the other