### PR TITLE
Improve pub.dev score for Satori and Nakama

### DIFF
--- a/nakama/example/lib/features/chat/providers/chat_provider.dart
+++ b/nakama/example/lib/features/chat/providers/chat_provider.dart
@@ -58,7 +58,8 @@ class ChatNotifier extends StateNotifier<ChatState?> {
     await refreshMessages(channel, session);
   }
 
-  Future<ChannelMessageList> refreshMessages(Channel channel, Session session) async {
+  Future<ChannelMessageList> refreshMessages(
+      Channel channel, Session session) async {
     // https://heroiclabs.com/docs/nakama/client-libraries/dart/index.html#listing-message-history
     final updatedMessages = await NakamaClient.instance!.listChannelMessages(
       channelId: channel.id,

--- a/nakama/example/lib/features/chat/views/chats.dart
+++ b/nakama/example/lib/features/chat/views/chats.dart
@@ -28,7 +28,9 @@ class _ChatsPageState extends ConsumerState<ChatsPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: chat == null ? const Text('Create or join chat') : Text('Chat room ${chat.channel?.roomName}'),
+        title: chat == null
+            ? const Text('Create or join chat')
+            : Text('Chat room ${chat.channel?.roomName}'),
         actions: [
           if (chat != null) ...[
             IconButton(
@@ -54,4 +56,3 @@ class _ChatsPageState extends ConsumerState<ChatsPage> {
     );
   }
 }
-

--- a/nakama/example/lib/features/chat/widgets/chat_room.dart
+++ b/nakama/example/lib/features/chat/widgets/chat_room.dart
@@ -16,100 +16,98 @@ class ChatRoom extends StatelessWidget {
   final WidgetRef ref;
 
   @override
-  Widget build(BuildContext context){
-  refreshMessagesOnChannelMessages(context);
-  return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text('Room Name: ${chat.channel!.roomName}'),
-              CopyButton(text: chat.channel!.roomName),
-            ],
+  Widget build(BuildContext context) {
+    refreshMessagesOnChannelMessages(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('Room Name: ${chat.channel!.roomName}'),
+            CopyButton(text: chat.channel!.roomName),
+          ],
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('Channel ID: ${chat.channel!.id}'),
+            CopyButton(text: chat.channel!.id),
+          ],
+        ),
+        const SizedBox(height: 20),
+        Text('Presence Count: ${chat.channel!.presences.length}'),
+        const SizedBox(height: 20),
+        for (final presence in chat.channel!.presences)
+          Text(
+            'User: ${presence.userId}, Username: ${presence.username}, Session ID: ${presence.sessionId}',
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text('Channel ID: ${chat.channel!.id}'),
-              CopyButton(text: chat.channel!.id),
-            ],
+        const Text('Messages:'),
+        const SizedBox(height: 10),
+        Expanded(
+          child: chat.messages?.messages.isEmpty ?? true
+              ? const Text('No messages yet.')
+              : ListView.builder(
+                  itemCount: chat.messages!.messages.length,
+                  itemBuilder: (context, index) {
+                    final message = chat.messages!.messages[index];
+                    return ListTile(
+                      title: Text(message.username),
+                      subtitle: Text(message.content),
+                      trailing: Text(
+                        message.createTime.toIso8601String(),
+                      ),
+                    );
+                  },
+                ),
+        ),
+        const SizedBox(height: 10),
+        SizedBox(
+          width: double.infinity,
+          child: TextButton(
+            onPressed: () async {
+              final session = ref.read(sessionProvider)!;
+              await ref
+                  .read(chatProvider.notifier)
+                  .refreshMessages(chat.channel!, session);
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Messages refreshed!')),
+                );
+              }
+            },
+            child: const Text('Refresh messages'),
           ),
-          const SizedBox(height: 20),
-          Text('Presence Count: ${chat.channel!.presences.length}'),
-          const SizedBox(height: 20),
-          for (final presence in chat.channel!.presences)
-            Text(
-              'User: ${presence.userId}, Username: ${presence.username}, Session ID: ${presence.sessionId}',
-            ),
-          const Text('Messages:'),
-          const SizedBox(height: 10),
-          Expanded(
-            child: chat.messages?.messages.isEmpty ?? true
-                ? const Text('No messages yet.')
-                : ListView.builder(
-                    itemCount: chat.messages!.messages.length,
-                    itemBuilder: (context, index) {
-                      final message = chat.messages!.messages[index];
-                      return ListTile(
-                        title: Text(message.username),
-                        subtitle: Text(message.content),
-                        trailing: Text(
-                          message.createTime.toIso8601String(),
-                        ),
-                      );
-                    },
-                  ),
+        ),
+        const SizedBox(height: 10),
+        SizedBox(
+          width: double.infinity,
+          child: TextButton(
+            onPressed: () async {
+              final randomMessage =
+                  'Random message ${DateTime.now().millisecondsSinceEpoch}';
+              await ref.read(chatProvider.notifier).sendMessage(randomMessage);
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Message sent: $randomMessage')),
+                );
+              }
+            },
+            child: const Text('Send random text as a message'),
           ),
-          const SizedBox(height: 10),
-          SizedBox(
-            width: double.infinity,
-            child: TextButton(
-              onPressed: () async {
-                final session = ref.read(sessionProvider)!;
-                await ref
-                    .read(chatProvider.notifier)
-                    .refreshMessages(chat.channel!, session);
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                        content: Text('Messages refreshed!')),
-                  );
-                }
-              },
-              child: const Text('Refresh messages'),
-            ),
-          ),
-          const SizedBox(height: 10),
-          SizedBox(
-            width: double.infinity,
-            child: TextButton(
-              onPressed: () async {
-                final randomMessage =
-                    'Random message ${DateTime.now().millisecondsSinceEpoch}';
-                await ref
-                    .read(chatProvider.notifier)
-                    .sendMessage(randomMessage);
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                        content: Text('Message sent: $randomMessage')),
-                  );
-                }
-              },
-              child: const Text('Send random text as a message'),
-            ),
-          ),
-        ],
-      );
-}
+        ),
+      ],
+    );
+  }
 
   void refreshMessagesOnChannelMessages(BuildContext context) {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final ws = NakamaWSClient.instance!;
       ws.onChannelMessage.listen((event) async {
         final session = ref.read(sessionProvider)!;
-        await ref.read(chatProvider.notifier).refreshMessages(chat.channel!, session);
+        await ref
+            .read(chatProvider.notifier)
+            .refreshMessages(chat.channel!, session);
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(content: Text('Messages refreshed!')),

--- a/nakama/example/lib/features/chat/widgets/list_chats_options.dart
+++ b/nakama/example/lib/features/chat/widgets/list_chats_options.dart
@@ -18,7 +18,9 @@ class ListChatsOptions extends ConsumerWidget {
             child: TextButton(
               onPressed: () async {
                 try {
-                  await ref.read(chatProvider.notifier).createAndJoinChat(context);
+                  await ref
+                      .read(chatProvider.notifier)
+                      .createAndJoinChat(context);
                 } catch (e) {
                   if (!context.mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
@@ -37,8 +39,9 @@ class ListChatsOptions extends ConsumerWidget {
           SizedBox(
             width: double.infinity,
             child: TextButton(
-              onPressed: () async =>
-                  ref.read(chatProvider.notifier).joinChat(_targetChat.text, context),
+              onPressed: () async => ref
+                  .read(chatProvider.notifier)
+                  .joinChat(_targetChat.text, context),
               child: const Text('Join chat'),
             ),
           ),

--- a/nakama/example/lib/features/common/widgets/copy_button.dart
+++ b/nakama/example/lib/features/common/widgets/copy_button.dart
@@ -3,21 +3,21 @@ import 'package:flutter/services.dart';
 
 class CopyButton extends StatelessWidget {
   const CopyButton({
-    required this.text, super.key,
+    required this.text,
+    super.key,
   });
 
   final String text;
 
   @override
   Widget build(BuildContext context) => IconButton(
-      icon: Icon(Icons.copy),
-      onPressed: () async {
-        await Clipboard.setData(
-            ClipboardData(text: text));
-        if (!context.mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Copied to clipboard!')),
-        );
-      },
-    );
+        icon: Icon(Icons.copy),
+        onPressed: () async {
+          await Clipboard.setData(ClipboardData(text: text));
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Copied to clipboard!')),
+          );
+        },
+      );
 }

--- a/nakama/example/lib/features/group/views/groups.dart
+++ b/nakama/example/lib/features/group/views/groups.dart
@@ -41,7 +41,8 @@ class GroupsPage extends ConsumerWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(groups[index].id),
-                        Text('Random generated group, click to modify its name'),
+                        Text(
+                            'Random generated group, click to modify its name'),
                       ],
                     ),
                     trailing: Icon(Icons.edit),

--- a/nakama/example/lib/features/leaderboard/views/pages/leaderboard.dart
+++ b/nakama/example/lib/features/leaderboard/views/pages/leaderboard.dart
@@ -16,12 +16,14 @@ class LeaderboardPage extends ConsumerWidget {
 
     // Fetch leaderboard records when the page is loaded
     ref.listen(leaderboardProvider.notifier, (previous, next) {
-      unawaited(ref.read(leaderboardProvider.notifier).listRecords(leaderboardName));
+      unawaited(
+          ref.read(leaderboardProvider.notifier).listRecords(leaderboardName));
     });
 
     // Fetch records initially
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      unawaited(ref.read(leaderboardProvider.notifier).listRecords(leaderboardName));
+      unawaited(
+          ref.read(leaderboardProvider.notifier).listRecords(leaderboardName));
     });
 
     return Scaffold(

--- a/nakama/example/lib/features/rpc/custom/views/pages/rpc_custom.dart
+++ b/nakama/example/lib/features/rpc/custom/views/pages/rpc_custom.dart
@@ -73,7 +73,8 @@ class RpcCustomPage extends ConsumerWidget {
                         .callWSWithPayload(
                             'hello_world', {'name': 'Websocket with payload'}),
                   ),
-                  child: const Text('Call "hello_world (WebSocket)" with payload'),
+                  child:
+                      const Text('Call "hello_world (WebSocket)" with payload'),
                 ),
               ),
             ],

--- a/nakama/example/pubspec.lock
+++ b/nakama/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -186,18 +186,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -339,5 +339,5 @@ packages:
     source: hosted
     version: "3.0.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.0.0"

--- a/nakama/lib/src/api/proto/api/api.pb.dart
+++ b/nakama/lib/src/api/proto/api/api.pb.dart
@@ -84,7 +84,6 @@ class Account extends $pb.GeneratedMessage {
   static Account create() => Account._();
   @$core.override
   Account createEmptyInstance() => create();
-  static $pb.PbList<Account> createRepeated() => $pb.PbList<Account>();
   @$core.pragma('dart2js:noInline')
   static Account getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Account>(create);
@@ -208,8 +207,6 @@ class AccountRefresh extends $pb.GeneratedMessage {
   static AccountRefresh create() => AccountRefresh._();
   @$core.override
   AccountRefresh createEmptyInstance() => create();
-  static $pb.PbList<AccountRefresh> createRepeated() =>
-      $pb.PbList<AccountRefresh>();
   @$core.pragma('dart2js:noInline')
   static AccountRefresh getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountRefresh>(create);
@@ -277,8 +274,6 @@ class AccountApple extends $pb.GeneratedMessage {
   static AccountApple create() => AccountApple._();
   @$core.override
   AccountApple createEmptyInstance() => create();
-  static $pb.PbList<AccountApple> createRepeated() =>
-      $pb.PbList<AccountApple>();
   @$core.pragma('dart2js:noInline')
   static AccountApple getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountApple>(create);
@@ -346,8 +341,6 @@ class AccountCustom extends $pb.GeneratedMessage {
   static AccountCustom create() => AccountCustom._();
   @$core.override
   AccountCustom createEmptyInstance() => create();
-  static $pb.PbList<AccountCustom> createRepeated() =>
-      $pb.PbList<AccountCustom>();
   @$core.pragma('dart2js:noInline')
   static AccountCustom getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountCustom>(create);
@@ -415,8 +408,6 @@ class AccountDevice extends $pb.GeneratedMessage {
   static AccountDevice create() => AccountDevice._();
   @$core.override
   AccountDevice createEmptyInstance() => create();
-  static $pb.PbList<AccountDevice> createRepeated() =>
-      $pb.PbList<AccountDevice>();
   @$core.pragma('dart2js:noInline')
   static AccountDevice getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountDevice>(create);
@@ -487,8 +478,6 @@ class AccountEmail extends $pb.GeneratedMessage {
   static AccountEmail create() => AccountEmail._();
   @$core.override
   AccountEmail createEmptyInstance() => create();
-  static $pb.PbList<AccountEmail> createRepeated() =>
-      $pb.PbList<AccountEmail>();
   @$core.pragma('dart2js:noInline')
   static AccountEmail getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountEmail>(create);
@@ -566,8 +555,6 @@ class AccountFacebook extends $pb.GeneratedMessage {
   static AccountFacebook create() => AccountFacebook._();
   @$core.override
   AccountFacebook createEmptyInstance() => create();
-  static $pb.PbList<AccountFacebook> createRepeated() =>
-      $pb.PbList<AccountFacebook>();
   @$core.pragma('dart2js:noInline')
   static AccountFacebook getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountFacebook>(create);
@@ -637,8 +624,6 @@ class AccountFacebookInstantGame extends $pb.GeneratedMessage {
   static AccountFacebookInstantGame create() => AccountFacebookInstantGame._();
   @$core.override
   AccountFacebookInstantGame createEmptyInstance() => create();
-  static $pb.PbList<AccountFacebookInstantGame> createRepeated() =>
-      $pb.PbList<AccountFacebookInstantGame>();
   @$core.pragma('dart2js:noInline')
   static AccountFacebookInstantGame getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountFacebookInstantGame>(create);
@@ -721,8 +706,6 @@ class AccountGameCenter extends $pb.GeneratedMessage {
   static AccountGameCenter create() => AccountGameCenter._();
   @$core.override
   AccountGameCenter createEmptyInstance() => create();
-  static $pb.PbList<AccountGameCenter> createRepeated() =>
-      $pb.PbList<AccountGameCenter>();
   @$core.pragma('dart2js:noInline')
   static AccountGameCenter getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountGameCenter>(create);
@@ -840,8 +823,6 @@ class AccountGoogle extends $pb.GeneratedMessage {
   static AccountGoogle create() => AccountGoogle._();
   @$core.override
   AccountGoogle createEmptyInstance() => create();
-  static $pb.PbList<AccountGoogle> createRepeated() =>
-      $pb.PbList<AccountGoogle>();
   @$core.pragma('dart2js:noInline')
   static AccountGoogle getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountGoogle>(create);
@@ -909,8 +890,6 @@ class AccountSteam extends $pb.GeneratedMessage {
   static AccountSteam create() => AccountSteam._();
   @$core.override
   AccountSteam createEmptyInstance() => create();
-  static $pb.PbList<AccountSteam> createRepeated() =>
-      $pb.PbList<AccountSteam>();
   @$core.pragma('dart2js:noInline')
   static AccountSteam getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AccountSteam>(create);
@@ -977,8 +956,6 @@ class AddFriendsRequest extends $pb.GeneratedMessage {
   static AddFriendsRequest create() => AddFriendsRequest._();
   @$core.override
   AddFriendsRequest createEmptyInstance() => create();
-  static $pb.PbList<AddFriendsRequest> createRepeated() =>
-      $pb.PbList<AddFriendsRequest>();
   @$core.pragma('dart2js:noInline')
   static AddFriendsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AddFriendsRequest>(create);
@@ -1046,8 +1023,6 @@ class AddGroupUsersRequest extends $pb.GeneratedMessage {
   static AddGroupUsersRequest create() => AddGroupUsersRequest._();
   @$core.override
   AddGroupUsersRequest createEmptyInstance() => create();
-  static $pb.PbList<AddGroupUsersRequest> createRepeated() =>
-      $pb.PbList<AddGroupUsersRequest>();
   @$core.pragma('dart2js:noInline')
   static AddGroupUsersRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AddGroupUsersRequest>(create);
@@ -1116,8 +1091,6 @@ class SessionRefreshRequest extends $pb.GeneratedMessage {
   static SessionRefreshRequest create() => SessionRefreshRequest._();
   @$core.override
   SessionRefreshRequest createEmptyInstance() => create();
-  static $pb.PbList<SessionRefreshRequest> createRepeated() =>
-      $pb.PbList<SessionRefreshRequest>();
   @$core.pragma('dart2js:noInline')
   static SessionRefreshRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SessionRefreshRequest>(create);
@@ -1181,8 +1154,6 @@ class SessionLogoutRequest extends $pb.GeneratedMessage {
   static SessionLogoutRequest create() => SessionLogoutRequest._();
   @$core.override
   SessionLogoutRequest createEmptyInstance() => create();
-  static $pb.PbList<SessionLogoutRequest> createRepeated() =>
-      $pb.PbList<SessionLogoutRequest>();
   @$core.pragma('dart2js:noInline')
   static SessionLogoutRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SessionLogoutRequest>(create);
@@ -1258,8 +1229,6 @@ class AuthenticateAppleRequest extends $pb.GeneratedMessage {
   static AuthenticateAppleRequest create() => AuthenticateAppleRequest._();
   @$core.override
   AuthenticateAppleRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateAppleRequest> createRepeated() =>
-      $pb.PbList<AuthenticateAppleRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateAppleRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AuthenticateAppleRequest>(create);
@@ -1349,8 +1318,6 @@ class AuthenticateCustomRequest extends $pb.GeneratedMessage {
   static AuthenticateCustomRequest create() => AuthenticateCustomRequest._();
   @$core.override
   AuthenticateCustomRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateCustomRequest> createRepeated() =>
-      $pb.PbList<AuthenticateCustomRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateCustomRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AuthenticateCustomRequest>(create);
@@ -1440,8 +1407,6 @@ class AuthenticateDeviceRequest extends $pb.GeneratedMessage {
   static AuthenticateDeviceRequest create() => AuthenticateDeviceRequest._();
   @$core.override
   AuthenticateDeviceRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateDeviceRequest> createRepeated() =>
-      $pb.PbList<AuthenticateDeviceRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateDeviceRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AuthenticateDeviceRequest>(create);
@@ -1531,8 +1496,6 @@ class AuthenticateEmailRequest extends $pb.GeneratedMessage {
   static AuthenticateEmailRequest create() => AuthenticateEmailRequest._();
   @$core.override
   AuthenticateEmailRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateEmailRequest> createRepeated() =>
-      $pb.PbList<AuthenticateEmailRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateEmailRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AuthenticateEmailRequest>(create);
@@ -1628,8 +1591,6 @@ class AuthenticateFacebookRequest extends $pb.GeneratedMessage {
       AuthenticateFacebookRequest._();
   @$core.override
   AuthenticateFacebookRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateFacebookRequest> createRepeated() =>
-      $pb.PbList<AuthenticateFacebookRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateFacebookRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AuthenticateFacebookRequest>(create);
@@ -1734,8 +1695,6 @@ class AuthenticateFacebookInstantGameRequest extends $pb.GeneratedMessage {
       AuthenticateFacebookInstantGameRequest._();
   @$core.override
   AuthenticateFacebookInstantGameRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateFacebookInstantGameRequest> createRepeated() =>
-      $pb.PbList<AuthenticateFacebookInstantGameRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateFacebookInstantGameRequest getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
@@ -1828,8 +1787,6 @@ class AuthenticateGameCenterRequest extends $pb.GeneratedMessage {
       AuthenticateGameCenterRequest._();
   @$core.override
   AuthenticateGameCenterRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateGameCenterRequest> createRepeated() =>
-      $pb.PbList<AuthenticateGameCenterRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateGameCenterRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AuthenticateGameCenterRequest>(create);
@@ -1919,8 +1876,6 @@ class AuthenticateGoogleRequest extends $pb.GeneratedMessage {
   static AuthenticateGoogleRequest create() => AuthenticateGoogleRequest._();
   @$core.override
   AuthenticateGoogleRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateGoogleRequest> createRepeated() =>
-      $pb.PbList<AuthenticateGoogleRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateGoogleRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AuthenticateGoogleRequest>(create);
@@ -2014,8 +1969,6 @@ class AuthenticateSteamRequest extends $pb.GeneratedMessage {
   static AuthenticateSteamRequest create() => AuthenticateSteamRequest._();
   @$core.override
   AuthenticateSteamRequest createEmptyInstance() => create();
-  static $pb.PbList<AuthenticateSteamRequest> createRepeated() =>
-      $pb.PbList<AuthenticateSteamRequest>();
   @$core.pragma('dart2js:noInline')
   static AuthenticateSteamRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<AuthenticateSteamRequest>(create);
@@ -2111,8 +2064,6 @@ class BanGroupUsersRequest extends $pb.GeneratedMessage {
   static BanGroupUsersRequest create() => BanGroupUsersRequest._();
   @$core.override
   BanGroupUsersRequest createEmptyInstance() => create();
-  static $pb.PbList<BanGroupUsersRequest> createRepeated() =>
-      $pb.PbList<BanGroupUsersRequest>();
   @$core.pragma('dart2js:noInline')
   static BanGroupUsersRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<BanGroupUsersRequest>(create);
@@ -2176,8 +2127,6 @@ class BlockFriendsRequest extends $pb.GeneratedMessage {
   static BlockFriendsRequest create() => BlockFriendsRequest._();
   @$core.override
   BlockFriendsRequest createEmptyInstance() => create();
-  static $pb.PbList<BlockFriendsRequest> createRepeated() =>
-      $pb.PbList<BlockFriendsRequest>();
   @$core.pragma('dart2js:noInline')
   static BlockFriendsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<BlockFriendsRequest>(create);
@@ -2272,8 +2221,6 @@ class ChannelMessage extends $pb.GeneratedMessage {
   static ChannelMessage create() => ChannelMessage._();
   @$core.override
   ChannelMessage createEmptyInstance() => create();
-  static $pb.PbList<ChannelMessage> createRepeated() =>
-      $pb.PbList<ChannelMessage>();
   @$core.pragma('dart2js:noInline')
   static ChannelMessage getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelMessage>(create);
@@ -2468,8 +2415,6 @@ class ChannelMessageList extends $pb.GeneratedMessage {
   static ChannelMessageList create() => ChannelMessageList._();
   @$core.override
   ChannelMessageList createEmptyInstance() => create();
-  static $pb.PbList<ChannelMessageList> createRepeated() =>
-      $pb.PbList<ChannelMessageList>();
   @$core.pragma('dart2js:noInline')
   static ChannelMessageList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageList>(create);
@@ -2565,8 +2510,6 @@ class CreateGroupRequest extends $pb.GeneratedMessage {
   static CreateGroupRequest create() => CreateGroupRequest._();
   @$core.override
   CreateGroupRequest createEmptyInstance() => create();
-  static $pb.PbList<CreateGroupRequest> createRepeated() =>
-      $pb.PbList<CreateGroupRequest>();
   @$core.pragma('dart2js:noInline')
   static CreateGroupRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CreateGroupRequest>(create);
@@ -2676,8 +2619,6 @@ class DeleteFriendsRequest extends $pb.GeneratedMessage {
   static DeleteFriendsRequest create() => DeleteFriendsRequest._();
   @$core.override
   DeleteFriendsRequest createEmptyInstance() => create();
-  static $pb.PbList<DeleteFriendsRequest> createRepeated() =>
-      $pb.PbList<DeleteFriendsRequest>();
   @$core.pragma('dart2js:noInline')
   static DeleteFriendsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DeleteFriendsRequest>(create);
@@ -2732,8 +2673,6 @@ class DeleteGroupRequest extends $pb.GeneratedMessage {
   static DeleteGroupRequest create() => DeleteGroupRequest._();
   @$core.override
   DeleteGroupRequest createEmptyInstance() => create();
-  static $pb.PbList<DeleteGroupRequest> createRepeated() =>
-      $pb.PbList<DeleteGroupRequest>();
   @$core.pragma('dart2js:noInline')
   static DeleteGroupRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DeleteGroupRequest>(create);
@@ -2793,8 +2732,6 @@ class DeleteLeaderboardRecordRequest extends $pb.GeneratedMessage {
       DeleteLeaderboardRecordRequest._();
   @$core.override
   DeleteLeaderboardRecordRequest createEmptyInstance() => create();
-  static $pb.PbList<DeleteLeaderboardRecordRequest> createRepeated() =>
-      $pb.PbList<DeleteLeaderboardRecordRequest>();
   @$core.pragma('dart2js:noInline')
   static DeleteLeaderboardRecordRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DeleteLeaderboardRecordRequest>(create);
@@ -2853,8 +2790,6 @@ class DeleteNotificationsRequest extends $pb.GeneratedMessage {
   static DeleteNotificationsRequest create() => DeleteNotificationsRequest._();
   @$core.override
   DeleteNotificationsRequest createEmptyInstance() => create();
-  static $pb.PbList<DeleteNotificationsRequest> createRepeated() =>
-      $pb.PbList<DeleteNotificationsRequest>();
   @$core.pragma('dart2js:noInline')
   static DeleteNotificationsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DeleteNotificationsRequest>(create);
@@ -2908,8 +2843,6 @@ class DeleteTournamentRecordRequest extends $pb.GeneratedMessage {
       DeleteTournamentRecordRequest._();
   @$core.override
   DeleteTournamentRecordRequest createEmptyInstance() => create();
-  static $pb.PbList<DeleteTournamentRecordRequest> createRepeated() =>
-      $pb.PbList<DeleteTournamentRecordRequest>();
   @$core.pragma('dart2js:noInline')
   static DeleteTournamentRecordRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DeleteTournamentRecordRequest>(create);
@@ -2973,8 +2906,6 @@ class DeleteStorageObjectId extends $pb.GeneratedMessage {
   static DeleteStorageObjectId create() => DeleteStorageObjectId._();
   @$core.override
   DeleteStorageObjectId createEmptyInstance() => create();
-  static $pb.PbList<DeleteStorageObjectId> createRepeated() =>
-      $pb.PbList<DeleteStorageObjectId>();
   @$core.pragma('dart2js:noInline')
   static DeleteStorageObjectId getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DeleteStorageObjectId>(create);
@@ -3055,8 +2986,6 @@ class DeleteStorageObjectsRequest extends $pb.GeneratedMessage {
       DeleteStorageObjectsRequest._();
   @$core.override
   DeleteStorageObjectsRequest createEmptyInstance() => create();
-  static $pb.PbList<DeleteStorageObjectsRequest> createRepeated() =>
-      $pb.PbList<DeleteStorageObjectsRequest>();
   @$core.pragma('dart2js:noInline')
   static DeleteStorageObjectsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DeleteStorageObjectsRequest>(create);
@@ -3120,7 +3049,6 @@ class Event extends $pb.GeneratedMessage {
   static Event create() => Event._();
   @$core.override
   Event createEmptyInstance() => create();
-  static $pb.PbList<Event> createRepeated() => $pb.PbList<Event>();
   @$core.pragma('dart2js:noInline')
   static Event getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Event>(create);
@@ -3213,7 +3141,6 @@ class Friend extends $pb.GeneratedMessage {
   static Friend create() => Friend._();
   @$core.override
   Friend createEmptyInstance() => create();
-  static $pb.PbList<Friend> createRepeated() => $pb.PbList<Friend>();
   @$core.pragma('dart2js:noInline')
   static Friend getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Friend>(create);
@@ -3309,7 +3236,6 @@ class FriendList extends $pb.GeneratedMessage {
   static FriendList create() => FriendList._();
   @$core.override
   FriendList createEmptyInstance() => create();
-  static $pb.PbList<FriendList> createRepeated() => $pb.PbList<FriendList>();
   @$core.pragma('dart2js:noInline')
   static FriendList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FriendList>(create);
@@ -3377,8 +3303,6 @@ class FriendsOfFriendsList_FriendOfFriend extends $pb.GeneratedMessage {
       FriendsOfFriendsList_FriendOfFriend._();
   @$core.override
   FriendsOfFriendsList_FriendOfFriend createEmptyInstance() => create();
-  static $pb.PbList<FriendsOfFriendsList_FriendOfFriend> createRepeated() =>
-      $pb.PbList<FriendsOfFriendsList_FriendOfFriend>();
   @$core.pragma('dart2js:noInline')
   static FriendsOfFriendsList_FriendOfFriend getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
@@ -3454,8 +3378,6 @@ class FriendsOfFriendsList extends $pb.GeneratedMessage {
   static FriendsOfFriendsList create() => FriendsOfFriendsList._();
   @$core.override
   FriendsOfFriendsList createEmptyInstance() => create();
-  static $pb.PbList<FriendsOfFriendsList> createRepeated() =>
-      $pb.PbList<FriendsOfFriendsList>();
   @$core.pragma('dart2js:noInline')
   static FriendsOfFriendsList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FriendsOfFriendsList>(create);
@@ -3523,8 +3445,6 @@ class GetUsersRequest extends $pb.GeneratedMessage {
   static GetUsersRequest create() => GetUsersRequest._();
   @$core.override
   GetUsersRequest createEmptyInstance() => create();
-  static $pb.PbList<GetUsersRequest> createRepeated() =>
-      $pb.PbList<GetUsersRequest>();
   @$core.pragma('dart2js:noInline')
   static GetUsersRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GetUsersRequest>(create);
@@ -3584,8 +3504,6 @@ class GetSubscriptionRequest extends $pb.GeneratedMessage {
   static GetSubscriptionRequest create() => GetSubscriptionRequest._();
   @$core.override
   GetSubscriptionRequest createEmptyInstance() => create();
-  static $pb.PbList<GetSubscriptionRequest> createRepeated() =>
-      $pb.PbList<GetSubscriptionRequest>();
   @$core.pragma('dart2js:noInline')
   static GetSubscriptionRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GetSubscriptionRequest>(create);
@@ -3677,7 +3595,6 @@ class Group extends $pb.GeneratedMessage {
   static Group create() => Group._();
   @$core.override
   Group createEmptyInstance() => create();
-  static $pb.PbList<Group> createRepeated() => $pb.PbList<Group>();
   @$core.pragma('dart2js:noInline')
   static Group getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Group>(create);
@@ -3852,7 +3769,6 @@ class GroupList extends $pb.GeneratedMessage {
   static GroupList create() => GroupList._();
   @$core.override
   GroupList createEmptyInstance() => create();
-  static $pb.PbList<GroupList> createRepeated() => $pb.PbList<GroupList>();
   @$core.pragma('dart2js:noInline')
   static GroupList getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GroupList>(create);
@@ -3918,8 +3834,6 @@ class GroupUserList_GroupUser extends $pb.GeneratedMessage {
   static GroupUserList_GroupUser create() => GroupUserList_GroupUser._();
   @$core.override
   GroupUserList_GroupUser createEmptyInstance() => create();
-  static $pb.PbList<GroupUserList_GroupUser> createRepeated() =>
-      $pb.PbList<GroupUserList_GroupUser>();
   @$core.pragma('dart2js:noInline')
   static GroupUserList_GroupUser getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GroupUserList_GroupUser>(create);
@@ -3994,8 +3908,6 @@ class GroupUserList extends $pb.GeneratedMessage {
   static GroupUserList create() => GroupUserList._();
   @$core.override
   GroupUserList createEmptyInstance() => create();
-  static $pb.PbList<GroupUserList> createRepeated() =>
-      $pb.PbList<GroupUserList>();
   @$core.pragma('dart2js:noInline')
   static GroupUserList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GroupUserList>(create);
@@ -4064,8 +3976,6 @@ class ImportFacebookFriendsRequest extends $pb.GeneratedMessage {
       ImportFacebookFriendsRequest._();
   @$core.override
   ImportFacebookFriendsRequest createEmptyInstance() => create();
-  static $pb.PbList<ImportFacebookFriendsRequest> createRepeated() =>
-      $pb.PbList<ImportFacebookFriendsRequest>();
   @$core.pragma('dart2js:noInline')
   static ImportFacebookFriendsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ImportFacebookFriendsRequest>(create);
@@ -4142,8 +4052,6 @@ class ImportSteamFriendsRequest extends $pb.GeneratedMessage {
   static ImportSteamFriendsRequest create() => ImportSteamFriendsRequest._();
   @$core.override
   ImportSteamFriendsRequest createEmptyInstance() => create();
-  static $pb.PbList<ImportSteamFriendsRequest> createRepeated() =>
-      $pb.PbList<ImportSteamFriendsRequest>();
   @$core.pragma('dart2js:noInline')
   static ImportSteamFriendsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ImportSteamFriendsRequest>(create);
@@ -4214,8 +4122,6 @@ class JoinGroupRequest extends $pb.GeneratedMessage {
   static JoinGroupRequest create() => JoinGroupRequest._();
   @$core.override
   JoinGroupRequest createEmptyInstance() => create();
-  static $pb.PbList<JoinGroupRequest> createRepeated() =>
-      $pb.PbList<JoinGroupRequest>();
   @$core.pragma('dart2js:noInline')
   static JoinGroupRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<JoinGroupRequest>(create);
@@ -4273,8 +4179,6 @@ class JoinTournamentRequest extends $pb.GeneratedMessage {
   static JoinTournamentRequest create() => JoinTournamentRequest._();
   @$core.override
   JoinTournamentRequest createEmptyInstance() => create();
-  static $pb.PbList<JoinTournamentRequest> createRepeated() =>
-      $pb.PbList<JoinTournamentRequest>();
   @$core.pragma('dart2js:noInline')
   static JoinTournamentRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<JoinTournamentRequest>(create);
@@ -4335,8 +4239,6 @@ class KickGroupUsersRequest extends $pb.GeneratedMessage {
   static KickGroupUsersRequest create() => KickGroupUsersRequest._();
   @$core.override
   KickGroupUsersRequest createEmptyInstance() => create();
-  static $pb.PbList<KickGroupUsersRequest> createRepeated() =>
-      $pb.PbList<KickGroupUsersRequest>();
   @$core.pragma('dart2js:noInline')
   static KickGroupUsersRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<KickGroupUsersRequest>(create);
@@ -4420,7 +4322,6 @@ class Leaderboard extends $pb.GeneratedMessage {
   static Leaderboard create() => Leaderboard._();
   @$core.override
   Leaderboard createEmptyInstance() => create();
-  static $pb.PbList<Leaderboard> createRepeated() => $pb.PbList<Leaderboard>();
   @$core.pragma('dart2js:noInline')
   static Leaderboard getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<Leaderboard>(create);
@@ -4553,8 +4454,6 @@ class LeaderboardList extends $pb.GeneratedMessage {
   static LeaderboardList create() => LeaderboardList._();
   @$core.override
   LeaderboardList createEmptyInstance() => create();
-  static $pb.PbList<LeaderboardList> createRepeated() =>
-      $pb.PbList<LeaderboardList>();
   @$core.pragma('dart2js:noInline')
   static LeaderboardList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<LeaderboardList>(create);
@@ -4653,8 +4552,6 @@ class LeaderboardRecord extends $pb.GeneratedMessage {
   static LeaderboardRecord create() => LeaderboardRecord._();
   @$core.override
   LeaderboardRecord createEmptyInstance() => create();
-  static $pb.PbList<LeaderboardRecord> createRepeated() =>
-      $pb.PbList<LeaderboardRecord>();
   @$core.pragma('dart2js:noInline')
   static LeaderboardRecord getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<LeaderboardRecord>(create);
@@ -4844,8 +4741,6 @@ class LeaderboardRecordList extends $pb.GeneratedMessage {
   static LeaderboardRecordList create() => LeaderboardRecordList._();
   @$core.override
   LeaderboardRecordList createEmptyInstance() => create();
-  static $pb.PbList<LeaderboardRecordList> createRepeated() =>
-      $pb.PbList<LeaderboardRecordList>();
   @$core.pragma('dart2js:noInline')
   static LeaderboardRecordList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<LeaderboardRecordList>(create);
@@ -4930,8 +4825,6 @@ class LeaveGroupRequest extends $pb.GeneratedMessage {
   static LeaveGroupRequest create() => LeaveGroupRequest._();
   @$core.override
   LeaveGroupRequest createEmptyInstance() => create();
-  static $pb.PbList<LeaveGroupRequest> createRepeated() =>
-      $pb.PbList<LeaveGroupRequest>();
   @$core.pragma('dart2js:noInline')
   static LeaveGroupRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<LeaveGroupRequest>(create);
@@ -4993,8 +4886,6 @@ class LinkFacebookRequest extends $pb.GeneratedMessage {
   static LinkFacebookRequest create() => LinkFacebookRequest._();
   @$core.override
   LinkFacebookRequest createEmptyInstance() => create();
-  static $pb.PbList<LinkFacebookRequest> createRepeated() =>
-      $pb.PbList<LinkFacebookRequest>();
   @$core.pragma('dart2js:noInline')
   static LinkFacebookRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<LinkFacebookRequest>(create);
@@ -5070,8 +4961,6 @@ class LinkSteamRequest extends $pb.GeneratedMessage {
   static LinkSteamRequest create() => LinkSteamRequest._();
   @$core.override
   LinkSteamRequest createEmptyInstance() => create();
-  static $pb.PbList<LinkSteamRequest> createRepeated() =>
-      $pb.PbList<LinkSteamRequest>();
   @$core.pragma('dart2js:noInline')
   static LinkSteamRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<LinkSteamRequest>(create);
@@ -5155,8 +5044,6 @@ class ListChannelMessagesRequest extends $pb.GeneratedMessage {
   static ListChannelMessagesRequest create() => ListChannelMessagesRequest._();
   @$core.override
   ListChannelMessagesRequest createEmptyInstance() => create();
-  static $pb.PbList<ListChannelMessagesRequest> createRepeated() =>
-      $pb.PbList<ListChannelMessagesRequest>();
   @$core.pragma('dart2js:noInline')
   static ListChannelMessagesRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListChannelMessagesRequest>(create);
@@ -5255,8 +5142,6 @@ class ListFriendsRequest extends $pb.GeneratedMessage {
   static ListFriendsRequest create() => ListFriendsRequest._();
   @$core.override
   ListFriendsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListFriendsRequest> createRepeated() =>
-      $pb.PbList<ListFriendsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListFriendsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListFriendsRequest>(create);
@@ -5343,8 +5228,6 @@ class ListFriendsOfFriendsRequest extends $pb.GeneratedMessage {
       ListFriendsOfFriendsRequest._();
   @$core.override
   ListFriendsOfFriendsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListFriendsOfFriendsRequest> createRepeated() =>
-      $pb.PbList<ListFriendsOfFriendsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListFriendsOfFriendsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListFriendsOfFriendsRequest>(create);
@@ -5431,8 +5314,6 @@ class ListGroupsRequest extends $pb.GeneratedMessage {
   static ListGroupsRequest create() => ListGroupsRequest._();
   @$core.override
   ListGroupsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListGroupsRequest> createRepeated() =>
-      $pb.PbList<ListGroupsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListGroupsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListGroupsRequest>(create);
@@ -5557,8 +5438,6 @@ class ListGroupUsersRequest extends $pb.GeneratedMessage {
   static ListGroupUsersRequest create() => ListGroupUsersRequest._();
   @$core.override
   ListGroupUsersRequest createEmptyInstance() => create();
-  static $pb.PbList<ListGroupUsersRequest> createRepeated() =>
-      $pb.PbList<ListGroupUsersRequest>();
   @$core.pragma('dart2js:noInline')
   static ListGroupUsersRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListGroupUsersRequest>(create);
@@ -5667,9 +5546,6 @@ class ListLeaderboardRecordsAroundOwnerRequest extends $pb.GeneratedMessage {
       ListLeaderboardRecordsAroundOwnerRequest._();
   @$core.override
   ListLeaderboardRecordsAroundOwnerRequest createEmptyInstance() => create();
-  static $pb.PbList<ListLeaderboardRecordsAroundOwnerRequest>
-      createRepeated() =>
-          $pb.PbList<ListLeaderboardRecordsAroundOwnerRequest>();
   @$core.pragma('dart2js:noInline')
   static ListLeaderboardRecordsAroundOwnerRequest getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
@@ -5788,8 +5664,6 @@ class ListLeaderboardRecordsRequest extends $pb.GeneratedMessage {
       ListLeaderboardRecordsRequest._();
   @$core.override
   ListLeaderboardRecordsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListLeaderboardRecordsRequest> createRepeated() =>
-      $pb.PbList<ListLeaderboardRecordsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListLeaderboardRecordsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListLeaderboardRecordsRequest>(create);
@@ -5905,8 +5779,6 @@ class ListMatchesRequest extends $pb.GeneratedMessage {
   static ListMatchesRequest create() => ListMatchesRequest._();
   @$core.override
   ListMatchesRequest createEmptyInstance() => create();
-  static $pb.PbList<ListMatchesRequest> createRepeated() =>
-      $pb.PbList<ListMatchesRequest>();
   @$core.pragma('dart2js:noInline')
   static ListMatchesRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListMatchesRequest>(create);
@@ -6030,8 +5902,6 @@ class ListNotificationsRequest extends $pb.GeneratedMessage {
   static ListNotificationsRequest create() => ListNotificationsRequest._();
   @$core.override
   ListNotificationsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListNotificationsRequest> createRepeated() =>
-      $pb.PbList<ListNotificationsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListNotificationsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListNotificationsRequest>(create);
@@ -6111,8 +5981,6 @@ class ListStorageObjectsRequest extends $pb.GeneratedMessage {
   static ListStorageObjectsRequest create() => ListStorageObjectsRequest._();
   @$core.override
   ListStorageObjectsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListStorageObjectsRequest> createRepeated() =>
-      $pb.PbList<ListStorageObjectsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListStorageObjectsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListStorageObjectsRequest>(create);
@@ -6206,8 +6074,6 @@ class ListSubscriptionsRequest extends $pb.GeneratedMessage {
   static ListSubscriptionsRequest create() => ListSubscriptionsRequest._();
   @$core.override
   ListSubscriptionsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListSubscriptionsRequest> createRepeated() =>
-      $pb.PbList<ListSubscriptionsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListSubscriptionsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListSubscriptionsRequest>(create);
@@ -6294,8 +6160,6 @@ class ListTournamentRecordsAroundOwnerRequest extends $pb.GeneratedMessage {
       ListTournamentRecordsAroundOwnerRequest._();
   @$core.override
   ListTournamentRecordsAroundOwnerRequest createEmptyInstance() => create();
-  static $pb.PbList<ListTournamentRecordsAroundOwnerRequest> createRepeated() =>
-      $pb.PbList<ListTournamentRecordsAroundOwnerRequest>();
   @$core.pragma('dart2js:noInline')
   static ListTournamentRecordsAroundOwnerRequest getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
@@ -6414,8 +6278,6 @@ class ListTournamentRecordsRequest extends $pb.GeneratedMessage {
       ListTournamentRecordsRequest._();
   @$core.override
   ListTournamentRecordsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListTournamentRecordsRequest> createRepeated() =>
-      $pb.PbList<ListTournamentRecordsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListTournamentRecordsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListTournamentRecordsRequest>(create);
@@ -6531,8 +6393,6 @@ class ListTournamentsRequest extends $pb.GeneratedMessage {
   static ListTournamentsRequest create() => ListTournamentsRequest._();
   @$core.override
   ListTournamentsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListTournamentsRequest> createRepeated() =>
-      $pb.PbList<ListTournamentsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListTournamentsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListTournamentsRequest>(create);
@@ -6661,8 +6521,6 @@ class ListUserGroupsRequest extends $pb.GeneratedMessage {
   static ListUserGroupsRequest create() => ListUserGroupsRequest._();
   @$core.override
   ListUserGroupsRequest createEmptyInstance() => create();
-  static $pb.PbList<ListUserGroupsRequest> createRepeated() =>
-      $pb.PbList<ListUserGroupsRequest>();
   @$core.pragma('dart2js:noInline')
   static ListUserGroupsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListUserGroupsRequest>(create);
@@ -6768,7 +6626,6 @@ class Match extends $pb.GeneratedMessage {
   static Match create() => Match._();
   @$core.override
   Match createEmptyInstance() => create();
-  static $pb.PbList<Match> createRepeated() => $pb.PbList<Match>();
   @$core.pragma('dart2js:noInline')
   static Match getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Match>(create);
@@ -6876,7 +6733,6 @@ class MatchList extends $pb.GeneratedMessage {
   static MatchList create() => MatchList._();
   @$core.override
   MatchList createEmptyInstance() => create();
-  static $pb.PbList<MatchList> createRepeated() => $pb.PbList<MatchList>();
   @$core.pragma('dart2js:noInline')
   static MatchList getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MatchList>(create);
@@ -6933,8 +6789,6 @@ class MatchmakerCompletionStats extends $pb.GeneratedMessage {
   static MatchmakerCompletionStats create() => MatchmakerCompletionStats._();
   @$core.override
   MatchmakerCompletionStats createEmptyInstance() => create();
-  static $pb.PbList<MatchmakerCompletionStats> createRepeated() =>
-      $pb.PbList<MatchmakerCompletionStats>();
   @$core.pragma('dart2js:noInline')
   static MatchmakerCompletionStats getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchmakerCompletionStats>(create);
@@ -7012,8 +6866,6 @@ class MatchmakerStats extends $pb.GeneratedMessage {
   static MatchmakerStats create() => MatchmakerStats._();
   @$core.override
   MatchmakerStats createEmptyInstance() => create();
-  static $pb.PbList<MatchmakerStats> createRepeated() =>
-      $pb.PbList<MatchmakerStats>();
   @$core.pragma('dart2js:noInline')
   static MatchmakerStats getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchmakerStats>(create);
@@ -7102,8 +6954,6 @@ class Notification extends $pb.GeneratedMessage {
   static Notification create() => Notification._();
   @$core.override
   Notification createEmptyInstance() => create();
-  static $pb.PbList<Notification> createRepeated() =>
-      $pb.PbList<Notification>();
   @$core.pragma('dart2js:noInline')
   static Notification getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<Notification>(create);
@@ -7226,8 +7076,6 @@ class NotificationList extends $pb.GeneratedMessage {
   static NotificationList create() => NotificationList._();
   @$core.override
   NotificationList createEmptyInstance() => create();
-  static $pb.PbList<NotificationList> createRepeated() =>
-      $pb.PbList<NotificationList>();
   @$core.pragma('dart2js:noInline')
   static NotificationList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<NotificationList>(create);
@@ -7292,8 +7140,6 @@ class PromoteGroupUsersRequest extends $pb.GeneratedMessage {
   static PromoteGroupUsersRequest create() => PromoteGroupUsersRequest._();
   @$core.override
   PromoteGroupUsersRequest createEmptyInstance() => create();
-  static $pb.PbList<PromoteGroupUsersRequest> createRepeated() =>
-      $pb.PbList<PromoteGroupUsersRequest>();
   @$core.pragma('dart2js:noInline')
   static PromoteGroupUsersRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PromoteGroupUsersRequest>(create);
@@ -7358,8 +7204,6 @@ class DemoteGroupUsersRequest extends $pb.GeneratedMessage {
   static DemoteGroupUsersRequest create() => DemoteGroupUsersRequest._();
   @$core.override
   DemoteGroupUsersRequest createEmptyInstance() => create();
-  static $pb.PbList<DemoteGroupUsersRequest> createRepeated() =>
-      $pb.PbList<DemoteGroupUsersRequest>();
   @$core.pragma('dart2js:noInline')
   static DemoteGroupUsersRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DemoteGroupUsersRequest>(create);
@@ -7426,8 +7270,6 @@ class ReadStorageObjectId extends $pb.GeneratedMessage {
   static ReadStorageObjectId create() => ReadStorageObjectId._();
   @$core.override
   ReadStorageObjectId createEmptyInstance() => create();
-  static $pb.PbList<ReadStorageObjectId> createRepeated() =>
-      $pb.PbList<ReadStorageObjectId>();
   @$core.pragma('dart2js:noInline')
   static ReadStorageObjectId getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ReadStorageObjectId>(create);
@@ -7506,8 +7348,6 @@ class ReadStorageObjectsRequest extends $pb.GeneratedMessage {
   static ReadStorageObjectsRequest create() => ReadStorageObjectsRequest._();
   @$core.override
   ReadStorageObjectsRequest createEmptyInstance() => create();
-  static $pb.PbList<ReadStorageObjectsRequest> createRepeated() =>
-      $pb.PbList<ReadStorageObjectsRequest>();
   @$core.pragma('dart2js:noInline')
   static ReadStorageObjectsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ReadStorageObjectsRequest>(create);
@@ -7563,7 +7403,6 @@ class Rpc extends $pb.GeneratedMessage {
   static Rpc create() => Rpc._();
   @$core.override
   Rpc createEmptyInstance() => create();
-  static $pb.PbList<Rpc> createRepeated() => $pb.PbList<Rpc>();
   @$core.pragma('dart2js:noInline')
   static Rpc getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Rpc>(create);
@@ -7645,7 +7484,6 @@ class Session extends $pb.GeneratedMessage {
   static Session create() => Session._();
   @$core.override
   Session createEmptyInstance() => create();
-  static $pb.PbList<Session> createRepeated() => $pb.PbList<Session>();
   @$core.pragma('dart2js:noInline')
   static Session getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Session>(create);
@@ -7748,8 +7586,6 @@ class StorageObject extends $pb.GeneratedMessage {
   static StorageObject create() => StorageObject._();
   @$core.override
   StorageObject createEmptyInstance() => create();
-  static $pb.PbList<StorageObject> createRepeated() =>
-      $pb.PbList<StorageObject>();
   @$core.pragma('dart2js:noInline')
   static StorageObject getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StorageObject>(create);
@@ -7907,8 +7743,6 @@ class StorageObjectAck extends $pb.GeneratedMessage {
   static StorageObjectAck create() => StorageObjectAck._();
   @$core.override
   StorageObjectAck createEmptyInstance() => create();
-  static $pb.PbList<StorageObjectAck> createRepeated() =>
-      $pb.PbList<StorageObjectAck>();
   @$core.pragma('dart2js:noInline')
   static StorageObjectAck getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StorageObjectAck>(create);
@@ -8020,8 +7854,6 @@ class StorageObjectAcks extends $pb.GeneratedMessage {
   static StorageObjectAcks create() => StorageObjectAcks._();
   @$core.override
   StorageObjectAcks createEmptyInstance() => create();
-  static $pb.PbList<StorageObjectAcks> createRepeated() =>
-      $pb.PbList<StorageObjectAcks>();
   @$core.pragma('dart2js:noInline')
   static StorageObjectAcks getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StorageObjectAcks>(create);
@@ -8073,8 +7905,6 @@ class StorageObjects extends $pb.GeneratedMessage {
   static StorageObjects create() => StorageObjects._();
   @$core.override
   StorageObjects createEmptyInstance() => create();
-  static $pb.PbList<StorageObjects> createRepeated() =>
-      $pb.PbList<StorageObjects>();
   @$core.pragma('dart2js:noInline')
   static StorageObjects getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StorageObjects>(create);
@@ -8129,8 +7959,6 @@ class StorageObjectList extends $pb.GeneratedMessage {
   static StorageObjectList create() => StorageObjectList._();
   @$core.override
   StorageObjectList createEmptyInstance() => create();
-  static $pb.PbList<StorageObjectList> createRepeated() =>
-      $pb.PbList<StorageObjectList>();
   @$core.pragma('dart2js:noInline')
   static StorageObjectList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StorageObjectList>(create);
@@ -8256,7 +8084,6 @@ class Tournament extends $pb.GeneratedMessage {
   static Tournament create() => Tournament._();
   @$core.override
   Tournament createEmptyInstance() => create();
-  static $pb.PbList<Tournament> createRepeated() => $pb.PbList<Tournament>();
   @$core.pragma('dart2js:noInline')
   static Tournament getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<Tournament>(create);
@@ -8523,8 +8350,6 @@ class TournamentList extends $pb.GeneratedMessage {
   static TournamentList create() => TournamentList._();
   @$core.override
   TournamentList createEmptyInstance() => create();
-  static $pb.PbList<TournamentList> createRepeated() =>
-      $pb.PbList<TournamentList>();
   @$core.pragma('dart2js:noInline')
   static TournamentList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<TournamentList>(create);
@@ -8599,8 +8424,6 @@ class TournamentRecordList extends $pb.GeneratedMessage {
   static TournamentRecordList create() => TournamentRecordList._();
   @$core.override
   TournamentRecordList createEmptyInstance() => create();
-  static $pb.PbList<TournamentRecordList> createRepeated() =>
-      $pb.PbList<TournamentRecordList>();
   @$core.pragma('dart2js:noInline')
   static TournamentRecordList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<TournamentRecordList>(create);
@@ -8706,8 +8529,6 @@ class UpdateAccountRequest extends $pb.GeneratedMessage {
   static UpdateAccountRequest create() => UpdateAccountRequest._();
   @$core.override
   UpdateAccountRequest createEmptyInstance() => create();
-  static $pb.PbList<UpdateAccountRequest> createRepeated() =>
-      $pb.PbList<UpdateAccountRequest>();
   @$core.pragma('dart2js:noInline')
   static UpdateAccountRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UpdateAccountRequest>(create);
@@ -8846,8 +8667,6 @@ class UpdateGroupRequest extends $pb.GeneratedMessage {
   static UpdateGroupRequest create() => UpdateGroupRequest._();
   @$core.override
   UpdateGroupRequest createEmptyInstance() => create();
-  static $pb.PbList<UpdateGroupRequest> createRepeated() =>
-      $pb.PbList<UpdateGroupRequest>();
   @$core.pragma('dart2js:noInline')
   static UpdateGroupRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UpdateGroupRequest>(create);
@@ -9017,7 +8836,6 @@ class User extends $pb.GeneratedMessage {
   static User create() => User._();
   @$core.override
   User createEmptyInstance() => create();
-  static $pb.PbList<User> createRepeated() => $pb.PbList<User>();
   @$core.pragma('dart2js:noInline')
   static User getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<User>(create);
@@ -9253,8 +9071,6 @@ class UserGroupList_UserGroup extends $pb.GeneratedMessage {
   static UserGroupList_UserGroup create() => UserGroupList_UserGroup._();
   @$core.override
   UserGroupList_UserGroup createEmptyInstance() => create();
-  static $pb.PbList<UserGroupList_UserGroup> createRepeated() =>
-      $pb.PbList<UserGroupList_UserGroup>();
   @$core.pragma('dart2js:noInline')
   static UserGroupList_UserGroup getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UserGroupList_UserGroup>(create);
@@ -9329,8 +9145,6 @@ class UserGroupList extends $pb.GeneratedMessage {
   static UserGroupList create() => UserGroupList._();
   @$core.override
   UserGroupList createEmptyInstance() => create();
-  static $pb.PbList<UserGroupList> createRepeated() =>
-      $pb.PbList<UserGroupList>();
   @$core.pragma('dart2js:noInline')
   static UserGroupList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UserGroupList>(create);
@@ -9390,7 +9204,6 @@ class Users extends $pb.GeneratedMessage {
   static Users create() => Users._();
   @$core.override
   Users createEmptyInstance() => create();
-  static $pb.PbList<Users> createRepeated() => $pb.PbList<Users>();
   @$core.pragma('dart2js:noInline')
   static Users getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Users>(create);
@@ -9448,8 +9261,6 @@ class ValidatePurchaseAppleRequest extends $pb.GeneratedMessage {
       ValidatePurchaseAppleRequest._();
   @$core.override
   ValidatePurchaseAppleRequest createEmptyInstance() => create();
-  static $pb.PbList<ValidatePurchaseAppleRequest> createRepeated() =>
-      $pb.PbList<ValidatePurchaseAppleRequest>();
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseAppleRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseAppleRequest>(create);
@@ -9526,8 +9337,6 @@ class ValidateSubscriptionAppleRequest extends $pb.GeneratedMessage {
       ValidateSubscriptionAppleRequest._();
   @$core.override
   ValidateSubscriptionAppleRequest createEmptyInstance() => create();
-  static $pb.PbList<ValidateSubscriptionAppleRequest> createRepeated() =>
-      $pb.PbList<ValidateSubscriptionAppleRequest>();
   @$core.pragma('dart2js:noInline')
   static ValidateSubscriptionAppleRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidateSubscriptionAppleRequest>(
@@ -9604,8 +9413,6 @@ class ValidatePurchaseGoogleRequest extends $pb.GeneratedMessage {
       ValidatePurchaseGoogleRequest._();
   @$core.override
   ValidatePurchaseGoogleRequest createEmptyInstance() => create();
-  static $pb.PbList<ValidatePurchaseGoogleRequest> createRepeated() =>
-      $pb.PbList<ValidatePurchaseGoogleRequest>();
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseGoogleRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseGoogleRequest>(create);
@@ -9682,8 +9489,6 @@ class ValidateSubscriptionGoogleRequest extends $pb.GeneratedMessage {
       ValidateSubscriptionGoogleRequest._();
   @$core.override
   ValidateSubscriptionGoogleRequest createEmptyInstance() => create();
-  static $pb.PbList<ValidateSubscriptionGoogleRequest> createRepeated() =>
-      $pb.PbList<ValidateSubscriptionGoogleRequest>();
   @$core.pragma('dart2js:noInline')
   static ValidateSubscriptionGoogleRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidateSubscriptionGoogleRequest>(
@@ -9763,8 +9568,6 @@ class ValidatePurchaseHuaweiRequest extends $pb.GeneratedMessage {
       ValidatePurchaseHuaweiRequest._();
   @$core.override
   ValidatePurchaseHuaweiRequest createEmptyInstance() => create();
-  static $pb.PbList<ValidatePurchaseHuaweiRequest> createRepeated() =>
-      $pb.PbList<ValidatePurchaseHuaweiRequest>();
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseHuaweiRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseHuaweiRequest>(create);
@@ -9851,8 +9654,6 @@ class ValidatePurchaseFacebookInstantRequest extends $pb.GeneratedMessage {
       ValidatePurchaseFacebookInstantRequest._();
   @$core.override
   ValidatePurchaseFacebookInstantRequest createEmptyInstance() => create();
-  static $pb.PbList<ValidatePurchaseFacebookInstantRequest> createRepeated() =>
-      $pb.PbList<ValidatePurchaseFacebookInstantRequest>();
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseFacebookInstantRequest getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
@@ -9870,6 +9671,81 @@ class ValidatePurchaseFacebookInstantRequest extends $pb.GeneratedMessage {
   void clearSignedRequest() => $_clearField(1);
 
   /// Persist the purchase
+  @$pb.TagNumber(2)
+  $1.BoolValue get persist => $_getN(1);
+  @$pb.TagNumber(2)
+  set persist($1.BoolValue value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasPersist() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearPersist() => $_clearField(2);
+  @$pb.TagNumber(2)
+  $1.BoolValue ensurePersist() => $_ensure(1);
+}
+
+/// Samsung IAP Purchase validation request.
+class ValidatePurchaseSamsungRequest extends $pb.GeneratedMessage {
+  factory ValidatePurchaseSamsungRequest({
+    $core.String? purchaseId,
+    $1.BoolValue? persist,
+  }) {
+    final result = create();
+    if (purchaseId != null) result.purchaseId = purchaseId;
+    if (persist != null) result.persist = persist;
+    return result;
+  }
+
+  ValidatePurchaseSamsungRequest._();
+
+  factory ValidatePurchaseSamsungRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory ValidatePurchaseSamsungRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ValidatePurchaseSamsungRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'nakama.api'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'purchaseId')
+    ..aOM<$1.BoolValue>(2, _omitFieldNames ? '' : 'persist',
+        subBuilder: $1.BoolValue.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatePurchaseSamsungRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  ValidatePurchaseSamsungRequest copyWith(
+          void Function(ValidatePurchaseSamsungRequest) updates) =>
+      super.copyWith(
+              (message) => updates(message as ValidatePurchaseSamsungRequest))
+          as ValidatePurchaseSamsungRequest;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ValidatePurchaseSamsungRequest create() =>
+      ValidatePurchaseSamsungRequest._();
+  @$core.override
+  ValidatePurchaseSamsungRequest createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static ValidatePurchaseSamsungRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseSamsungRequest>(create);
+  static ValidatePurchaseSamsungRequest? _defaultInstance;
+
+  /// The purchase ID returned by the Samsung IAP SDK PurchaseVo.
+  @$pb.TagNumber(1)
+  $core.String get purchaseId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set purchaseId($core.String value) => $_setString(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasPurchaseId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPurchaseId() => $_clearField(1);
+
+  /// Persist the purchase so that seenBefore can be computed to protect against replay attacks.
   @$pb.TagNumber(2)
   $1.BoolValue get persist => $_getN(1);
   @$pb.TagNumber(2)
@@ -9958,8 +9834,6 @@ class ValidatedPurchase extends $pb.GeneratedMessage {
   static ValidatedPurchase create() => ValidatedPurchase._();
   @$core.override
   ValidatedPurchase createEmptyInstance() => create();
-  static $pb.PbList<ValidatedPurchase> createRepeated() =>
-      $pb.PbList<ValidatedPurchase>();
   @$core.pragma('dart2js:noInline')
   static ValidatedPurchase getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidatedPurchase>(create);
@@ -10127,8 +10001,6 @@ class ValidatePurchaseResponse extends $pb.GeneratedMessage {
   static ValidatePurchaseResponse create() => ValidatePurchaseResponse._();
   @$core.override
   ValidatePurchaseResponse createEmptyInstance() => create();
-  static $pb.PbList<ValidatePurchaseResponse> createRepeated() =>
-      $pb.PbList<ValidatePurchaseResponse>();
   @$core.pragma('dart2js:noInline')
   static ValidatePurchaseResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidatePurchaseResponse>(create);
@@ -10185,8 +10057,6 @@ class ValidateSubscriptionResponse extends $pb.GeneratedMessage {
       ValidateSubscriptionResponse._();
   @$core.override
   ValidateSubscriptionResponse createEmptyInstance() => create();
-  static $pb.PbList<ValidateSubscriptionResponse> createRepeated() =>
-      $pb.PbList<ValidateSubscriptionResponse>();
   @$core.pragma('dart2js:noInline')
   static ValidateSubscriptionResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidateSubscriptionResponse>(create);
@@ -10290,8 +10160,6 @@ class ValidatedSubscription extends $pb.GeneratedMessage {
   static ValidatedSubscription create() => ValidatedSubscription._();
   @$core.override
   ValidatedSubscription createEmptyInstance() => create();
-  static $pb.PbList<ValidatedSubscription> createRepeated() =>
-      $pb.PbList<ValidatedSubscription>();
   @$core.pragma('dart2js:noInline')
   static ValidatedSubscription getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ValidatedSubscription>(create);
@@ -10486,8 +10354,6 @@ class PurchaseList extends $pb.GeneratedMessage {
   static PurchaseList create() => PurchaseList._();
   @$core.override
   PurchaseList createEmptyInstance() => create();
-  static $pb.PbList<PurchaseList> createRepeated() =>
-      $pb.PbList<PurchaseList>();
   @$core.pragma('dart2js:noInline')
   static PurchaseList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PurchaseList>(create);
@@ -10567,8 +10433,6 @@ class SubscriptionList extends $pb.GeneratedMessage {
   static SubscriptionList create() => SubscriptionList._();
   @$core.override
   SubscriptionList createEmptyInstance() => create();
-  static $pb.PbList<SubscriptionList> createRepeated() =>
-      $pb.PbList<SubscriptionList>();
   @$core.pragma('dart2js:noInline')
   static SubscriptionList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SubscriptionList>(create);
@@ -10659,9 +10523,6 @@ class WriteLeaderboardRecordRequest_LeaderboardRecordWrite
   @$core.override
   WriteLeaderboardRecordRequest_LeaderboardRecordWrite createEmptyInstance() =>
       create();
-  static $pb.PbList<WriteLeaderboardRecordRequest_LeaderboardRecordWrite>
-      createRepeated() =>
-          $pb.PbList<WriteLeaderboardRecordRequest_LeaderboardRecordWrite>();
   @$core.pragma('dart2js:noInline')
   static WriteLeaderboardRecordRequest_LeaderboardRecordWrite getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
@@ -10757,8 +10618,6 @@ class WriteLeaderboardRecordRequest extends $pb.GeneratedMessage {
       WriteLeaderboardRecordRequest._();
   @$core.override
   WriteLeaderboardRecordRequest createEmptyInstance() => create();
-  static $pb.PbList<WriteLeaderboardRecordRequest> createRepeated() =>
-      $pb.PbList<WriteLeaderboardRecordRequest>();
   @$core.pragma('dart2js:noInline')
   static WriteLeaderboardRecordRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<WriteLeaderboardRecordRequest>(create);
@@ -10846,8 +10705,6 @@ class WriteStorageObject extends $pb.GeneratedMessage {
   static WriteStorageObject create() => WriteStorageObject._();
   @$core.override
   WriteStorageObject createEmptyInstance() => create();
-  static $pb.PbList<WriteStorageObject> createRepeated() =>
-      $pb.PbList<WriteStorageObject>();
   @$core.pragma('dart2js:noInline')
   static WriteStorageObject getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<WriteStorageObject>(create);
@@ -10961,8 +10818,6 @@ class WriteStorageObjectsRequest extends $pb.GeneratedMessage {
   static WriteStorageObjectsRequest create() => WriteStorageObjectsRequest._();
   @$core.override
   WriteStorageObjectsRequest createEmptyInstance() => create();
-  static $pb.PbList<WriteStorageObjectsRequest> createRepeated() =>
-      $pb.PbList<WriteStorageObjectsRequest>();
   @$core.pragma('dart2js:noInline')
   static WriteStorageObjectsRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<WriteStorageObjectsRequest>(create);
@@ -11033,9 +10888,6 @@ class WriteTournamentRecordRequest_TournamentRecordWrite
   @$core.override
   WriteTournamentRecordRequest_TournamentRecordWrite createEmptyInstance() =>
       create();
-  static $pb.PbList<WriteTournamentRecordRequest_TournamentRecordWrite>
-      createRepeated() =>
-          $pb.PbList<WriteTournamentRecordRequest_TournamentRecordWrite>();
   @$core.pragma('dart2js:noInline')
   static WriteTournamentRecordRequest_TournamentRecordWrite getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
@@ -11131,8 +10983,6 @@ class WriteTournamentRecordRequest extends $pb.GeneratedMessage {
       WriteTournamentRecordRequest._();
   @$core.override
   WriteTournamentRecordRequest createEmptyInstance() => create();
-  static $pb.PbList<WriteTournamentRecordRequest> createRepeated() =>
-      $pb.PbList<WriteTournamentRecordRequest>();
   @$core.pragma('dart2js:noInline')
   static WriteTournamentRecordRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<WriteTournamentRecordRequest>(create);
@@ -11216,8 +11066,6 @@ class ListPartiesRequest extends $pb.GeneratedMessage {
   static ListPartiesRequest create() => ListPartiesRequest._();
   @$core.override
   ListPartiesRequest createEmptyInstance() => create();
-  static $pb.PbList<ListPartiesRequest> createRepeated() =>
-      $pb.PbList<ListPartiesRequest>();
   @$core.pragma('dart2js:noInline')
   static ListPartiesRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ListPartiesRequest>(create);
@@ -11323,7 +11171,6 @@ class Party extends $pb.GeneratedMessage {
   static Party create() => Party._();
   @$core.override
   Party createEmptyInstance() => create();
-  static $pb.PbList<Party> createRepeated() => $pb.PbList<Party>();
   @$core.pragma('dart2js:noInline')
   static Party getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Party>(create);
@@ -11422,7 +11269,6 @@ class PartyList extends $pb.GeneratedMessage {
   static PartyList create() => PartyList._();
   @$core.override
   PartyList createEmptyInstance() => create();
-  static $pb.PbList<PartyList> createRepeated() => $pb.PbList<PartyList>();
   @$core.pragma('dart2js:noInline')
   static PartyList getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PartyList>(create);

--- a/nakama/lib/src/api/proto/api/api.pb.dart
+++ b/nakama/lib/src/api/proto/api/api.pb.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/api/api.pbenum.dart
+++ b/nakama/lib/src/api/proto/api/api.pbenum.dart
@@ -33,15 +33,20 @@ class StoreProvider extends $pb.ProtobufEnum {
   static const StoreProvider FACEBOOK_INSTANT_STORE =
       StoreProvider._(3, _omitEnumNames ? '' : 'FACEBOOK_INSTANT_STORE');
 
+  /// Samsung Galaxy Store
+  static const StoreProvider SAMSUNG_GALAXY_STORE =
+      StoreProvider._(4, _omitEnumNames ? '' : 'SAMSUNG_GALAXY_STORE');
+
   static const $core.List<StoreProvider> values = <StoreProvider>[
     APPLE_APP_STORE,
     GOOGLE_PLAY_STORE,
     HUAWEI_APP_GALLERY,
     FACEBOOK_INSTANT_STORE,
+    SAMSUNG_GALAXY_STORE,
   ];
 
   static final $core.List<StoreProvider?> _byValue =
-      $pb.ProtobufEnum.$_initByValueList(values, 3);
+      $pb.ProtobufEnum.$_initByValueList(values, 4);
   static StoreProvider? valueOf($core.int value) =>
       value < 0 || value >= _byValue.length ? null : _byValue[value];
 

--- a/nakama/lib/src/api/proto/api/api.pbenum.dart
+++ b/nakama/lib/src/api/proto/api/api.pbenum.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/api/api.pbjson.dart
+++ b/nakama/lib/src/api/proto/api/api.pbjson.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/api/api.pbjson.dart
+++ b/nakama/lib/src/api/proto/api/api.pbjson.dart
@@ -23,13 +23,15 @@ const StoreProvider$json = {
     {'1': 'GOOGLE_PLAY_STORE', '2': 1},
     {'1': 'HUAWEI_APP_GALLERY', '2': 2},
     {'1': 'FACEBOOK_INSTANT_STORE', '2': 3},
+    {'1': 'SAMSUNG_GALAXY_STORE', '2': 4},
   ],
 };
 
 /// Descriptor for `StoreProvider`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List storeProviderDescriptor = $convert.base64Decode(
     'Cg1TdG9yZVByb3ZpZGVyEhMKD0FQUExFX0FQUF9TVE9SRRAAEhUKEUdPT0dMRV9QTEFZX1NUT1'
-    'JFEAESFgoSSFVBV0VJX0FQUF9HQUxMRVJZEAISGgoWRkFDRUJPT0tfSU5TVEFOVF9TVE9SRRAD');
+    'JFEAESFgoSSFVBV0VJX0FQUF9HQUxMRVJZEAISGgoWRkFDRUJPT0tfSU5TVEFOVF9TVE9SRRAD'
+    'EhgKFFNBTVNVTkdfR0FMQVhZX1NUT1JFEAQ=');
 
 @$core.Deprecated('Use storeEnvironmentDescriptor instead')
 const StoreEnvironment$json = {
@@ -3153,6 +3155,29 @@ final $typed_data.Uint8List validatePurchaseFacebookInstantRequestDescriptor =
         'CiZWYWxpZGF0ZVB1cmNoYXNlRmFjZWJvb2tJbnN0YW50UmVxdWVzdBIlCg5zaWduZWRfcmVxdW'
         'VzdBgBIAEoCVINc2lnbmVkUmVxdWVzdBI0CgdwZXJzaXN0GAIgASgLMhouZ29vZ2xlLnByb3Rv'
         'YnVmLkJvb2xWYWx1ZVIHcGVyc2lzdA==');
+
+@$core.Deprecated('Use validatePurchaseSamsungRequestDescriptor instead')
+const ValidatePurchaseSamsungRequest$json = {
+  '1': 'ValidatePurchaseSamsungRequest',
+  '2': [
+    {'1': 'purchase_id', '3': 1, '4': 1, '5': 9, '10': 'purchaseId'},
+    {
+      '1': 'persist',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.BoolValue',
+      '10': 'persist'
+    },
+  ],
+};
+
+/// Descriptor for `ValidatePurchaseSamsungRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List validatePurchaseSamsungRequestDescriptor =
+    $convert.base64Decode(
+        'Ch5WYWxpZGF0ZVB1cmNoYXNlU2Ftc3VuZ1JlcXVlc3QSHwoLcHVyY2hhc2VfaWQYASABKAlSCn'
+        'B1cmNoYXNlSWQSNAoHcGVyc2lzdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5Cb29sVmFsdWVS'
+        'B3BlcnNpc3Q=');
 
 @$core.Deprecated('Use validatedPurchaseDescriptor instead')
 const ValidatedPurchase$json = {

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pb.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pb.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pbenum.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pbenum.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pbgrpc.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pbgrpc.dart
@@ -703,6 +703,15 @@ class NakamaClient extends $grpc.Client {
         options: options);
   }
 
+  /// Validate Samsung Galaxy Store IAP Receipt
+  $grpc.ResponseFuture<$0.ValidatePurchaseResponse> validatePurchaseSamsung(
+    $0.ValidatePurchaseSamsungRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$validatePurchaseSamsung, request,
+        options: options);
+  }
+
   /// Write a record to a leaderboard.
   $grpc.ResponseFuture<$0.LeaderboardRecord> writeLeaderboardRecord(
     $0.WriteLeaderboardRecordRequest request, {
@@ -1122,6 +1131,11 @@ class NakamaClient extends $grpc.Client {
       '/nakama.api.Nakama/ValidatePurchaseFacebookInstant',
       ($0.ValidatePurchaseFacebookInstantRequest value) =>
           value.writeToBuffer(),
+      $0.ValidatePurchaseResponse.fromBuffer);
+  static final _$validatePurchaseSamsung = $grpc.ClientMethod<
+          $0.ValidatePurchaseSamsungRequest, $0.ValidatePurchaseResponse>(
+      '/nakama.api.Nakama/ValidatePurchaseSamsung',
+      ($0.ValidatePurchaseSamsungRequest value) => value.writeToBuffer(),
       $0.ValidatePurchaseResponse.fromBuffer);
   static final _$writeLeaderboardRecord = $grpc.ClientMethod<
           $0.WriteLeaderboardRecordRequest, $0.LeaderboardRecord>(
@@ -1786,6 +1800,15 @@ abstract class NakamaServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) =>
             $0.ValidatePurchaseFacebookInstantRequest.fromBuffer(value),
+        ($0.ValidatePurchaseResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ValidatePurchaseSamsungRequest,
+            $0.ValidatePurchaseResponse>(
+        'ValidatePurchaseSamsung',
+        validatePurchaseSamsung_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) =>
+            $0.ValidatePurchaseSamsungRequest.fromBuffer(value),
         ($0.ValidatePurchaseResponse value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.WriteLeaderboardRecordRequest,
             $0.LeaderboardRecord>(
@@ -2486,6 +2509,15 @@ abstract class NakamaServiceBase extends $grpc.Service {
   $async.Future<$0.ValidatePurchaseResponse> validatePurchaseFacebookInstant(
       $grpc.ServiceCall call,
       $0.ValidatePurchaseFacebookInstantRequest request);
+
+  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseSamsung_Pre(
+      $grpc.ServiceCall $call,
+      $async.Future<$0.ValidatePurchaseSamsungRequest> $request) async {
+    return validatePurchaseSamsung($call, await $request);
+  }
+
+  $async.Future<$0.ValidatePurchaseResponse> validatePurchaseSamsung(
+      $grpc.ServiceCall call, $0.ValidatePurchaseSamsungRequest request);
 
   $async.Future<$0.LeaderboardRecord> writeLeaderboardRecord_Pre(
       $grpc.ServiceCall $call,

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pbgrpc.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pbgrpc.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/apigrpc/apigrpc.pbjson.dart
+++ b/nakama/lib/src/api/proto/apigrpc/apigrpc.pbjson.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/empty.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/empty.pb.dart
@@ -56,7 +56,6 @@ class Empty extends $pb.GeneratedMessage {
   static Empty create() => Empty._();
   @$core.override
   Empty createEmptyInstance() => create();
-  static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
   static Empty getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);

--- a/nakama/lib/src/api/proto/google/protobuf/empty.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/empty.pb.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/empty.pbenum.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/empty.pbenum.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/empty.pbjson.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/empty.pbjson.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/timestamp.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/timestamp.pb.dart
@@ -152,7 +152,6 @@ class Timestamp extends $pb.GeneratedMessage with $mixin.TimestampMixin {
   static Timestamp create() => Timestamp._();
   @$core.override
   Timestamp createEmptyInstance() => create();
-  static $pb.PbList<Timestamp> createRepeated() => $pb.PbList<Timestamp>();
   @$core.pragma('dart2js:noInline')
   static Timestamp getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Timestamp>(create);

--- a/nakama/lib/src/api/proto/google/protobuf/timestamp.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/timestamp.pb.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/timestamp.pbenum.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/timestamp.pbenum.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/timestamp.pbjson.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/timestamp.pbjson.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/wrappers.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/wrappers.pb.dart
@@ -67,7 +67,6 @@ class DoubleValue extends $pb.GeneratedMessage with $mixin.DoubleValueMixin {
   static DoubleValue create() => DoubleValue._();
   @$core.override
   DoubleValue createEmptyInstance() => create();
-  static $pb.PbList<DoubleValue> createRepeated() => $pb.PbList<DoubleValue>();
   @$core.pragma('dart2js:noInline')
   static DoubleValue getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DoubleValue>(create);
@@ -130,7 +129,6 @@ class FloatValue extends $pb.GeneratedMessage with $mixin.FloatValueMixin {
   static FloatValue create() => FloatValue._();
   @$core.override
   FloatValue createEmptyInstance() => create();
-  static $pb.PbList<FloatValue> createRepeated() => $pb.PbList<FloatValue>();
   @$core.pragma('dart2js:noInline')
   static FloatValue getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FloatValue>(create);
@@ -193,7 +191,6 @@ class Int64Value extends $pb.GeneratedMessage with $mixin.Int64ValueMixin {
   static Int64Value create() => Int64Value._();
   @$core.override
   Int64Value createEmptyInstance() => create();
-  static $pb.PbList<Int64Value> createRepeated() => $pb.PbList<Int64Value>();
   @$core.pragma('dart2js:noInline')
   static Int64Value getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<Int64Value>(create);
@@ -258,7 +255,6 @@ class UInt64Value extends $pb.GeneratedMessage with $mixin.UInt64ValueMixin {
   static UInt64Value create() => UInt64Value._();
   @$core.override
   UInt64Value createEmptyInstance() => create();
-  static $pb.PbList<UInt64Value> createRepeated() => $pb.PbList<UInt64Value>();
   @$core.pragma('dart2js:noInline')
   static UInt64Value getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UInt64Value>(create);
@@ -321,7 +317,6 @@ class Int32Value extends $pb.GeneratedMessage with $mixin.Int32ValueMixin {
   static Int32Value create() => Int32Value._();
   @$core.override
   Int32Value createEmptyInstance() => create();
-  static $pb.PbList<Int32Value> createRepeated() => $pb.PbList<Int32Value>();
   @$core.pragma('dart2js:noInline')
   static Int32Value getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<Int32Value>(create);
@@ -385,7 +380,6 @@ class UInt32Value extends $pb.GeneratedMessage with $mixin.UInt32ValueMixin {
   static UInt32Value create() => UInt32Value._();
   @$core.override
   UInt32Value createEmptyInstance() => create();
-  static $pb.PbList<UInt32Value> createRepeated() => $pb.PbList<UInt32Value>();
   @$core.pragma('dart2js:noInline')
   static UInt32Value getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UInt32Value>(create);
@@ -448,7 +442,6 @@ class BoolValue extends $pb.GeneratedMessage with $mixin.BoolValueMixin {
   static BoolValue create() => BoolValue._();
   @$core.override
   BoolValue createEmptyInstance() => create();
-  static $pb.PbList<BoolValue> createRepeated() => $pb.PbList<BoolValue>();
   @$core.pragma('dart2js:noInline')
   static BoolValue getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BoolValue>(create);
@@ -512,7 +505,6 @@ class StringValue extends $pb.GeneratedMessage with $mixin.StringValueMixin {
   static StringValue create() => StringValue._();
   @$core.override
   StringValue createEmptyInstance() => create();
-  static $pb.PbList<StringValue> createRepeated() => $pb.PbList<StringValue>();
   @$core.pragma('dart2js:noInline')
   static StringValue getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StringValue>(create);
@@ -576,7 +568,6 @@ class BytesValue extends $pb.GeneratedMessage with $mixin.BytesValueMixin {
   static BytesValue create() => BytesValue._();
   @$core.override
   BytesValue createEmptyInstance() => create();
-  static $pb.PbList<BytesValue> createRepeated() => $pb.PbList<BytesValue>();
   @$core.pragma('dart2js:noInline')
   static BytesValue getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<BytesValue>(create);

--- a/nakama/lib/src/api/proto/google/protobuf/wrappers.pb.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/wrappers.pb.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/wrappers.pbenum.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/wrappers.pbenum.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/google/protobuf/wrappers.pbjson.dart
+++ b/nakama/lib/src/api/proto/google/protobuf/wrappers.pbjson.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/rtapi/realtime.pb.dart
+++ b/nakama/lib/src/api/proto/rtapi/realtime.pb.dart
@@ -435,7 +435,6 @@ class Envelope extends $pb.GeneratedMessage {
   static Envelope create() => Envelope._();
   @$core.override
   Envelope createEmptyInstance() => create();
-  static $pb.PbList<Envelope> createRepeated() => $pb.PbList<Envelope>();
   @$core.pragma('dart2js:noInline')
   static Envelope getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Envelope>(create);
@@ -1216,7 +1215,6 @@ class Channel extends $pb.GeneratedMessage {
   static Channel create() => Channel._();
   @$core.override
   Channel createEmptyInstance() => create();
-  static $pb.PbList<Channel> createRepeated() => $pb.PbList<Channel>();
   @$core.pragma('dart2js:noInline')
   static Channel getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Channel>(create);
@@ -1341,7 +1339,6 @@ class ChannelJoin extends $pb.GeneratedMessage {
   static ChannelJoin create() => ChannelJoin._();
   @$core.override
   ChannelJoin createEmptyInstance() => create();
-  static $pb.PbList<ChannelJoin> createRepeated() => $pb.PbList<ChannelJoin>();
   @$core.pragma('dart2js:noInline')
   static ChannelJoin getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelJoin>(create);
@@ -1433,8 +1430,6 @@ class ChannelLeave extends $pb.GeneratedMessage {
   static ChannelLeave create() => ChannelLeave._();
   @$core.override
   ChannelLeave createEmptyInstance() => create();
-  static $pb.PbList<ChannelLeave> createRepeated() =>
-      $pb.PbList<ChannelLeave>();
   @$core.pragma('dart2js:noInline')
   static ChannelLeave getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelLeave>(create);
@@ -1526,8 +1521,6 @@ class ChannelMessageAck extends $pb.GeneratedMessage {
   static ChannelMessageAck create() => ChannelMessageAck._();
   @$core.override
   ChannelMessageAck createEmptyInstance() => create();
-  static $pb.PbList<ChannelMessageAck> createRepeated() =>
-      $pb.PbList<ChannelMessageAck>();
   @$core.pragma('dart2js:noInline')
   static ChannelMessageAck getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageAck>(create);
@@ -1696,8 +1689,6 @@ class ChannelMessageSend extends $pb.GeneratedMessage {
   static ChannelMessageSend create() => ChannelMessageSend._();
   @$core.override
   ChannelMessageSend createEmptyInstance() => create();
-  static $pb.PbList<ChannelMessageSend> createRepeated() =>
-      $pb.PbList<ChannelMessageSend>();
   @$core.pragma('dart2js:noInline')
   static ChannelMessageSend getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageSend>(create);
@@ -1771,8 +1762,6 @@ class ChannelMessageUpdate extends $pb.GeneratedMessage {
   static ChannelMessageUpdate create() => ChannelMessageUpdate._();
   @$core.override
   ChannelMessageUpdate createEmptyInstance() => create();
-  static $pb.PbList<ChannelMessageUpdate> createRepeated() =>
-      $pb.PbList<ChannelMessageUpdate>();
   @$core.pragma('dart2js:noInline')
   static ChannelMessageUpdate getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageUpdate>(create);
@@ -1853,8 +1842,6 @@ class ChannelMessageRemove extends $pb.GeneratedMessage {
   static ChannelMessageRemove create() => ChannelMessageRemove._();
   @$core.override
   ChannelMessageRemove createEmptyInstance() => create();
-  static $pb.PbList<ChannelMessageRemove> createRepeated() =>
-      $pb.PbList<ChannelMessageRemove>();
   @$core.pragma('dart2js:noInline')
   static ChannelMessageRemove getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelMessageRemove>(create);
@@ -1942,8 +1929,6 @@ class ChannelPresenceEvent extends $pb.GeneratedMessage {
   static ChannelPresenceEvent create() => ChannelPresenceEvent._();
   @$core.override
   ChannelPresenceEvent createEmptyInstance() => create();
-  static $pb.PbList<ChannelPresenceEvent> createRepeated() =>
-      $pb.PbList<ChannelPresenceEvent>();
   @$core.pragma('dart2js:noInline')
   static ChannelPresenceEvent getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ChannelPresenceEvent>(create);
@@ -2058,7 +2043,6 @@ class Error extends $pb.GeneratedMessage {
   static Error create() => Error._();
   @$core.override
   Error createEmptyInstance() => create();
-  static $pb.PbList<Error> createRepeated() => $pb.PbList<Error>();
   @$core.pragma('dart2js:noInline')
   static Error getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Error>(create);
@@ -2147,7 +2131,6 @@ class Match extends $pb.GeneratedMessage {
   static Match create() => Match._();
   @$core.override
   Match createEmptyInstance() => create();
-  static $pb.PbList<Match> createRepeated() => $pb.PbList<Match>();
   @$core.pragma('dart2js:noInline')
   static Match getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Match>(create);
@@ -2253,7 +2236,6 @@ class MatchCreate extends $pb.GeneratedMessage {
   static MatchCreate create() => MatchCreate._();
   @$core.override
   MatchCreate createEmptyInstance() => create();
-  static $pb.PbList<MatchCreate> createRepeated() => $pb.PbList<MatchCreate>();
   @$core.pragma('dart2js:noInline')
   static MatchCreate getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchCreate>(create);
@@ -2324,7 +2306,6 @@ class MatchData extends $pb.GeneratedMessage {
   static MatchData create() => MatchData._();
   @$core.override
   MatchData createEmptyInstance() => create();
-  static $pb.PbList<MatchData> createRepeated() => $pb.PbList<MatchData>();
   @$core.pragma('dart2js:noInline')
   static MatchData getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MatchData>(create);
@@ -2438,8 +2419,6 @@ class MatchDataSend extends $pb.GeneratedMessage {
   static MatchDataSend create() => MatchDataSend._();
   @$core.override
   MatchDataSend createEmptyInstance() => create();
-  static $pb.PbList<MatchDataSend> createRepeated() =>
-      $pb.PbList<MatchDataSend>();
   @$core.pragma('dart2js:noInline')
   static MatchDataSend getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchDataSend>(create);
@@ -2548,7 +2527,6 @@ class MatchJoin extends $pb.GeneratedMessage {
   static MatchJoin create() => MatchJoin._();
   @$core.override
   MatchJoin createEmptyInstance() => create();
-  static $pb.PbList<MatchJoin> createRepeated() => $pb.PbList<MatchJoin>();
   @$core.pragma('dart2js:noInline')
   static MatchJoin getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MatchJoin>(create);
@@ -2626,7 +2604,6 @@ class MatchLeave extends $pb.GeneratedMessage {
   static MatchLeave create() => MatchLeave._();
   @$core.override
   MatchLeave createEmptyInstance() => create();
-  static $pb.PbList<MatchLeave> createRepeated() => $pb.PbList<MatchLeave>();
   @$core.pragma('dart2js:noInline')
   static MatchLeave getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchLeave>(create);
@@ -2692,8 +2669,6 @@ class MatchPresenceEvent extends $pb.GeneratedMessage {
   static MatchPresenceEvent create() => MatchPresenceEvent._();
   @$core.override
   MatchPresenceEvent createEmptyInstance() => create();
-  static $pb.PbList<MatchPresenceEvent> createRepeated() =>
-      $pb.PbList<MatchPresenceEvent>();
   @$core.pragma('dart2js:noInline')
   static MatchPresenceEvent getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchPresenceEvent>(create);
@@ -2789,8 +2764,6 @@ class MatchmakerAdd extends $pb.GeneratedMessage {
   static MatchmakerAdd create() => MatchmakerAdd._();
   @$core.override
   MatchmakerAdd createEmptyInstance() => create();
-  static $pb.PbList<MatchmakerAdd> createRepeated() =>
-      $pb.PbList<MatchmakerAdd>();
   @$core.pragma('dart2js:noInline')
   static MatchmakerAdd getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchmakerAdd>(create);
@@ -2917,8 +2890,6 @@ class MatchmakerMatched_MatchmakerUser extends $pb.GeneratedMessage {
       MatchmakerMatched_MatchmakerUser._();
   @$core.override
   MatchmakerMatched_MatchmakerUser createEmptyInstance() => create();
-  static $pb.PbList<MatchmakerMatched_MatchmakerUser> createRepeated() =>
-      $pb.PbList<MatchmakerMatched_MatchmakerUser>();
   @$core.pragma('dart2js:noInline')
   static MatchmakerMatched_MatchmakerUser getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchmakerMatched_MatchmakerUser>(
@@ -3020,8 +2991,6 @@ class MatchmakerMatched extends $pb.GeneratedMessage {
   static MatchmakerMatched create() => MatchmakerMatched._();
   @$core.override
   MatchmakerMatched createEmptyInstance() => create();
-  static $pb.PbList<MatchmakerMatched> createRepeated() =>
-      $pb.PbList<MatchmakerMatched>();
   @$core.pragma('dart2js:noInline')
   static MatchmakerMatched getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchmakerMatched>(create);
@@ -3123,8 +3092,6 @@ class MatchmakerRemove extends $pb.GeneratedMessage {
   static MatchmakerRemove create() => MatchmakerRemove._();
   @$core.override
   MatchmakerRemove createEmptyInstance() => create();
-  static $pb.PbList<MatchmakerRemove> createRepeated() =>
-      $pb.PbList<MatchmakerRemove>();
   @$core.pragma('dart2js:noInline')
   static MatchmakerRemove getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchmakerRemove>(create);
@@ -3182,8 +3149,6 @@ class MatchmakerTicket extends $pb.GeneratedMessage {
   static MatchmakerTicket create() => MatchmakerTicket._();
   @$core.override
   MatchmakerTicket createEmptyInstance() => create();
-  static $pb.PbList<MatchmakerTicket> createRepeated() =>
-      $pb.PbList<MatchmakerTicket>();
   @$core.pragma('dart2js:noInline')
   static MatchmakerTicket getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MatchmakerTicket>(create);
@@ -3242,8 +3207,6 @@ class Notifications extends $pb.GeneratedMessage {
   static Notifications create() => Notifications._();
   @$core.override
   Notifications createEmptyInstance() => create();
-  static $pb.PbList<Notifications> createRepeated() =>
-      $pb.PbList<Notifications>();
   @$core.pragma('dart2js:noInline')
   static Notifications getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<Notifications>(create);
@@ -3318,7 +3281,6 @@ class Party extends $pb.GeneratedMessage {
   static Party create() => Party._();
   @$core.override
   Party createEmptyInstance() => create();
-  static $pb.PbList<Party> createRepeated() => $pb.PbList<Party>();
   @$core.pragma('dart2js:noInline')
   static Party getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Party>(create);
@@ -3453,7 +3415,6 @@ class PartyCreate extends $pb.GeneratedMessage {
   static PartyCreate create() => PartyCreate._();
   @$core.override
   PartyCreate createEmptyInstance() => create();
-  static $pb.PbList<PartyCreate> createRepeated() => $pb.PbList<PartyCreate>();
   @$core.pragma('dart2js:noInline')
   static PartyCreate getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyCreate>(create);
@@ -3550,7 +3511,6 @@ class PartyUpdate extends $pb.GeneratedMessage {
   static PartyUpdate create() => PartyUpdate._();
   @$core.override
   PartyUpdate createEmptyInstance() => create();
-  static $pb.PbList<PartyUpdate> createRepeated() => $pb.PbList<PartyUpdate>();
   @$core.pragma('dart2js:noInline')
   static PartyUpdate getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyUpdate>(create);
@@ -3637,7 +3597,6 @@ class PartyJoin extends $pb.GeneratedMessage {
   static PartyJoin create() => PartyJoin._();
   @$core.override
   PartyJoin createEmptyInstance() => create();
-  static $pb.PbList<PartyJoin> createRepeated() => $pb.PbList<PartyJoin>();
   @$core.pragma('dart2js:noInline')
   static PartyJoin getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PartyJoin>(create);
@@ -3694,7 +3653,6 @@ class PartyLeave extends $pb.GeneratedMessage {
   static PartyLeave create() => PartyLeave._();
   @$core.override
   PartyLeave createEmptyInstance() => create();
-  static $pb.PbList<PartyLeave> createRepeated() => $pb.PbList<PartyLeave>();
   @$core.pragma('dart2js:noInline')
   static PartyLeave getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyLeave>(create);
@@ -3756,8 +3714,6 @@ class PartyPromote extends $pb.GeneratedMessage {
   static PartyPromote create() => PartyPromote._();
   @$core.override
   PartyPromote createEmptyInstance() => create();
-  static $pb.PbList<PartyPromote> createRepeated() =>
-      $pb.PbList<PartyPromote>();
   @$core.pragma('dart2js:noInline')
   static PartyPromote getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyPromote>(create);
@@ -3831,7 +3787,6 @@ class PartyLeader extends $pb.GeneratedMessage {
   static PartyLeader create() => PartyLeader._();
   @$core.override
   PartyLeader createEmptyInstance() => create();
-  static $pb.PbList<PartyLeader> createRepeated() => $pb.PbList<PartyLeader>();
   @$core.pragma('dart2js:noInline')
   static PartyLeader getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyLeader>(create);
@@ -3905,7 +3860,6 @@ class PartyAccept extends $pb.GeneratedMessage {
   static PartyAccept create() => PartyAccept._();
   @$core.override
   PartyAccept createEmptyInstance() => create();
-  static $pb.PbList<PartyAccept> createRepeated() => $pb.PbList<PartyAccept>();
   @$core.pragma('dart2js:noInline')
   static PartyAccept getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyAccept>(create);
@@ -3979,7 +3933,6 @@ class PartyRemove extends $pb.GeneratedMessage {
   static PartyRemove create() => PartyRemove._();
   @$core.override
   PartyRemove createEmptyInstance() => create();
-  static $pb.PbList<PartyRemove> createRepeated() => $pb.PbList<PartyRemove>();
   @$core.pragma('dart2js:noInline')
   static PartyRemove getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyRemove>(create);
@@ -4048,7 +4001,6 @@ class PartyClose extends $pb.GeneratedMessage {
   static PartyClose create() => PartyClose._();
   @$core.override
   PartyClose createEmptyInstance() => create();
-  static $pb.PbList<PartyClose> createRepeated() => $pb.PbList<PartyClose>();
   @$core.pragma('dart2js:noInline')
   static PartyClose getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyClose>(create);
@@ -4106,8 +4058,6 @@ class PartyJoinRequestList extends $pb.GeneratedMessage {
   static PartyJoinRequestList create() => PartyJoinRequestList._();
   @$core.override
   PartyJoinRequestList createEmptyInstance() => create();
-  static $pb.PbList<PartyJoinRequestList> createRepeated() =>
-      $pb.PbList<PartyJoinRequestList>();
   @$core.pragma('dart2js:noInline')
   static PartyJoinRequestList getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyJoinRequestList>(create);
@@ -4169,8 +4119,6 @@ class PartyJoinRequest extends $pb.GeneratedMessage {
   static PartyJoinRequest create() => PartyJoinRequest._();
   @$core.override
   PartyJoinRequest createEmptyInstance() => create();
-  static $pb.PbList<PartyJoinRequest> createRepeated() =>
-      $pb.PbList<PartyJoinRequest>();
   @$core.pragma('dart2js:noInline')
   static PartyJoinRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyJoinRequest>(create);
@@ -4265,8 +4213,6 @@ class PartyMatchmakerAdd extends $pb.GeneratedMessage {
   static PartyMatchmakerAdd create() => PartyMatchmakerAdd._();
   @$core.override
   PartyMatchmakerAdd createEmptyInstance() => create();
-  static $pb.PbList<PartyMatchmakerAdd> createRepeated() =>
-      $pb.PbList<PartyMatchmakerAdd>();
   @$core.pragma('dart2js:noInline')
   static PartyMatchmakerAdd getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyMatchmakerAdd>(create);
@@ -4378,8 +4324,6 @@ class PartyMatchmakerRemove extends $pb.GeneratedMessage {
   static PartyMatchmakerRemove create() => PartyMatchmakerRemove._();
   @$core.override
   PartyMatchmakerRemove createEmptyInstance() => create();
-  static $pb.PbList<PartyMatchmakerRemove> createRepeated() =>
-      $pb.PbList<PartyMatchmakerRemove>();
   @$core.pragma('dart2js:noInline')
   static PartyMatchmakerRemove getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyMatchmakerRemove>(create);
@@ -4451,8 +4395,6 @@ class PartyMatchmakerTicket extends $pb.GeneratedMessage {
   static PartyMatchmakerTicket create() => PartyMatchmakerTicket._();
   @$core.override
   PartyMatchmakerTicket createEmptyInstance() => create();
-  static $pb.PbList<PartyMatchmakerTicket> createRepeated() =>
-      $pb.PbList<PartyMatchmakerTicket>();
   @$core.pragma('dart2js:noInline')
   static PartyMatchmakerTicket getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyMatchmakerTicket>(create);
@@ -4530,7 +4472,6 @@ class PartyData extends $pb.GeneratedMessage {
   static PartyData create() => PartyData._();
   @$core.override
   PartyData createEmptyInstance() => create();
-  static $pb.PbList<PartyData> createRepeated() => $pb.PbList<PartyData>();
   @$core.pragma('dart2js:noInline')
   static PartyData getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PartyData>(create);
@@ -4627,8 +4568,6 @@ class PartyDataSend extends $pb.GeneratedMessage {
   static PartyDataSend create() => PartyDataSend._();
   @$core.override
   PartyDataSend createEmptyInstance() => create();
-  static $pb.PbList<PartyDataSend> createRepeated() =>
-      $pb.PbList<PartyDataSend>();
   @$core.pragma('dart2js:noInline')
   static PartyDataSend getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyDataSend>(create);
@@ -4714,8 +4653,6 @@ class PartyPresenceEvent extends $pb.GeneratedMessage {
   static PartyPresenceEvent create() => PartyPresenceEvent._();
   @$core.override
   PartyPresenceEvent createEmptyInstance() => create();
-  static $pb.PbList<PartyPresenceEvent> createRepeated() =>
-      $pb.PbList<PartyPresenceEvent>();
   @$core.pragma('dart2js:noInline')
   static PartyPresenceEvent getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PartyPresenceEvent>(create);
@@ -4773,7 +4710,6 @@ class Ping extends $pb.GeneratedMessage {
   static Ping create() => Ping._();
   @$core.override
   Ping createEmptyInstance() => create();
-  static $pb.PbList<Ping> createRepeated() => $pb.PbList<Ping>();
   @$core.pragma('dart2js:noInline')
   static Ping getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Ping>(create);
@@ -4813,7 +4749,6 @@ class Pong extends $pb.GeneratedMessage {
   static Pong create() => Pong._();
   @$core.override
   Pong createEmptyInstance() => create();
-  static $pb.PbList<Pong> createRepeated() => $pb.PbList<Pong>();
   @$core.pragma('dart2js:noInline')
   static Pong getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Pong>(create);
@@ -4861,7 +4796,6 @@ class Status extends $pb.GeneratedMessage {
   static Status create() => Status._();
   @$core.override
   Status createEmptyInstance() => create();
-  static $pb.PbList<Status> createRepeated() => $pb.PbList<Status>();
   @$core.pragma('dart2js:noInline')
   static Status getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Status>(create);
@@ -4916,8 +4850,6 @@ class StatusFollow extends $pb.GeneratedMessage {
   static StatusFollow create() => StatusFollow._();
   @$core.override
   StatusFollow createEmptyInstance() => create();
-  static $pb.PbList<StatusFollow> createRepeated() =>
-      $pb.PbList<StatusFollow>();
   @$core.pragma('dart2js:noInline')
   static StatusFollow getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StatusFollow>(create);
@@ -4978,8 +4910,6 @@ class StatusPresenceEvent extends $pb.GeneratedMessage {
   static StatusPresenceEvent create() => StatusPresenceEvent._();
   @$core.override
   StatusPresenceEvent createEmptyInstance() => create();
-  static $pb.PbList<StatusPresenceEvent> createRepeated() =>
-      $pb.PbList<StatusPresenceEvent>();
   @$core.pragma('dart2js:noInline')
   static StatusPresenceEvent getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StatusPresenceEvent>(create);
@@ -5035,8 +4965,6 @@ class StatusUnfollow extends $pb.GeneratedMessage {
   static StatusUnfollow create() => StatusUnfollow._();
   @$core.override
   StatusUnfollow createEmptyInstance() => create();
-  static $pb.PbList<StatusUnfollow> createRepeated() =>
-      $pb.PbList<StatusUnfollow>();
   @$core.pragma('dart2js:noInline')
   static StatusUnfollow getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StatusUnfollow>(create);
@@ -5089,8 +5017,6 @@ class StatusUpdate extends $pb.GeneratedMessage {
   static StatusUpdate create() => StatusUpdate._();
   @$core.override
   StatusUpdate createEmptyInstance() => create();
-  static $pb.PbList<StatusUpdate> createRepeated() =>
-      $pb.PbList<StatusUpdate>();
   @$core.pragma('dart2js:noInline')
   static StatusUpdate getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StatusUpdate>(create);
@@ -5158,7 +5084,6 @@ class Stream extends $pb.GeneratedMessage {
   static Stream create() => Stream._();
   @$core.override
   Stream createEmptyInstance() => create();
-  static $pb.PbList<Stream> createRepeated() => $pb.PbList<Stream>();
   @$core.pragma('dart2js:noInline')
   static Stream getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Stream>(create);
@@ -5255,7 +5180,6 @@ class StreamData extends $pb.GeneratedMessage {
   static StreamData create() => StreamData._();
   @$core.override
   StreamData createEmptyInstance() => create();
-  static $pb.PbList<StreamData> createRepeated() => $pb.PbList<StreamData>();
   @$core.pragma('dart2js:noInline')
   static StreamData getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StreamData>(create);
@@ -5355,8 +5279,6 @@ class StreamPresenceEvent extends $pb.GeneratedMessage {
   static StreamPresenceEvent create() => StreamPresenceEvent._();
   @$core.override
   StreamPresenceEvent createEmptyInstance() => create();
-  static $pb.PbList<StreamPresenceEvent> createRepeated() =>
-      $pb.PbList<StreamPresenceEvent>();
   @$core.pragma('dart2js:noInline')
   static StreamPresenceEvent getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StreamPresenceEvent>(create);
@@ -5437,8 +5359,6 @@ class UserPresence extends $pb.GeneratedMessage {
   static UserPresence create() => UserPresence._();
   @$core.override
   UserPresence createEmptyInstance() => create();
-  static $pb.PbList<UserPresence> createRepeated() =>
-      $pb.PbList<UserPresence>();
   @$core.pragma('dart2js:noInline')
   static UserPresence getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UserPresence>(create);

--- a/nakama/lib/src/api/proto/rtapi/realtime.pb.dart
+++ b/nakama/lib/src/api/proto/rtapi/realtime.pb.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/rtapi/realtime.pbenum.dart
+++ b/nakama/lib/src/api/proto/rtapi/realtime.pbenum.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/api/proto/rtapi/realtime.pbjson.dart
+++ b/nakama/lib/src/api/proto/rtapi/realtime.pbjson.dart
@@ -4,6 +4,7 @@
 
 // @dart = 3.3
 
+// ignore_for_file: always_use_package_imports
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: curly_braces_in_flow_control_structures

--- a/nakama/lib/src/enum/channel_type.dart
+++ b/nakama/lib/src/enum/channel_type.dart
@@ -1,5 +1,1 @@
-enum ChannelType {
-  directMessage,
-  group,
-  room,
-}
+enum ChannelType { directMessage, group, room }

--- a/nakama/lib/src/models/account.dart
+++ b/nakama/lib/src/models/account.dart
@@ -19,34 +19,35 @@ sealed class Account with _$Account {
     required User user,
   }) = _Account;
 
-  factory Account.fromJson(Map<String, Object?> json) => _$AccountFromJson(json);
+  factory Account.fromJson(Map<String, Object?> json) =>
+      _$AccountFromJson(json);
 
   factory Account.fromDto(api.Account dto) => Account(
-        wallet: PlatformNormalizer.normalizeNullableString(dto.wallet),
-        email: PlatformNormalizer.normalizeNullableString(dto.email),
-        devices: dto.devices.map((e) => Device.fromDto(e)).toList(growable: false),
-        customId: PlatformNormalizer.normalizeNullableString(dto.customId),
-        verifyTime: dto.verifyTime.hasSeconds() ? dto.verifyTime.toDateTime() : null,
-        disableTime: dto.disableTime.hasSeconds() ? dto.disableTime.toDateTime() : null,
-        user: User.fromDto(dto.user),
-      );
+    wallet: PlatformNormalizer.normalizeNullableString(dto.wallet),
+    email: PlatformNormalizer.normalizeNullableString(dto.email),
+    devices: dto.devices.map((e) => Device.fromDto(e)).toList(growable: false),
+    customId: PlatformNormalizer.normalizeNullableString(dto.customId),
+    verifyTime: dto.verifyTime.hasSeconds()
+        ? dto.verifyTime.toDateTime()
+        : null,
+    disableTime: dto.disableTime.hasSeconds()
+        ? dto.disableTime.toDateTime()
+        : null,
+    user: User.fromDto(dto.user),
+  );
 }
 
 @freezed
 sealed class Device with _$Device {
   const Device._();
 
-  const factory Device({
-    required String id,
-    Map<String, dynamic>? vars,
-  }) = _Device;
+  const factory Device({required String id, Map<String, dynamic>? vars}) =
+      _Device;
 
   factory Device.fromJson(Map<String, Object?> json) => _$DeviceFromJson(json);
 
-  factory Device.fromDto(api.AccountDevice dto) => Device(
-        id: dto.id,
-        vars: dto.vars,
-      );
+  factory Device.fromDto(api.AccountDevice dto) =>
+      Device(id: dto.id, vars: dto.vars);
 }
 
 @freezed
@@ -77,23 +78,25 @@ sealed class User with _$User {
   factory User.fromJson(Map<String, Object?> json) => _$UserFromJson(json);
 
   factory User.fromDto(api.User user) => User(
-        id: user.id,
-        username: PlatformNormalizer.normalizeNullableString(user.username),
-        displayName: PlatformNormalizer.normalizeNullableString(user.displayName),
-        avatarUrl: PlatformNormalizer.normalizeNullableString(user.avatarUrl),
-        langTag: PlatformNormalizer.normalizeNullableString(user.langTag),
-        location: PlatformNormalizer.normalizeNullableString(user.location),
-        timezone: PlatformNormalizer.normalizeNullableString(user.timezone),
-        metadata: PlatformNormalizer.normalizeNullableString(user.metadata),
-        facebookId: PlatformNormalizer.normalizeNullableString(user.facebookId),
-        googleId: PlatformNormalizer.normalizeNullableString(user.googleId),
-        gamecenterId: PlatformNormalizer.normalizeNullableString(user.gamecenterId),
-        steamId: PlatformNormalizer.normalizeNullableString(user.steamId),
-        online: user.online,
-        edgeCount: user.edgeCount,
-        createTime: user.createTime.toDateTime(),
-        updateTime: user.updateTime.toDateTime(),
-        facebookInstantGameId: PlatformNormalizer.normalizeNullableString(user.facebookInstantGameId),
-        appleId: PlatformNormalizer.normalizeNullableString(user.appleId),
-      );
+    id: user.id,
+    username: PlatformNormalizer.normalizeNullableString(user.username),
+    displayName: PlatformNormalizer.normalizeNullableString(user.displayName),
+    avatarUrl: PlatformNormalizer.normalizeNullableString(user.avatarUrl),
+    langTag: PlatformNormalizer.normalizeNullableString(user.langTag),
+    location: PlatformNormalizer.normalizeNullableString(user.location),
+    timezone: PlatformNormalizer.normalizeNullableString(user.timezone),
+    metadata: PlatformNormalizer.normalizeNullableString(user.metadata),
+    facebookId: PlatformNormalizer.normalizeNullableString(user.facebookId),
+    googleId: PlatformNormalizer.normalizeNullableString(user.googleId),
+    gamecenterId: PlatformNormalizer.normalizeNullableString(user.gamecenterId),
+    steamId: PlatformNormalizer.normalizeNullableString(user.steamId),
+    online: user.online,
+    edgeCount: user.edgeCount,
+    createTime: user.createTime.toDateTime(),
+    updateTime: user.updateTime.toDateTime(),
+    facebookInstantGameId: PlatformNormalizer.normalizeNullableString(
+      user.facebookInstantGameId,
+    ),
+    appleId: PlatformNormalizer.normalizeNullableString(user.appleId),
+  );
 }

--- a/nakama/lib/src/models/channel_message.dart
+++ b/nakama/lib/src/models/channel_message.dart
@@ -25,23 +25,24 @@ sealed class ChannelMessage with _$ChannelMessage {
     @JsonKey(name: 'user_id_two') required String? userIdTwo,
   }) = _ChannelMessage;
 
-  factory ChannelMessage.fromJson(Map<String, Object?> json) => _$ChannelMessageFromJson(json);
+  factory ChannelMessage.fromJson(Map<String, Object?> json) =>
+      _$ChannelMessageFromJson(json);
 
   factory ChannelMessage.fromDto(api.ChannelMessage dto) => ChannelMessage(
-        channelId: dto.channelId,
-        messageId: dto.messageId,
-        code: dto.code.value,
-        senderId: dto.senderId,
-        username: dto.username,
-        content: dto.content,
-        createTime: dto.createTime.toDateTime(),
-        updateTime: dto.updateTime.toDateTime(),
-        persistent: dto.persistent.value,
-        roomName: PlatformNormalizer.normalizeNullableString(dto.roomName),
-        groupId: PlatformNormalizer.normalizeNullableString(dto.groupId),
-        userIdOne: PlatformNormalizer.normalizeNullableString(dto.userIdOne),
-        userIdTwo: PlatformNormalizer.normalizeNullableString(dto.userIdTwo),
-      );
+    channelId: dto.channelId,
+    messageId: dto.messageId,
+    code: dto.code.value,
+    senderId: dto.senderId,
+    username: dto.username,
+    content: dto.content,
+    createTime: dto.createTime.toDateTime(),
+    updateTime: dto.updateTime.toDateTime(),
+    persistent: dto.persistent.value,
+    roomName: PlatformNormalizer.normalizeNullableString(dto.roomName),
+    groupId: PlatformNormalizer.normalizeNullableString(dto.groupId),
+    userIdOne: PlatformNormalizer.normalizeNullableString(dto.userIdOne),
+    userIdTwo: PlatformNormalizer.normalizeNullableString(dto.userIdTwo),
+  );
 }
 
 @freezed
@@ -49,18 +50,26 @@ sealed class ChannelMessageList with _$ChannelMessageList {
   const ChannelMessageList._();
 
   const factory ChannelMessageList({
-    @JsonKey(name: 'messages') @Default(<ChannelMessage>[]) List<ChannelMessage> messages,
+    @JsonKey(name: 'messages')
+    @Default(<ChannelMessage>[])
+    List<ChannelMessage> messages,
     @JsonKey(name: 'next_cursor') required String? nextCursor,
     @JsonKey(name: 'prev_cursor') required String? prevCursor,
     @JsonKey(name: 'cacheable_cursor') required String? cacheableCursor,
   }) = _ChannelMessageList;
 
-  factory ChannelMessageList.fromJson(Map<String, Object?> json) => _$ChannelMessageListFromJson(json);
+  factory ChannelMessageList.fromJson(Map<String, Object?> json) =>
+      _$ChannelMessageListFromJson(json);
 
-  factory ChannelMessageList.fromDto(api.ChannelMessageList dto) => ChannelMessageList(
-        messages: dto.messages.map((e) => ChannelMessage.fromDto(e)).toList(growable: false),
+  factory ChannelMessageList.fromDto(api.ChannelMessageList dto) =>
+      ChannelMessageList(
+        messages: dto.messages
+            .map((e) => ChannelMessage.fromDto(e))
+            .toList(growable: false),
         nextCursor: PlatformNormalizer.normalizeNullableString(dto.nextCursor),
         prevCursor: PlatformNormalizer.normalizeNullableString(dto.prevCursor),
-        cacheableCursor: PlatformNormalizer.normalizeNullableString(dto.cacheableCursor),
+        cacheableCursor: PlatformNormalizer.normalizeNullableString(
+          dto.cacheableCursor,
+        ),
       );
 }

--- a/nakama/lib/src/models/chat.dart
+++ b/nakama/lib/src/models/chat.dart
@@ -36,14 +36,16 @@ sealed class Channel with _$Channel {
   }) = _Channel;
 
   factory Channel.fromDto(rtpb.Channel dto) => Channel(
-        id: dto.id,
-        presences: dto.presences.map((e) => UserPresence.fromDto(e)).toList(growable: false),
-        self: UserPresence.fromDto(dto.self),
-        roomName: dto.roomName,
-        groupId: dto.groupId,
-        userIdOne: dto.userIdOne,
-        userIdTwo: dto.userIdTwo,
-      );
+    id: dto.id,
+    presences: dto.presences
+        .map((e) => UserPresence.fromDto(e))
+        .toList(growable: false),
+    self: UserPresence.fromDto(dto.self),
+    roomName: dto.roomName,
+    groupId: dto.groupId,
+    userIdOne: dto.userIdOne,
+    userIdTwo: dto.userIdTwo,
+  );
 }
 
 @freezed
@@ -87,7 +89,8 @@ sealed class ChannelMessageAck with _$ChannelMessageAck {
     @JsonKey(name: 'user_id_two') required String userIdTwo,
   }) = _ChannelMessageAck;
 
-  factory ChannelMessageAck.fromDto(rtpb.ChannelMessageAck dto) => ChannelMessageAck(
+  factory ChannelMessageAck.fromDto(rtpb.ChannelMessageAck dto) =>
+      ChannelMessageAck(
         channelId: dto.channelId,
         messageId: dto.messageId,
         code: dto.code.value,

--- a/nakama/lib/src/models/friends.dart
+++ b/nakama/lib/src/models/friends.dart
@@ -16,18 +16,21 @@ sealed class FriendsList with _$FriendsList {
     @Default(<Friend>[]) List<Friend> friends,
   }) = _FriendsList;
 
-  factory FriendsList.fromJson(Map<String, Object?> json) => _$FriendsListFromJson(json);
+  factory FriendsList.fromJson(Map<String, Object?> json) =>
+      _$FriendsListFromJson(json);
 
   factory FriendsList.fromDto(api.FriendList dto) => FriendsList(
-        cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
-        friends: dto.friends
-            .map((e) => Friend(
-                  state: FriendshipState.values[e.state.value],
-                  updateTime: e.updateTime.toDateTime(),
-                  user: User.fromDto(e.user),
-                ))
-            .toList(growable: false),
-      );
+    cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
+    friends: dto.friends
+        .map(
+          (e) => Friend(
+            state: FriendshipState.values[e.state.value],
+            updateTime: e.updateTime.toDateTime(),
+            user: User.fromDto(e.user),
+          ),
+        )
+        .toList(growable: false),
+  );
 }
 
 @freezed
@@ -49,18 +52,26 @@ sealed class FriendsOfFriendsList with _$FriendsOfFriendsList {
 
   const factory FriendsOfFriendsList({
     @JsonKey(name: 'cursor') String? cursor,
-    @JsonKey(name: 'friends_of_friends') @Default(<FriendOfFriend>[]) List<FriendOfFriend> friendsOfFriends,
+    @JsonKey(name: 'friends_of_friends')
+    @Default(<FriendOfFriend>[])
+    List<FriendOfFriend> friendsOfFriends,
   }) = _FriendsOfFriendsList;
 
-  factory FriendsOfFriendsList.fromJson(Map<String, Object?> json) => _$FriendsOfFriendsListFromJson(json);
+  factory FriendsOfFriendsList.fromJson(Map<String, Object?> json) =>
+      _$FriendsOfFriendsListFromJson(json);
 
-  factory FriendsOfFriendsList.fromDto(api.FriendsOfFriendsList dto) => FriendsOfFriendsList(
+  factory FriendsOfFriendsList.fromDto(api.FriendsOfFriendsList dto) =>
+      FriendsOfFriendsList(
         cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
         friendsOfFriends: dto.friendsOfFriends
-            .map((e) => FriendOfFriend(
-                  referrer: PlatformNormalizer.normalizeNullableString(e.referrer),
-                  user: User.fromDto(e.user),
-                ))
+            .map(
+              (e) => FriendOfFriend(
+                referrer: PlatformNormalizer.normalizeNullableString(
+                  e.referrer,
+                ),
+                user: User.fromDto(e.user),
+              ),
+            )
             .toList(growable: false),
       );
 }
@@ -77,5 +88,6 @@ sealed class FriendOfFriend with _$FriendOfFriend {
     @JsonKey(name: 'user') required User user,
   }) = _FriendOfFriend;
 
-  factory FriendOfFriend.fromJson(Map<String, Object?> json) => _$FriendOfFriendFromJson(json);
+  factory FriendOfFriend.fromJson(Map<String, Object?> json) =>
+      _$FriendOfFriendFromJson(json);
 }

--- a/nakama/lib/src/models/group.dart
+++ b/nakama/lib/src/models/group.dart
@@ -29,19 +29,19 @@ sealed class Group with _$Group {
   factory Group.fromJson(Map<String, Object?> json) => _$GroupFromJson(json);
 
   factory Group.fromDto(api.Group dto) => Group(
-        id: dto.id,
-        creatorId: PlatformNormalizer.normalizeNullableString(dto.creatorId),
-        name: PlatformNormalizer.normalizeNullableString(dto.name),
-        description: PlatformNormalizer.normalizeNullableString(dto.description),
-        langTag: PlatformNormalizer.normalizeNullableString(dto.langTag),
-        metadata: PlatformNormalizer.normalizeNullableString(dto.metadata),
-        avatarUrl: PlatformNormalizer.normalizeNullableString(dto.avatarUrl),
-        open: dto.open.value,
-        edgeCount: dto.edgeCount,
-        maxCount: dto.maxCount,
-        createTime: dto.createTime.toDateTime(),
-        updateTime: dto.updateTime.toDateTime(),
-      );
+    id: dto.id,
+    creatorId: PlatformNormalizer.normalizeNullableString(dto.creatorId),
+    name: PlatformNormalizer.normalizeNullableString(dto.name),
+    description: PlatformNormalizer.normalizeNullableString(dto.description),
+    langTag: PlatformNormalizer.normalizeNullableString(dto.langTag),
+    metadata: PlatformNormalizer.normalizeNullableString(dto.metadata),
+    avatarUrl: PlatformNormalizer.normalizeNullableString(dto.avatarUrl),
+    open: dto.open.value,
+    edgeCount: dto.edgeCount,
+    maxCount: dto.maxCount,
+    createTime: dto.createTime.toDateTime(),
+    updateTime: dto.updateTime.toDateTime(),
+  );
 }
 
 @freezed
@@ -53,12 +53,13 @@ sealed class GroupList with _$GroupList {
     @Default(<Group>[]) List<Group> groups,
   }) = _GroupList;
 
-  factory GroupList.fromJson(Map<String, Object?> json) => _$GroupListFromJson(json);
+  factory GroupList.fromJson(Map<String, Object?> json) =>
+      _$GroupListFromJson(json);
 
   factory GroupList.fromDto(api.GroupList dto) => GroupList(
-        cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
-        groups: dto.groups.map((e) => Group.fromDto(e)).toList(growable: false),
-      );
+    cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
+    groups: dto.groups.map((e) => Group.fromDto(e)).toList(growable: false),
+  );
 }
 
 @freezed
@@ -67,15 +68,20 @@ sealed class UserGroupList with _$UserGroupList {
 
   const factory UserGroupList({
     String? cursor,
-    @JsonKey(name: 'user_groups') @Default(<UserGroup>[]) List<UserGroup> userGroups,
+    @JsonKey(name: 'user_groups')
+    @Default(<UserGroup>[])
+    List<UserGroup> userGroups,
   }) = _UserGroupList;
 
-  factory UserGroupList.fromJson(Map<String, Object?> json) => _$UserGroupListFromJson(json);
+  factory UserGroupList.fromJson(Map<String, Object?> json) =>
+      _$UserGroupListFromJson(json);
 
   factory UserGroupList.fromDto(api.UserGroupList dto) => UserGroupList(
-        cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
-        userGroups: dto.userGroups.map((e) => UserGroup.fromDto(e)).toList(growable: false),
-      );
+    cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
+    userGroups: dto.userGroups
+        .map((e) => UserGroup.fromDto(e))
+        .toList(growable: false),
+  );
 }
 
 @freezed
@@ -87,12 +93,13 @@ sealed class UserGroup with _$UserGroup {
     required Group group,
   }) = _UserGroup;
 
-  factory UserGroup.fromJson(Map<String, Object?> json) => _$UserGroupFromJson(json);
+  factory UserGroup.fromJson(Map<String, Object?> json) =>
+      _$UserGroupFromJson(json);
 
   factory UserGroup.fromDto(api.UserGroupList_UserGroup dto) => UserGroup(
-        group: Group.fromDto(dto.group),
-        state: GroupMembershipState.values[dto.state.value],
-      );
+    group: Group.fromDto(dto.group),
+    state: GroupMembershipState.values[dto.state.value],
+  );
 }
 
 @freezed
@@ -101,15 +108,20 @@ sealed class GroupUserList with _$GroupUserList {
 
   const factory GroupUserList({
     String? cursor,
-    @JsonKey(name: 'group_users') @Default(<GroupUser>[]) List<GroupUser> groupUsers,
+    @JsonKey(name: 'group_users')
+    @Default(<GroupUser>[])
+    List<GroupUser> groupUsers,
   }) = _GroupUserList;
 
-  factory GroupUserList.fromJson(Map<String, Object?> json) => _$GroupUserListFromJson(json);
+  factory GroupUserList.fromJson(Map<String, Object?> json) =>
+      _$GroupUserListFromJson(json);
 
   factory GroupUserList.fromDto(api.GroupUserList dto) => GroupUserList(
-        cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
-        groupUsers: dto.groupUsers.map((e) => GroupUser.fromDto(e)).toList(growable: false),
-      );
+    cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
+    groupUsers: dto.groupUsers
+        .map((e) => GroupUser.fromDto(e))
+        .toList(growable: false),
+  );
 }
 
 @freezed
@@ -121,10 +133,11 @@ sealed class GroupUser with _$GroupUser {
     required User user,
   }) = _GroupUser;
 
-  factory GroupUser.fromJson(Map<String, Object?> json) => _$GroupUserFromJson(json);
+  factory GroupUser.fromJson(Map<String, Object?> json) =>
+      _$GroupUserFromJson(json);
 
   factory GroupUser.fromDto(api.GroupUserList_GroupUser dto) => GroupUser(
-        state: GroupMembershipState.values[dto.state.value],
-        user: User.fromDto(dto.user),
-      );
+    state: GroupMembershipState.values[dto.state.value],
+    user: User.fromDto(dto.user),
+  );
 }

--- a/nakama/lib/src/models/leaderboard.dart
+++ b/nakama/lib/src/models/leaderboard.dart
@@ -27,17 +27,25 @@ sealed class LeaderboardRecordList with _$LeaderboardRecordList {
   const LeaderboardRecordList._();
 
   const factory LeaderboardRecordList({
-    @JsonKey(name: 'records') @Default(<LeaderboardRecord>[]) List<LeaderboardRecord> records,
-    @JsonKey(name: 'owner_records') @Default(<LeaderboardRecord>[]) List<LeaderboardRecord> ownerRecords,
+    @JsonKey(name: 'records')
+    @Default(<LeaderboardRecord>[])
+    List<LeaderboardRecord> records,
+    @JsonKey(name: 'owner_records')
+    @Default(<LeaderboardRecord>[])
+    List<LeaderboardRecord> ownerRecords,
     @JsonKey(name: 'next_cursor') String? nextCursor,
     @JsonKey(name: 'prev_cursor') String? prevCursor,
   }) = _LeaderboardRecordList;
 
-  factory LeaderboardRecordList.fromJson(Map<String, Object?> json) => _$LeaderboardRecordListFromJson(json);
+  factory LeaderboardRecordList.fromJson(Map<String, Object?> json) =>
+      _$LeaderboardRecordListFromJson(json);
 
-  factory LeaderboardRecordList.fromDto(api.LeaderboardRecordList dto) => LeaderboardRecordList(
+  factory LeaderboardRecordList.fromDto(api.LeaderboardRecordList dto) =>
+      LeaderboardRecordList(
         records: dto.records.map((e) => LeaderboardRecord.fromDto(e)).toList(),
-        ownerRecords: dto.ownerRecords.map((e) => LeaderboardRecord.fromDto(e)).toList(),
+        ownerRecords: dto.ownerRecords
+            .map((e) => LeaderboardRecord.fromDto(e))
+            .toList(),
         nextCursor: PlatformNormalizer.normalizeNullableString(dto.nextCursor),
         prevCursor: PlatformNormalizer.normalizeNullableString(dto.prevCursor),
       );
@@ -51,31 +59,46 @@ sealed class LeaderboardRecord with _$LeaderboardRecord {
     @JsonKey(name: 'leaderboard_id') String? leaderboardId,
     @JsonKey(name: 'owner_id') String? ownerId,
     @JsonKey(name: 'username') String? username,
-    @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int score,
-    @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int subscore,
-    @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int numScore,
+    @JsonKey(name: 'score', fromJson: PlatformNormalizer.normalizeInt)
+    @Default(0)
+    int score,
+    @JsonKey(name: 'subscore', fromJson: PlatformNormalizer.normalizeInt)
+    @Default(0)
+    int subscore,
+    @JsonKey(name: 'num_score', fromJson: PlatformNormalizer.normalizeInt)
+    @Default(0)
+    int numScore,
     @JsonKey(name: 'metadata') String? metadata,
     @JsonKey(name: 'create_time') DateTime? createTime,
     @JsonKey(name: 'update_time') DateTime? updateTime,
     @JsonKey(name: 'expiry_time') DateTime? expiryTime,
-    @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int rank,
-    @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt) @Default(0) int maxNumScore,
+    @JsonKey(name: 'rank', fromJson: PlatformNormalizer.normalizeInt)
+    @Default(0)
+    int rank,
+    @JsonKey(name: 'max_num_score', fromJson: PlatformNormalizer.normalizeInt)
+    @Default(0)
+    int maxNumScore,
   }) = _LeaderboardRecord;
 
-  factory LeaderboardRecord.fromJson(Map<String, Object?> json) => _$LeaderboardRecordFromJson(json);
+  factory LeaderboardRecord.fromJson(Map<String, Object?> json) =>
+      _$LeaderboardRecordFromJson(json);
 
-  factory LeaderboardRecord.fromDto(api.LeaderboardRecord dto) => LeaderboardRecord(
-        leaderboardId: PlatformNormalizer.normalizeNullableString(dto.leaderboardId),
-        ownerId: PlatformNormalizer.normalizeNullableString(dto.ownerId),
-        username: PlatformNormalizer.normalizeNullableString(dto.username.value),
-        score: dto.score.toInt(),
-        subscore: dto.subscore.toInt(),
-        numScore: dto.numScore.toInt(),
-        metadata: PlatformNormalizer.normalizeNullableString(dto.metadata),
-        createTime: dto.createTime.hasNanos() ? dto.createTime.toDateTime() : null,
-        updateTime: dto.updateTime.hasNanos() ? dto.updateTime.toDateTime() : null,
-        expiryTime: dto.expiryTime.hasNanos() ? dto.expiryTime.toDateTime() : null,
-        rank: dto.rank.toInt(),
-        maxNumScore: dto.maxNumScore.toInt(),
-      );
+  factory LeaderboardRecord.fromDto(
+    api.LeaderboardRecord dto,
+  ) => LeaderboardRecord(
+    leaderboardId: PlatformNormalizer.normalizeNullableString(
+      dto.leaderboardId,
+    ),
+    ownerId: PlatformNormalizer.normalizeNullableString(dto.ownerId),
+    username: PlatformNormalizer.normalizeNullableString(dto.username.value),
+    score: dto.score.toInt(),
+    subscore: dto.subscore.toInt(),
+    numScore: dto.numScore.toInt(),
+    metadata: PlatformNormalizer.normalizeNullableString(dto.metadata),
+    createTime: dto.createTime.hasNanos() ? dto.createTime.toDateTime() : null,
+    updateTime: dto.updateTime.hasNanos() ? dto.updateTime.toDateTime() : null,
+    expiryTime: dto.expiryTime.hasNanos() ? dto.expiryTime.toDateTime() : null,
+    rank: dto.rank.toInt(),
+    maxNumScore: dto.maxNumScore.toInt(),
+  );
 }

--- a/nakama/lib/src/models/match.dart
+++ b/nakama/lib/src/models/match.dart
@@ -24,22 +24,24 @@ sealed class Match with _$Match {
   factory Match.fromJson(Map<String, Object?> json) => _$MatchFromJson(json);
 
   factory Match.fromDto(api.Match dto) => Match(
-        matchId: dto.matchId,
-        authoritative: dto.authoritative,
-        handlerName: PlatformNormalizer.normalizeNullableString(dto.handlerName),
-        label: dto.label.value,
-        size: dto.size,
-        tickRate: dto.tickRate,
-        presences: [],
-      );
+    matchId: dto.matchId,
+    authoritative: dto.authoritative,
+    handlerName: PlatformNormalizer.normalizeNullableString(dto.handlerName),
+    label: dto.label.value,
+    size: dto.size,
+    tickRate: dto.tickRate,
+    presences: [],
+  );
 
   factory Match.fromRtpb(rtpb.Match dto) => Match(
-        matchId: dto.matchId,
-        authoritative: dto.authoritative,
-        label: dto.label.value,
-        size: dto.size,
-        presences: dto.presences.map((e) => UserPresence.fromDto(e)).toList(growable: false),
-      );
+    matchId: dto.matchId,
+    authoritative: dto.authoritative,
+    label: dto.label.value,
+    size: dto.size,
+    presences: dto.presences
+        .map((e) => UserPresence.fromDto(e))
+        .toList(growable: false),
+  );
 }
 
 @freezed
@@ -67,11 +69,13 @@ sealed class Party with _$Party {
   }) = _Party;
 
   factory Party.fromDto(rtpb.Party dto) => Party(
-        partyId: dto.partyId,
-        open: dto.open,
-        maxSize: dto.maxSize,
-        self: UserPresence.fromDto(dto.self),
-        leader: UserPresence.fromDto(dto.leader),
-        presences: dto.presences.map((e) => UserPresence.fromDto(e)).toList(growable: false),
-      );
+    partyId: dto.partyId,
+    open: dto.open,
+    maxSize: dto.maxSize,
+    self: UserPresence.fromDto(dto.self),
+    leader: UserPresence.fromDto(dto.leader),
+    presences: dto.presences
+        .map((e) => UserPresence.fromDto(e))
+        .toList(growable: false),
+  );
 }

--- a/nakama/lib/src/models/matchmaker.dart
+++ b/nakama/lib/src/models/matchmaker.dart
@@ -15,9 +15,8 @@ sealed class MatchmakerTicket with _$MatchmakerTicket {
     required String ticket,
   }) = _MatchmakerTicket;
 
-  factory MatchmakerTicket.fromDto(rtpb.MatchmakerTicket dto) => MatchmakerTicket(
-        ticket: dto.ticket,
-      );
+  factory MatchmakerTicket.fromDto(rtpb.MatchmakerTicket dto) =>
+      MatchmakerTicket(ticket: dto.ticket);
 }
 
 @freezed
@@ -32,10 +31,8 @@ sealed class PartyMatchmakerTicket with _$PartyMatchmakerTicket {
     @JsonKey(name: 'ticket') required String ticket,
   }) = _PartyMatchmakerTicket;
 
-  factory PartyMatchmakerTicket.fromDto(rtpb.PartyMatchmakerTicket dto) => PartyMatchmakerTicket(
-        partyId: dto.partyId,
-        ticket: dto.ticket,
-      );
+  factory PartyMatchmakerTicket.fromDto(rtpb.PartyMatchmakerTicket dto) =>
+      PartyMatchmakerTicket(partyId: dto.partyId, ticket: dto.ticket);
 }
 
 @freezed
@@ -69,12 +66,17 @@ sealed class ChannelPresenceEvent with _$ChannelPresenceEvent {
     @JsonKey(name: 'user_id_two') String? userIdTwo,
   }) = _ChannelPresenceEvent;
 
-  factory ChannelPresenceEvent.fromDto(rtpb.ChannelPresenceEvent dto) => ChannelPresenceEvent(
+  factory ChannelPresenceEvent.fromDto(rtpb.ChannelPresenceEvent dto) =>
+      ChannelPresenceEvent(
         channelId: dto.channelId,
         roomName: dto.roomName,
         groupId: dto.groupId,
-        joins: dto.joins.map((e) => UserPresence.fromDto(e)).toList(growable: false),
-        leaves: dto.leaves.map((e) => UserPresence.fromDto(e)).toList(growable: false),
+        joins: dto.joins
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
+        leaves: dto.leaves
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
         userIdOne: dto.userIdOne,
         userIdTwo: dto.userIdTwo,
       );
@@ -92,13 +94,16 @@ sealed class MatchmakerUser with _$MatchmakerUser {
     @JsonKey(name: 'party_id') required String partyId,
 
     /// String properties.
-    @JsonKey(name: 'string_properties') required Map<String, String> stringProperties,
+    @JsonKey(name: 'string_properties')
+    required Map<String, String> stringProperties,
 
     /// Numeric properties.
-    @JsonKey(name: 'numeric_properties') required Map<String, double> numericProperties,
+    @JsonKey(name: 'numeric_properties')
+    required Map<String, double> numericProperties,
   }) = _MatchmakerUser;
 
-  factory MatchmakerUser.fromDto(rtpb.MatchmakerMatched_MatchmakerUser dto) => MatchmakerUser(
+  factory MatchmakerUser.fromDto(rtpb.MatchmakerMatched_MatchmakerUser dto) =>
+      MatchmakerUser(
         presence: UserPresence.fromDto(dto.presence),
         partyId: dto.partyId,
         stringProperties: dto.stringProperties,
@@ -127,11 +132,14 @@ sealed class MatchmakerMatched with _$MatchmakerMatched {
     @JsonKey(name: 'self') required MatchmakerUser self,
   }) = _MatchmakerMatched;
 
-  factory MatchmakerMatched.fromDto(rtpb.MatchmakerMatched dto) => MatchmakerMatched(
+  factory MatchmakerMatched.fromDto(rtpb.MatchmakerMatched dto) =>
+      MatchmakerMatched(
         ticket: dto.ticket,
         matchId: dto.matchId,
         token: dto.token,
-        users: dto.users.map((e) => MatchmakerUser.fromDto(e)).toList(growable: false),
+        users: dto.users
+            .map((e) => MatchmakerUser.fromDto(e))
+            .toList(growable: false),
         self: MatchmakerUser.fromDto(dto.self),
       );
 }
@@ -158,12 +166,12 @@ sealed class MatchData with _$MatchData {
   }) = _MatchData;
 
   factory MatchData.fromDto(rtpb.MatchData dto) => MatchData(
-        matchId: dto.matchId,
-        presence: UserPresence.fromDto(dto.presence),
-        opCode: dto.opCode.toInt(),
-        data: dto.data,
-        reliable: dto.reliable,
-      );
+    matchId: dto.matchId,
+    presence: UserPresence.fromDto(dto.presence),
+    opCode: dto.opCode.toInt(),
+    data: dto.data,
+    reliable: dto.reliable,
+  );
 }
 
 @freezed
@@ -181,10 +189,15 @@ sealed class MatchPresenceEvent with _$MatchPresenceEvent {
     @JsonKey(name: 'leaves') required List<UserPresence> leaves,
   }) = _MatchPresenceEvent;
 
-  factory MatchPresenceEvent.fromDto(rtpb.MatchPresenceEvent dto) => MatchPresenceEvent(
+  factory MatchPresenceEvent.fromDto(rtpb.MatchPresenceEvent dto) =>
+      MatchPresenceEvent(
         matchId: dto.matchId,
-        joins: dto.joins.map((e) => UserPresence.fromDto(e)).toList(growable: false),
-        leaves: dto.leaves.map((e) => UserPresence.fromDto(e)).toList(growable: false),
+        joins: dto.joins
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
+        leaves: dto.leaves
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
       );
 }
 
@@ -197,19 +210,27 @@ sealed class MatchmakerStats with _$MatchmakerStats {
     @JsonKey(name: 'ticket_count') @Default(0) int ticketCount,
 
     /// The creation time of the oldest currently active matchmaker ticket, if any.
-    @JsonKey(name: 'oldest_ticket_create_time') DateTime? oldestTicketCreateTime,
+    @JsonKey(name: 'oldest_ticket_create_time')
+    DateTime? oldestTicketCreateTime,
 
     /// Recent matchmaker completion times.
-    @JsonKey(name: 'completions') @Default(<MatchmakerCompletionStats>[]) List<MatchmakerCompletionStats> completions,
+    @JsonKey(name: 'completions')
+    @Default(<MatchmakerCompletionStats>[])
+    List<MatchmakerCompletionStats> completions,
   }) = _MatchmakerStats;
 
-  factory MatchmakerStats.fromJson(Map<String, Object?> json) => _$MatchmakerStatsFromJson(json);
+  factory MatchmakerStats.fromJson(Map<String, Object?> json) =>
+      _$MatchmakerStatsFromJson(json);
 
   factory MatchmakerStats.fromDto(api.MatchmakerStats dto) => MatchmakerStats(
-        ticketCount: dto.ticketCount,
-        oldestTicketCreateTime: dto.hasOldestTicketCreateTime() ? dto.oldestTicketCreateTime.toDateTime() : null,
-        completions: dto.completions.map((e) => MatchmakerCompletionStats.fromDto(e)).toList(growable: false),
-      );
+    ticketCount: dto.ticketCount,
+    oldestTicketCreateTime: dto.hasOldestTicketCreateTime()
+        ? dto.oldestTicketCreateTime.toDateTime()
+        : null,
+    completions: dto.completions
+        .map((e) => MatchmakerCompletionStats.fromDto(e))
+        .toList(growable: false),
+  );
 }
 
 @freezed
@@ -224,10 +245,13 @@ sealed class MatchmakerCompletionStats with _$MatchmakerCompletionStats {
     @JsonKey(name: 'complete_time') DateTime? completeTime,
   }) = _MatchmakerCompletionStats;
 
-  factory MatchmakerCompletionStats.fromJson(Map<String, Object?> json) => _$MatchmakerCompletionStatsFromJson(json);
+  factory MatchmakerCompletionStats.fromJson(Map<String, Object?> json) =>
+      _$MatchmakerCompletionStatsFromJson(json);
 
-  factory MatchmakerCompletionStats.fromDto(api.MatchmakerCompletionStats dto) => MatchmakerCompletionStats(
-        createTime: dto.hasCreateTime() ? dto.createTime.toDateTime() : null,
-        completeTime: dto.hasCompleteTime() ? dto.completeTime.toDateTime() : null,
-      );
+  factory MatchmakerCompletionStats.fromDto(
+    api.MatchmakerCompletionStats dto,
+  ) => MatchmakerCompletionStats(
+    createTime: dto.hasCreateTime() ? dto.createTime.toDateTime() : null,
+    completeTime: dto.hasCompleteTime() ? dto.completeTime.toDateTime() : null,
+  );
 }

--- a/nakama/lib/src/models/notification.dart
+++ b/nakama/lib/src/models/notification.dart
@@ -19,17 +19,18 @@ sealed class Notification with _$Notification {
     @JsonKey(name: 'persistent') required bool persistent,
   }) = _Notification;
 
-  factory Notification.fromJson(Map<String, Object?> json) => _$NotificationFromJson(json);
+  factory Notification.fromJson(Map<String, Object?> json) =>
+      _$NotificationFromJson(json);
 
   factory Notification.fromDto(api.Notification dto) => Notification(
-        id: dto.id,
-        code: dto.code,
-        content: PlatformNormalizer.normalizeNullableString(dto.content),
-        subject: PlatformNormalizer.normalizeNullableString(dto.subject),
-        senderId: dto.senderId,
-        createTime: dto.createTime.toDateTime(),
-        persistent: dto.persistent,
-      );
+    id: dto.id,
+    code: dto.code,
+    content: PlatformNormalizer.normalizeNullableString(dto.content),
+    subject: PlatformNormalizer.normalizeNullableString(dto.subject),
+    senderId: dto.senderId,
+    createTime: dto.createTime.toDateTime(),
+    persistent: dto.persistent,
+  );
 }
 
 @freezed
@@ -38,13 +39,19 @@ sealed class NotificationList with _$NotificationList {
 
   const factory NotificationList({
     @JsonKey(name: 'cacheable_cursor') String? cursor,
-    @JsonKey(name: 'notifications') @Default(<Notification>[]) List<Notification> notifications,
+    @JsonKey(name: 'notifications')
+    @Default(<Notification>[])
+    List<Notification> notifications,
   }) = _NotificationList;
 
-  factory NotificationList.fromJson(Map<String, Object?> json) => _$NotificationListFromJson(json);
+  factory NotificationList.fromJson(Map<String, Object?> json) =>
+      _$NotificationListFromJson(json);
 
-  factory NotificationList.fromDto(api.NotificationList dto) => NotificationList(
+  factory NotificationList.fromDto(api.NotificationList dto) =>
+      NotificationList(
         cursor: PlatformNormalizer.normalizeNullableString(dto.cacheableCursor),
-        notifications: dto.notifications.map((e) => Notification.fromDto(e)).toList(growable: false),
+        notifications: dto.notifications
+            .map((e) => Notification.fromDto(e))
+            .toList(growable: false),
       );
 }

--- a/nakama/lib/src/models/party.dart
+++ b/nakama/lib/src/models/party.dart
@@ -26,12 +26,13 @@ sealed class PartyData with _$PartyData {
   }) = _PartyData;
 
   factory PartyData.fromDto(rtpb.PartyData dto) => PartyData(
-        partyId: dto.partyId,
-        presence: UserPresence.fromDto(dto.presence),
-        opCode: dto.opCode.toInt(),
-        data: dto.data,
-      );
+    partyId: dto.partyId,
+    presence: UserPresence.fromDto(dto.presence),
+    opCode: dto.opCode.toInt(),
+    data: dto.data,
+  );
 }
+
 @freezed
 sealed class PartyPresenceEvent with _$PartyPresenceEvent {
   const PartyPresenceEvent._();
@@ -47,7 +48,8 @@ sealed class PartyPresenceEvent with _$PartyPresenceEvent {
     @JsonKey(name: 'leaves') List<UserPresence>? leaves,
   }) = _PartyPresenceEvent;
 
-  factory PartyPresenceEvent.fromDto(rtpb.PartyPresenceEvent dto) => PartyPresenceEvent(
+  factory PartyPresenceEvent.fromDto(rtpb.PartyPresenceEvent dto) =>
+      PartyPresenceEvent(
         partyId: dto.partyId,
         joins: dto.joins.map((e) => UserPresence.fromDto(e)).toList(),
         leaves: dto.leaves.map((e) => UserPresence.fromDto(e)).toList(),
@@ -67,9 +69,9 @@ sealed class PartyLeader with _$PartyLeader {
   }) = _PartyLeader;
 
   factory PartyLeader.fromDto(rtpb.PartyLeader dto) => PartyLeader(
-        partyId: dto.partyId,
-        newLeader: UserPresence.fromDto(dto.presence),
-      );
+    partyId: dto.partyId,
+    newLeader: UserPresence.fromDto(dto.presence),
+  );
 }
 
 @freezed
@@ -81,9 +83,8 @@ sealed class PartyClose with _$PartyClose {
     @JsonKey(name: 'party_id') required String partyId,
   }) = _PartyClose;
 
-  factory PartyClose.fromDto(rtpb.PartyClose dto) => PartyClose(
-        partyId: dto.partyId,
-      );
+  factory PartyClose.fromDto(rtpb.PartyClose dto) =>
+      PartyClose(partyId: dto.partyId);
 }
 
 @freezed
@@ -98,9 +99,12 @@ sealed class PartyJoinRequest with _$PartyJoinRequest {
     @JsonKey(name: 'presences') required List<UserPresence> presences,
   }) = _PartyJoinRequest;
 
-  factory PartyJoinRequest.fromDto(rtpb.PartyJoinRequest dto) => PartyJoinRequest(
+  factory PartyJoinRequest.fromDto(rtpb.PartyJoinRequest dto) =>
+      PartyJoinRequest(
         partyId: dto.partyId,
-        presences: dto.presences.map((e) => UserPresence.fromDto(e)).toList(growable: false),
+        presences: dto.presences
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
       );
 }
 
@@ -110,18 +114,23 @@ sealed class PartyList with _$PartyList {
 
   const factory PartyList({
     /// The parties matching the list request.
-    @JsonKey(name: 'parties') @Default(<PartyListItem>[]) List<PartyListItem> parties,
+    @JsonKey(name: 'parties')
+    @Default(<PartyListItem>[])
+    List<PartyListItem> parties,
 
     /// A cursor for the next page of results, if any.
     @JsonKey(name: 'cursor') String? cursor,
   }) = _PartyList;
 
-  factory PartyList.fromJson(Map<String, Object?> json) => _$PartyListFromJson(json);
+  factory PartyList.fromJson(Map<String, Object?> json) =>
+      _$PartyListFromJson(json);
 
   factory PartyList.fromDto(api.PartyList dto) => PartyList(
-        parties: dto.parties.map((e) => PartyListItem.fromDto(e)).toList(growable: false),
-        cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
-      );
+    parties: dto.parties
+        .map((e) => PartyListItem.fromDto(e))
+        .toList(growable: false),
+    cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
+  );
 }
 
 @freezed
@@ -145,13 +154,14 @@ sealed class PartyListItem with _$PartyListItem {
     @JsonKey(name: 'label') String? label,
   }) = _PartyListItem;
 
-  factory PartyListItem.fromJson(Map<String, Object?> json) => _$PartyListItemFromJson(json);
+  factory PartyListItem.fromJson(Map<String, Object?> json) =>
+      _$PartyListItemFromJson(json);
 
   factory PartyListItem.fromDto(api.Party dto) => PartyListItem(
-        partyId: dto.partyId,
-        open: dto.open,
-        hidden: dto.hidden,
-        maxSize: dto.maxSize,
-        label: PlatformNormalizer.normalizeNullableString(dto.label),
-      );
+    partyId: dto.partyId,
+    open: dto.open,
+    hidden: dto.hidden,
+    maxSize: dto.maxSize,
+    label: PlatformNormalizer.normalizeNullableString(dto.label),
+  );
 }

--- a/nakama/lib/src/models/purchase.dart
+++ b/nakama/lib/src/models/purchase.dart
@@ -18,11 +18,14 @@ sealed class ValidatePurchaseResponse with _$ValidatePurchaseResponse {
     List<ValidatedPurchase> validatedPurchases,
   }) = _ValidatePurchaseResponse;
 
-  factory ValidatePurchaseResponse.fromJson(Map<String, Object?> json) => _$ValidatePurchaseResponseFromJson(json);
+  factory ValidatePurchaseResponse.fromJson(Map<String, Object?> json) =>
+      _$ValidatePurchaseResponseFromJson(json);
 
-  factory ValidatePurchaseResponse.fromDto(api.ValidatePurchaseResponse dto) => ValidatePurchaseResponse(
-        validatedPurchases:
-            dto.validatedPurchases.map((e) => ValidatedPurchase.fromDto(e)).toList(growable: false),
+  factory ValidatePurchaseResponse.fromDto(api.ValidatePurchaseResponse dto) =>
+      ValidatePurchaseResponse(
+        validatedPurchases: dto.validatedPurchases
+            .map((e) => ValidatedPurchase.fromDto(e))
+            .toList(growable: false),
       );
 }
 
@@ -69,18 +72,26 @@ sealed class ValidatedPurchase with _$ValidatedPurchase {
     @JsonKey(name: 'seen_before') @Default(false) bool seenBefore,
   }) = _ValidatedPurchase;
 
-  factory ValidatedPurchase.fromJson(Map<String, Object?> json) => _$ValidatedPurchaseFromJson(json);
+  factory ValidatedPurchase.fromJson(Map<String, Object?> json) =>
+      _$ValidatedPurchaseFromJson(json);
 
-  factory ValidatedPurchase.fromDto(api.ValidatedPurchase dto) => ValidatedPurchase(
+  factory ValidatedPurchase.fromDto(api.ValidatedPurchase dto) =>
+      ValidatedPurchase(
         userId: PlatformNormalizer.normalizeNullableString(dto.userId),
         productId: PlatformNormalizer.normalizeNullableString(dto.productId),
-        transactionId: PlatformNormalizer.normalizeNullableString(dto.transactionId),
+        transactionId: PlatformNormalizer.normalizeNullableString(
+          dto.transactionId,
+        ),
         store: StoreProvider.values[dto.store.value],
-        purchaseTime: dto.hasPurchaseTime() ? dto.purchaseTime.toDateTime() : null,
+        purchaseTime: dto.hasPurchaseTime()
+            ? dto.purchaseTime.toDateTime()
+            : null,
         createTime: dto.hasCreateTime() ? dto.createTime.toDateTime() : null,
         updateTime: dto.hasUpdateTime() ? dto.updateTime.toDateTime() : null,
         refundTime: dto.hasRefundTime() ? dto.refundTime.toDateTime() : null,
-        providerResponse: PlatformNormalizer.normalizeNullableString(dto.providerResponse),
+        providerResponse: PlatformNormalizer.normalizeNullableString(
+          dto.providerResponse,
+        ),
         environment: StoreEnvironment.values[dto.environment.value],
         seenBefore: dto.seenBefore,
       );

--- a/nakama/lib/src/models/response_error.dart
+++ b/nakama/lib/src/models/response_error.dart
@@ -4,15 +4,13 @@ part 'response_error.g.dart';
 
 @JsonSerializable()
 class ResponseError implements Exception {
-  ResponseError({
-    this.code,
-    this.message,
-  });
+  ResponseError({this.code, this.message});
 
   final int? code;
   final String? message;
 
-  factory ResponseError.fromJson(Map<String, dynamic> json) => _$ResponseErrorFromJson(json);
+  factory ResponseError.fromJson(Map<String, dynamic> json) =>
+      _$ResponseErrorFromJson(json);
 
   Map<String, dynamic> toJson() => _$ResponseErrorToJson(this);
 

--- a/nakama/lib/src/models/rpc.dart
+++ b/nakama/lib/src/models/rpc.dart
@@ -7,9 +7,7 @@ part 'rpc.freezed.dart';
 sealed class Rpc with _$Rpc {
   const Rpc._();
 
-  const factory Rpc({
-    required String payload,
-  }) = _Rpc;
+  const factory Rpc({required String payload}) = _Rpc;
 
   factory Rpc.fromDto(api.Rpc dto) => Rpc(payload: dto.payload);
 }

--- a/nakama/lib/src/models/session.dart
+++ b/nakama/lib/src/models/session.dart
@@ -29,7 +29,9 @@ sealed class Session with _$Session {
       token: session.token,
       refreshToken: session.refreshToken,
       created: session.created,
-      vars: token.containsKey('vars') ? token['vars'] as Map<String, String>? : {},
+      vars: token.containsKey('vars')
+          ? token['vars'] as Map<String, String>?
+          : {},
       userId: token['uid'] as String,
       expiresAt: DateTime.fromMillisecondsSinceEpoch(
         (token['exp'] as int) * 1000,
@@ -50,7 +52,9 @@ sealed class Session with _$Session {
       token: session.token!,
       refreshToken: session.refreshToken,
       created: session.created ?? false,
-      vars: token.containsKey('vars') ? token['vars'] as Map<String, String>? : {},
+      vars: token.containsKey('vars')
+          ? token['vars'] as Map<String, String>?
+          : {},
       userId: token['uid'] as String,
       expiresAt: DateTime.fromMillisecondsSinceEpoch(
         (token['exp'] as int) * 1000,

--- a/nakama/lib/src/models/status.dart
+++ b/nakama/lib/src/models/status.dart
@@ -29,14 +29,15 @@ sealed class UserPresence with _$UserPresence {
   }) = _UserPresence;
 
   factory UserPresence.fromDto(rtpb.UserPresence dto) => UserPresence(
-        userId: dto.userId,
-        sessionId: dto.sessionId,
-        username: dto.username,
-        persistence: dto.persistence,
-        status: PlatformNormalizer.normalizeNullableString(dto.status.value),
-      );
+    userId: dto.userId,
+    sessionId: dto.sessionId,
+    username: dto.username,
+    persistence: dto.persistence,
+    status: PlatformNormalizer.normalizeNullableString(dto.status.value),
+  );
 
-  factory UserPresence.fromJson(Map<String, Object?> json) => _$UserPresenceFromJson(json);
+  factory UserPresence.fromJson(Map<String, Object?> json) =>
+      _$UserPresenceFromJson(json);
 }
 
 @freezed
@@ -51,9 +52,14 @@ sealed class StatusPresenceEvent with _$StatusPresenceEvent {
     required List<UserPresence> leaves,
   }) = _StatusPresenceEvent;
 
-  factory StatusPresenceEvent.fromDto(rtpb.StatusPresenceEvent dto) => StatusPresenceEvent(
-        joins: dto.joins.map((e) => UserPresence.fromDto(e)).toList(growable: false),
-        leaves: dto.leaves.map((e) => UserPresence.fromDto(e)).toList(growable: false),
+  factory StatusPresenceEvent.fromDto(rtpb.StatusPresenceEvent dto) =>
+      StatusPresenceEvent(
+        joins: dto.joins
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
+        leaves: dto.leaves
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
       );
 }
 
@@ -76,11 +82,11 @@ sealed class RealtimeStream with _$RealtimeStream {
   }) = _RealtimeStream;
 
   factory RealtimeStream.fromDto(rtpb.Stream dto) => RealtimeStream(
-        mode: dto.mode,
-        subject: dto.subject,
-        subcontext: dto.subcontext,
-        label: dto.label,
-      );
+    mode: dto.mode,
+    subject: dto.subject,
+    subcontext: dto.subcontext,
+    label: dto.label,
+  );
 }
 
 @freezed
@@ -102,11 +108,11 @@ sealed class RealtimeStreamData with _$RealtimeStreamData {
   }) = _RealtimeStreamData;
 
   factory RealtimeStreamData.fromDto(rtpb.StreamData dto) => RealtimeStreamData(
-        stream: RealtimeStream.fromDto(dto.stream),
-        sender: UserPresence.fromDto(dto.sender),
-        data: dto.data,
-        reliable: dto.reliable,
-      );
+    stream: RealtimeStream.fromDto(dto.stream),
+    sender: UserPresence.fromDto(dto.sender),
+    data: dto.data,
+    reliable: dto.reliable,
+  );
 }
 
 @freezed
@@ -124,9 +130,14 @@ sealed class StreamPresenceEvent with _$StreamPresenceEvent {
     required List<UserPresence> leaves,
   }) = _StreamPresenceEvent;
 
-  factory StreamPresenceEvent.fromDto(rtpb.StreamPresenceEvent dto) => StreamPresenceEvent(
+  factory StreamPresenceEvent.fromDto(rtpb.StreamPresenceEvent dto) =>
+      StreamPresenceEvent(
         stream: RealtimeStream.fromDto(dto.stream),
-        joins: dto.joins.map((e) => UserPresence.fromDto(e)).toList(growable: false),
-        leaves: dto.leaves.map((e) => UserPresence.fromDto(e)).toList(growable: false),
+        joins: dto.joins
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
+        leaves: dto.leaves
+            .map((e) => UserPresence.fromDto(e))
+            .toList(growable: false),
       );
 }

--- a/nakama/lib/src/models/storage.dart
+++ b/nakama/lib/src/models/storage.dart
@@ -23,19 +23,20 @@ sealed class StorageObject with _$StorageObject {
     @JsonKey(name: 'update_time') DateTime? updateTime,
   }) = _StorageObject;
 
-  factory StorageObject.fromJson(Map<String, Object?> json) => _$StorageObjectFromJson(json);
+  factory StorageObject.fromJson(Map<String, Object?> json) =>
+      _$StorageObjectFromJson(json);
 
   factory StorageObject.fromDto(api.StorageObject dto) => StorageObject(
-        collection: dto.collection,
-        key: dto.key,
-        userId: PlatformNormalizer.normalizeNullableString(dto.userId),
-        value: dto.value,
-        version: dto.version,
-        permissionRead: StorageReadPermission.values[dto.permissionRead],
-        permissionWrite: StorageWritePermission.values[dto.permissionWrite],
-        createTime: dto.createTime.toDateTime(),
-        updateTime: dto.updateTime.toDateTime(),
-      );
+    collection: dto.collection,
+    key: dto.key,
+    userId: PlatformNormalizer.normalizeNullableString(dto.userId),
+    value: dto.value,
+    version: dto.version,
+    permissionRead: StorageReadPermission.values[dto.permissionRead],
+    permissionWrite: StorageWritePermission.values[dto.permissionWrite],
+    createTime: dto.createTime.toDateTime(),
+    updateTime: dto.updateTime.toDateTime(),
+  );
 }
 
 @freezed
@@ -47,11 +48,15 @@ sealed class StorageObjectList with _$StorageObjectList {
     @Default(<StorageObject>[]) List<StorageObject> objects,
   }) = _StorageObjectList;
 
-  factory StorageObjectList.fromJson(Map<String, Object?> json) => _$StorageObjectListFromJson(json);
+  factory StorageObjectList.fromJson(Map<String, Object?> json) =>
+      _$StorageObjectListFromJson(json);
 
-  factory StorageObjectList.fromDto(api.StorageObjectList dto) => StorageObjectList(
+  factory StorageObjectList.fromDto(api.StorageObjectList dto) =>
+      StorageObjectList(
         cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
-        objects: dto.objects.map((e) => StorageObject.fromDto(e)).toList(growable: false),
+        objects: dto.objects
+            .map((e) => StorageObject.fromDto(e))
+            .toList(growable: false),
       );
 }
 
@@ -66,9 +71,11 @@ sealed class StorageObjectId with _$StorageObjectId {
     @JsonKey(name: 'version') String? version,
   }) = _StorageObjectId;
 
-  factory StorageObjectId.fromJson(Map<String, Object?> json) => _$StorageObjectIdFromJson(json);
+  factory StorageObjectId.fromJson(Map<String, Object?> json) =>
+      _$StorageObjectIdFromJson(json);
 
-  factory StorageObjectId.fromDto(api.DeleteStorageObjectId dto) => StorageObjectId(
+  factory StorageObjectId.fromDto(api.DeleteStorageObjectId dto) =>
+      StorageObjectId(
         collection: dto.collection,
         key: dto.key,
         version: PlatformNormalizer.normalizeNullableString(dto.version),
@@ -88,11 +95,14 @@ sealed class StorageObjectWrite with _$StorageObjectWrite {
     @JsonKey(name: 'permission_write') StorageWritePermission? permissionWrite,
   }) = _StorageObjectWrite;
 
-  factory StorageObjectWrite.fromJson(Map<String, Object?> json) => _$StorageObjectWriteFromJson(json);
+  factory StorageObjectWrite.fromJson(Map<String, Object?> json) =>
+      _$StorageObjectWriteFromJson(json);
 
   api.WriteStorageObject toDto() {
-    final permissionRead = this.permissionRead ?? StorageReadPermission.ownerRead;
-    final permissionWrite = this.permissionWrite ?? StorageWritePermission.ownerWrite;
+    final permissionRead =
+        this.permissionRead ?? StorageReadPermission.ownerRead;
+    final permissionWrite =
+        this.permissionWrite ?? StorageWritePermission.ownerWrite;
     return api.WriteStorageObject(
       collection: collection,
       key: key,

--- a/nakama/lib/src/models/tournament.dart
+++ b/nakama/lib/src/models/tournament.dart
@@ -31,28 +31,29 @@ sealed class Tournament with _$Tournament {
     @JsonKey(name: 'prev_reset') int? prevReset,
   }) = _Tournament;
 
-  factory Tournament.fromJson(Map<String, Object?> json) => _$TournamentFromJson(json);
+  factory Tournament.fromJson(Map<String, Object?> json) =>
+      _$TournamentFromJson(json);
 
   factory Tournament.fromDto(api.Tournament dto) => Tournament(
-        id: dto.id,
-        canEnter: dto.canEnter,
-        category: dto.category,
-        createTime: dto.createTime.hasNanos() ? dto.createTime.toDateTime() : null,
-        endTime: dto.endTime.hasNanos() ? dto.endTime.toDateTime() : null,
-        startTime: dto.startTime.hasNanos() ? dto.startTime.toDateTime() : null,
-        description: PlatformNormalizer.normalizeNullableString(dto.description),
-        duration: dto.duration,
-        endActive: dto.endActive,
-        maxNumScore: dto.maxNumScore,
-        maxSize: dto.maxSize,
-        metadata: PlatformNormalizer.normalizeNullableString(dto.metadata),
-        nextReset: dto.nextReset,
-        prevReset: dto.prevReset,
-        size: dto.size,
-        sortOrder: dto.sortOrder,
-        startActive: dto.startActive,
-        title: PlatformNormalizer.normalizeNullableString(dto.title),
-      );
+    id: dto.id,
+    canEnter: dto.canEnter,
+    category: dto.category,
+    createTime: dto.createTime.hasNanos() ? dto.createTime.toDateTime() : null,
+    endTime: dto.endTime.hasNanos() ? dto.endTime.toDateTime() : null,
+    startTime: dto.startTime.hasNanos() ? dto.startTime.toDateTime() : null,
+    description: PlatformNormalizer.normalizeNullableString(dto.description),
+    duration: dto.duration,
+    endActive: dto.endActive,
+    maxNumScore: dto.maxNumScore,
+    maxSize: dto.maxSize,
+    metadata: PlatformNormalizer.normalizeNullableString(dto.metadata),
+    nextReset: dto.nextReset,
+    prevReset: dto.prevReset,
+    size: dto.size,
+    sortOrder: dto.sortOrder,
+    startActive: dto.startActive,
+    title: PlatformNormalizer.normalizeNullableString(dto.title),
+  );
 }
 
 @freezed
@@ -64,12 +65,15 @@ sealed class TournamentList with _$TournamentList {
     @Default(<Tournament>[]) List<Tournament> tournaments,
   }) = _TournamentList;
 
-  factory TournamentList.fromJson(Map<String, Object?> json) => _$TournamentListFromJson(json);
+  factory TournamentList.fromJson(Map<String, Object?> json) =>
+      _$TournamentListFromJson(json);
 
   factory TournamentList.fromDto(api.TournamentList dto) => TournamentList(
-        tournaments: dto.tournaments.map((e) => Tournament.fromDto(e)).toList(growable: false),
-        cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
-      );
+    tournaments: dto.tournaments
+        .map((e) => Tournament.fromDto(e))
+        .toList(growable: false),
+    cursor: PlatformNormalizer.normalizeNullableString(dto.cursor),
+  );
 }
 
 @freezed
@@ -77,18 +81,30 @@ sealed class TournamentRecordList with _$TournamentRecordList {
   const TournamentRecordList._();
 
   const factory TournamentRecordList({
-    @JsonKey(name: 'records') @Default(<LeaderboardRecord>[]) List<LeaderboardRecord> records,
-    @JsonKey(name: 'owner_records') @Default(<LeaderboardRecord>[]) List<LeaderboardRecord> ownerRecords,
+    @JsonKey(name: 'records')
+    @Default(<LeaderboardRecord>[])
+    List<LeaderboardRecord> records,
+    @JsonKey(name: 'owner_records')
+    @Default(<LeaderboardRecord>[])
+    List<LeaderboardRecord> ownerRecords,
     @JsonKey(name: 'next_cursor') String? nextCursor,
     @JsonKey(name: 'previous_cursor') String? previousCursor,
   }) = _TournamentRecordList;
 
-  factory TournamentRecordList.fromJson(Map<String, Object?> json) => _$TournamentRecordListFromJson(json);
+  factory TournamentRecordList.fromJson(Map<String, Object?> json) =>
+      _$TournamentRecordListFromJson(json);
 
-  factory TournamentRecordList.fromDto(api.TournamentRecordList dto) => TournamentRecordList(
-        records: dto.records.map((e) => LeaderboardRecord.fromDto(e)).toList(growable: false),
-        ownerRecords: dto.ownerRecords.map((e) => LeaderboardRecord.fromDto(e)).toList(growable: false),
+  factory TournamentRecordList.fromDto(api.TournamentRecordList dto) =>
+      TournamentRecordList(
+        records: dto.records
+            .map((e) => LeaderboardRecord.fromDto(e))
+            .toList(growable: false),
+        ownerRecords: dto.ownerRecords
+            .map((e) => LeaderboardRecord.fromDto(e))
+            .toList(growable: false),
         nextCursor: PlatformNormalizer.normalizeNullableString(dto.nextCursor),
-        previousCursor: PlatformNormalizer.normalizeNullableString(dto.prevCursor),
+        previousCursor: PlatformNormalizer.normalizeNullableString(
+          dto.prevCursor,
+        ),
       );
 }

--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -76,23 +76,33 @@ class NakamaRestApiClient extends NakamaBaseClient {
     required String path,
     required bool ssl,
   }) {
-    apiBaseUrl = Uri(host: host, scheme: ssl ? 'https' : 'http', port: port, path: path);
-    final dio = Dio(BaseOptions(baseUrl: apiBaseUrl.toString()));
-    dio.interceptors.add(InterceptorsWrapper(
-      onRequest: (options, handler) {
-        if (_session != null) {
-          options.headers.putIfAbsent('Authorization', () => 'Bearer ${_session!.token}');
-        } else {
-          options.headers.putIfAbsent('Authorization', () => 'Basic ${base64Encode('$serverKey:'.codeUnits)}');
-        }
-
-        handler.next(options);
-      },
-    ));
-    _api = ApiClient(
-      dio,
-      baseUrl: apiBaseUrl.toString(),
+    apiBaseUrl = Uri(
+      host: host,
+      scheme: ssl ? 'https' : 'http',
+      port: port,
+      path: path,
     );
+    final dio = Dio(BaseOptions(baseUrl: apiBaseUrl.toString()));
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          if (_session != null) {
+            options.headers.putIfAbsent(
+              'Authorization',
+              () => 'Bearer ${_session!.token}',
+            );
+          } else {
+            options.headers.putIfAbsent(
+              'Authorization',
+              () => 'Basic ${base64Encode('$serverKey:'.codeUnits)}',
+            );
+          }
+
+          handler.next(options);
+        },
+      ),
+    );
+    _api = ApiClient(dio, baseUrl: apiBaseUrl.toString());
   }
 
   /// Handles errors and returns a [ResponseError] if the error is a [DioException] and the response data is not null.
@@ -153,11 +163,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     _session = null;
     try {
       final session = await _api.authenticateEmail(
-        body: ApiAccountEmail(
-          email: email,
-          password: password,
-          vars: vars,
-        ),
+        body: ApiAccountEmail(email: email, password: password, vars: vars),
         username: username,
         create: create,
       );
@@ -176,11 +182,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }) async {
     try {
       await _api.linkEmail(
-        body: ApiAccountEmail(
-          email: email,
-          password: password,
-          vars: vars,
-        ),
+        body: ApiAccountEmail(email: email, password: password, vars: vars),
       );
     } on Exception catch (e) {
       throw _handleError(e);
@@ -196,11 +198,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }) async {
     try {
       await _api.unlinkEmail(
-        body: ApiAccountEmail(
-          email: email,
-          password: password,
-          vars: vars,
-        ),
+        body: ApiAccountEmail(email: email, password: password, vars: vars),
       );
     } on Exception catch (e) {
       throw _handleError(e);
@@ -270,10 +268,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
     try {
       final session = await _api.authenticateFacebook(
-        body: ApiAccountFacebook(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountFacebook(token: token, vars: vars),
         sync: import,
         create: create,
         username: username,
@@ -293,10 +288,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }) async {
     try {
       await _api.linkFacebook(
-        body: ApiAccountFacebook(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountFacebook(token: token, vars: vars),
         sync: import,
       );
     } on Exception catch (e) {
@@ -312,10 +304,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }) async {
     try {
       await _api.unlinkFacebook(
-        body: ApiAccountFacebook(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountFacebook(token: token, vars: vars),
       );
     } on Exception catch (e) {
       throw _handleError(e);
@@ -333,10 +322,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
     try {
       final session = await _api.authenticateGoogle(
-        body: ApiAccountGoogle(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountGoogle(token: token, vars: vars),
         create: create,
         username: username,
       );
@@ -354,10 +340,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }) async {
     try {
       await _api.linkGoogle(
-        body: ApiAccountGoogle(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountGoogle(token: token, vars: vars),
       );
     } on Exception catch (e) {
       throw _handleError(e);
@@ -372,10 +355,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }) async {
     try {
       await _api.unlinkGoogle(
-        body: ApiAccountGoogle(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountGoogle(token: token, vars: vars),
       );
     } on Exception catch (e) {
       throw _handleError(e);
@@ -393,10 +373,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
     try {
       final session = await _api.authenticateApple(
-        body: ApiAccountApple(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountApple(token: token, vars: vars),
         create: create,
         username: username,
       );
@@ -414,10 +391,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }) async {
     try {
       await _api.linkApple(
-        body: ApiAccountApple(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountApple(token: token, vars: vars),
       );
     } on Exception catch (e) {
       throw _handleError(e);
@@ -432,10 +406,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }) async {
     try {
       await _api.unlinkApple(
-        body: ApiAccountApple(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountApple(token: token, vars: vars),
       );
     } on Exception catch (e) {
       throw _handleError(e);
@@ -711,10 +682,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
     try {
       await _api.importFacebookFriends(
-        body: ApiAccountFacebook(
-          token: token,
-          vars: vars,
-        ),
+        body: ApiAccountFacebook(token: token, vars: vars),
         reset: reset,
       );
     } on Exception catch (e) {
@@ -783,9 +751,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<void> deleteAccount({
-    required model.Session session,
-  }) async {
+  Future<void> deleteAccount({required model.Session session}) async {
     _session = session;
 
     try {
@@ -810,7 +776,10 @@ class NakamaRestApiClient extends NakamaBaseClient {
         facebookIds: facebookIds ?? [],
       );
 
-      return users.users?.map((e) => model.User.fromJson(e.toJson())).toList(growable: false) ?? [];
+      return users.users
+              ?.map((e) => model.User.fromJson(e.toJson()))
+              .toList(growable: false) ??
+          [];
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -827,14 +796,16 @@ class NakamaRestApiClient extends NakamaBaseClient {
       await _api.writeStorageObjects(
         body: ApiWriteStorageObjectsRequest(
           objects: objects
-              .map((e) => ApiWriteStorageObject(
-                    collection: e.collection,
-                    key: e.key,
-                    permissionRead: e.permissionRead?.index ?? 1,
-                    permissionWrite: e.permissionWrite?.index ?? 1,
-                    value: e.value,
-                    version: e.version,
-                  ))
+              .map(
+                (e) => ApiWriteStorageObject(
+                  collection: e.collection,
+                  key: e.key,
+                  permissionRead: e.permissionRead?.index ?? 1,
+                  permissionWrite: e.permissionWrite?.index ?? 1,
+                  value: e.value,
+                  version: e.version,
+                ),
+              )
               .toList(growable: false),
         ),
       );
@@ -878,16 +849,21 @@ class NakamaRestApiClient extends NakamaBaseClient {
       final objects = await _api.readStorageObjects(
         body: ApiReadStorageObjectsRequest(
           objectIds: objectIds
-              .map((e) => ApiReadStorageObjectId(
-                    collection: e.collection,
-                    key: e.key,
-                    userId: e.userId,
-                  ))
+              .map(
+                (e) => ApiReadStorageObjectId(
+                  collection: e.collection,
+                  key: e.key,
+                  userId: e.userId,
+                ),
+              )
               .toList(growable: false),
         ),
       );
 
-      return objects.objects?.map((e) => model.StorageObject.fromJson(e.toJson())).toList(growable: false) ?? [];
+      return objects.objects
+              ?.map((e) => model.StorageObject.fromJson(e.toJson()))
+              .toList(growable: false) ??
+          [];
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -904,11 +880,13 @@ class NakamaRestApiClient extends NakamaBaseClient {
       await _api.deleteStorageObjects(
         body: ApiDeleteStorageObjectsRequest(
           objectIds: objectIds
-              .map((e) => ApiDeleteStorageObjectId(
-                    collection: e.collection,
-                    key: e.key,
-                    version: e.version,
-                  ))
+              .map(
+                (e) => ApiDeleteStorageObjectId(
+                  collection: e.collection,
+                  key: e.key,
+                  version: e.version,
+                ),
+              )
               .toList(growable: false),
         ),
       );
@@ -958,7 +936,9 @@ class NakamaRestApiClient extends NakamaBaseClient {
         ownerIds: ownerIds ?? [],
         limit: limit,
         cursor: cursor,
-        expiry: expiry == null ? null : (expiry.millisecondsSinceEpoch ~/ 1000).toString(),
+        expiry: expiry == null
+            ? null
+            : (expiry.millisecondsSinceEpoch ~/ 1000).toString(),
       );
 
       return model.LeaderboardRecordList.fromJson(res.toJson());
@@ -982,7 +962,9 @@ class NakamaRestApiClient extends NakamaBaseClient {
         leaderboardId: leaderboardName,
         ownerId: ownerId,
         limit: limit,
-        expiry: expiry == null ? null : (expiry.millisecondsSinceEpoch ~/ 1000).toString(),
+        expiry: expiry == null
+            ? null
+            : (expiry.millisecondsSinceEpoch ~/ 1000).toString(),
       );
 
       return model.LeaderboardRecordList.fromJson(res.toJson());
@@ -1004,13 +986,14 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
     try {
       final res = await _api.writeLeaderboardRecord(
-          leaderboardId: leaderboardName,
-          body: WriteLeaderboardRecordRequestLeaderboardRecordWrite(
-            score: score.toString(),
-            subscore: (subscore ?? 0).toString(),
-            metadata: metadata,
-            operator: ApiOperator.values[operator?.index ?? 0],
-          ));
+        leaderboardId: leaderboardName,
+        body: WriteLeaderboardRecordRequestLeaderboardRecordWrite(
+          score: score.toString(),
+          subscore: (subscore ?? 0).toString(),
+          metadata: metadata,
+          operator: ApiOperator.values[operator?.index ?? 0],
+        ),
+      );
 
       return model.LeaderboardRecord.fromJson(res.toJson());
     } on Exception catch (e) {
@@ -1078,10 +1061,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     _session = session;
 
     try {
-      final res = await _api.listFriendsOfFriends(
-        cursor: cursor,
-        limit: limit,
-      );
+      final res = await _api.listFriendsOfFriends(cursor: cursor, limit: limit);
 
       return model.FriendsOfFriendsList.fromJson(res.toJson());
     } on Exception catch (e) {
@@ -1098,10 +1078,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     _session = session;
 
     try {
-      await _api.deleteFriends(
-        ids: ids,
-        usernames: usernames ?? [],
-      );
+      await _api.deleteFriends(ids: ids, usernames: usernames ?? []);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1116,10 +1093,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     _session = session;
 
     try {
-      await _api.blockFriends(
-        ids: ids,
-        usernames: usernames ?? [],
-      );
+      await _api.blockFriends(ids: ids, usernames: usernames ?? []);
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1449,15 +1423,18 @@ class NakamaRestApiClient extends NakamaBaseClient {
         query: query,
       );
 
-      return res.matches?.map((e) {
-        final json = e.toJson();
-        json['runtimeType'] = 'default';
-        // Handle null values that are required fields in the domain model
-        json['authoritative'] ??= false;
-        json['label'] ??= '';
-        json['presences'] ??= <Map<String, dynamic>>[];
-        return model.Match.fromJson(json);
-      }).toList(growable: false) ?? [];
+      return res.matches
+              ?.map((e) {
+                final json = e.toJson();
+                json['runtimeType'] = 'default';
+                // Handle null values that are required fields in the domain model
+                json['authoritative'] ??= false;
+                json['label'] ??= '';
+                json['presences'] ??= <Map<String, dynamic>>[];
+                return model.Match.fromJson(json);
+              })
+              .toList(growable: false) ??
+          [];
     } on Exception catch (e) {
       throw _handleError(e);
     }
@@ -1494,8 +1471,12 @@ class NakamaRestApiClient extends NakamaBaseClient {
         categoryStart: categoryStart,
         categoryEnd: categoryEnd,
         cursor: cursor,
-        startTime: startTime != null ? startTime.millisecondsSinceEpoch ~/ 1000 : null,
-        endTime: endTime != null ? endTime.millisecondsSinceEpoch ~/ 1000 : null,
+        startTime: startTime != null
+            ? startTime.millisecondsSinceEpoch ~/ 1000
+            : null,
+        endTime: endTime != null
+            ? endTime.millisecondsSinceEpoch ~/ 1000
+            : null,
         limit: limit,
       );
 

--- a/nakama/lib/src/nakama_client/nakama_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_client.dart
@@ -443,9 +443,7 @@ abstract class NakamaBaseClient {
   /// Delete the current user's account.
   ///
   /// [session] The session for the user.
-  Future<void> deleteAccount({
-    required model.Session session,
-  });
+  Future<void> deleteAccount({required model.Session session});
 
   /// Fetch one or more users by id, usernames, or Facebook ids.
   ///

--- a/nakama/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_grpc_client.dart
@@ -86,7 +86,9 @@ class NakamaGrpcClient extends NakamaBaseClient {
       host,
       port: port,
       options: ChannelOptions(
-        credentials: ssl == true ? const ChannelCredentials.secure() : const ChannelCredentials.insecure(),
+        credentials: ssl == true
+            ? const ChannelCredentials.secure()
+            : const ChannelCredentials.insecure(),
       ),
     );
 
@@ -101,9 +103,8 @@ class NakamaGrpcClient extends NakamaBaseClient {
   /// Use with cation, API can change every time.
   NakamaClient get rawGrpcClient => _client;
 
-  CallOptions _getSessionCallOptions(model.Session session) => CallOptions(
-        metadata: {'authorization': 'Bearer ${session.token}'},
-      );
+  CallOptions _getSessionCallOptions(model.Session session) =>
+      CallOptions(metadata: {'authorization': 'Bearer ${session.token}'});
 
   @override
   Future<model.Session> sessionRefresh({
@@ -111,7 +112,10 @@ class NakamaGrpcClient extends NakamaBaseClient {
     Map<String, String>? vars,
   }) async {
     final res = await _client.sessionRefresh(
-      api.SessionRefreshRequest(token: session.refreshToken, vars: vars?.entries),
+      api.SessionRefreshRequest(
+        token: session.refreshToken,
+        vars: vars?.entries,
+      ),
     );
 
     return model.Session.fromDto(res);
@@ -174,10 +178,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       ..password = password
       ..vars.addAll(vars ?? {});
 
-    await _client.linkEmail(
-      request,
-      options: _getSessionCallOptions(session),
-    );
+    await _client.linkEmail(request, options: _getSessionCallOptions(session));
   }
 
   @override
@@ -230,10 +231,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       ..id = deviceId
       ..vars.addAll(vars ?? {});
 
-    await _client.linkDevice(
-      request,
-      options: _getSessionCallOptions(session),
-    );
+    await _client.linkDevice(request, options: _getSessionCallOptions(session));
   }
 
   @override
@@ -343,10 +341,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       ..token = token
       ..vars.addAll(vars ?? {});
 
-    await _client.linkApple(
-      request,
-      options: _getSessionCallOptions(session),
-    );
+    await _client.linkApple(request, options: _getSessionCallOptions(session));
   }
 
   @override
@@ -451,10 +446,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       ..token = token
       ..vars.addAll(vars ?? {});
 
-    await _client.linkGoogle(
-      request,
-      options: _getSessionCallOptions(session),
-    );
+    await _client.linkGoogle(request, options: _getSessionCallOptions(session));
   }
 
   @override
@@ -594,10 +586,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
         ..token = token
         ..vars.addAll(vars ?? {}));
 
-    await _client.linkSteam(
-      request,
-      options: _getSessionCallOptions(session),
-    );
+    await _client.linkSteam(request, options: _getSessionCallOptions(session));
   }
 
   @override
@@ -613,10 +602,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
         ..token = token
         ..vars.addAll(vars ?? {}));
 
-    await _client.linkSteam(
-      request,
-      options: _getSessionCallOptions(session),
-    );
+    await _client.linkSteam(request, options: _getSessionCallOptions(session));
   }
 
   @override
@@ -651,10 +637,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       ..id = id
       ..vars.addAll(vars ?? {});
 
-    await _client.linkCustom(
-      request,
-      options: _getSessionCallOptions(session),
-    );
+    await _client.linkCustom(request, options: _getSessionCallOptions(session));
   }
 
   @override
@@ -667,10 +650,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
       ..id = id
       ..vars.addAll(vars ?? {});
 
-    await _client.linkCustom(
-      request,
-      options: _getSessionCallOptions(session),
-    );
+    await _client.linkCustom(request, options: _getSessionCallOptions(session));
   }
 
   @override
@@ -696,7 +676,9 @@ class NakamaGrpcClient extends NakamaBaseClient {
     await _client.updateAccount(
       api.UpdateAccountRequest(
         username: username == null ? null : api.StringValue(value: username),
-        displayName: displayName == null ? null : api.StringValue(value: displayName),
+        displayName: displayName == null
+            ? null
+            : api.StringValue(value: displayName),
         avatarUrl: avatarUrl == null ? null : api.StringValue(value: avatarUrl),
         langTag: langTag == null ? null : api.StringValue(value: langTag),
         location: location == null ? null : api.StringValue(value: location),
@@ -707,9 +689,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<void> deleteAccount({
-    required model.Session session,
-  }) async {
+  Future<void> deleteAccount({required model.Session session}) async {
     await _client.deleteAccount(
       api.Empty(),
       options: _getSessionCallOptions(session),
@@ -796,7 +776,11 @@ class NakamaGrpcClient extends NakamaBaseClient {
         ownerIds: ownerIds,
         limit: api.Int32Value(value: limit),
         cursor: cursor,
-        expiry: expiry == null ? null : api.Int64Value(value: Int64(expiry.millisecondsSinceEpoch ~/ 1000)),
+        expiry: expiry == null
+            ? null
+            : api.Int64Value(
+                value: Int64(expiry.millisecondsSinceEpoch ~/ 1000),
+              ),
       ),
       options: _getSessionCallOptions(session),
     );
@@ -819,7 +803,11 @@ class NakamaGrpcClient extends NakamaBaseClient {
         leaderboardId: leaderboardName,
         ownerId: ownerId,
         limit: api.UInt32Value(value: limit),
-        expiry: expiry == null ? null : api.Int64Value(value: Int64(expiry.millisecondsSinceEpoch ~/ 1000)),
+        expiry: expiry == null
+            ? null
+            : api.Int64Value(
+                value: Int64(expiry.millisecondsSinceEpoch ~/ 1000),
+              ),
       ),
       options: _getSessionCallOptions(session),
     );
@@ -858,9 +846,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required String leaderboardName,
   }) async {
     await _client.deleteLeaderboardRecord(
-      api.DeleteLeaderboardRecordRequest(
-        leaderboardId: leaderboardName,
-      ),
+      api.DeleteLeaderboardRecordRequest(leaderboardId: leaderboardName),
       options: _getSessionCallOptions(session),
     );
   }
@@ -872,10 +858,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     List<String>? ids,
   }) async {
     await _client.addFriends(
-      api.AddFriendsRequest(
-        usernames: usernames,
-        ids: ids,
-      ),
+      api.AddFriendsRequest(usernames: usernames, ids: ids),
       options: _getSessionCallOptions(session),
     );
   }
@@ -891,7 +874,9 @@ class NakamaGrpcClient extends NakamaBaseClient {
       api.ListFriendsRequest(
         cursor: cursor,
         limit: api.Int32Value(value: limit),
-        state: friendshipState == null ? null : api.Int32Value(value: friendshipState.index),
+        state: friendshipState == null
+            ? null
+            : api.Int32Value(value: friendshipState.index),
       ),
       options: _getSessionCallOptions(session),
     );
@@ -923,10 +908,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     List<String>? ids,
   }) async {
     await _client.deleteFriends(
-      api.DeleteFriendsRequest(
-        ids: ids,
-        usernames: usernames,
-      ),
+      api.DeleteFriendsRequest(ids: ids, usernames: usernames),
       options: _getSessionCallOptions(session),
     );
   }
@@ -938,10 +920,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     List<String>? ids,
   }) async {
     await _client.blockFriends(
-      api.BlockFriendsRequest(
-        ids: ids,
-        usernames: usernames,
-      ),
+      api.BlockFriendsRequest(ids: ids, usernames: usernames),
       options: _getSessionCallOptions(session),
     );
   }
@@ -985,7 +964,9 @@ class NakamaGrpcClient extends NakamaBaseClient {
       api.UpdateGroupRequest(
         groupId: groupId,
         avatarUrl: avatarUrl != null ? api.StringValue(value: avatarUrl) : null,
-        description: description != null ? api.StringValue(value: description) : null,
+        description: description != null
+            ? api.StringValue(value: description)
+            : null,
         langTag: langTag != null ? api.StringValue(value: langTag) : null,
         name: name != null ? api.StringValue(value: name) : null,
         open: open != null ? api.BoolValue(value: open) : null,
@@ -1090,10 +1071,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required Iterable<String> userIds,
   }) async {
     await _client.addGroupUsers(
-      api.AddGroupUsersRequest(
-        groupId: groupId,
-        userIds: userIds,
-      ),
+      api.AddGroupUsersRequest(groupId: groupId, userIds: userIds),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1105,10 +1083,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required Iterable<String> userIds,
   }) async {
     await _client.promoteGroupUsers(
-      api.PromoteGroupUsersRequest(
-        groupId: groupId,
-        userIds: userIds,
-      ),
+      api.PromoteGroupUsersRequest(groupId: groupId, userIds: userIds),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1120,10 +1095,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required Iterable<String> userIds,
   }) async {
     await _client.demoteGroupUsers(
-      api.DemoteGroupUsersRequest(
-        groupId: groupId,
-        userIds: userIds,
-      ),
+      api.DemoteGroupUsersRequest(groupId: groupId, userIds: userIds),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1135,10 +1107,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required Iterable<String> userIds,
   }) async {
     await _client.kickGroupUsers(
-      api.KickGroupUsersRequest(
-        groupId: groupId,
-        userIds: userIds,
-      ),
+      api.KickGroupUsersRequest(groupId: groupId, userIds: userIds),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1150,10 +1119,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required Iterable<String> userIds,
   }) async {
     await _client.banGroupUsers(
-      api.BanGroupUsersRequest(
-        groupId: groupId,
-        userIds: userIds,
-      ),
+      api.BanGroupUsersRequest(groupId: groupId, userIds: userIds),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1164,9 +1130,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required String groupId,
   }) async {
     await _client.leaveGroup(
-      api.LeaveGroupRequest(
-        groupId: groupId,
-      ),
+      api.LeaveGroupRequest(groupId: groupId),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1194,9 +1158,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required Iterable<String> notificationIds,
   }) async {
     await _client.deleteNotifications(
-      api.DeleteNotificationsRequest(
-        ids: notificationIds,
-      ),
+      api.DeleteNotificationsRequest(ids: notificationIds),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1213,7 +1175,9 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }) async {
     final res = await _client.listMatches(
       api.ListMatchesRequest(
-        authoritative: authoritative != null ? api.BoolValue(value: authoritative) : null,
+        authoritative: authoritative != null
+            ? api.BoolValue(value: authoritative)
+            : null,
         label: label != null ? api.StringValue(value: label) : null,
         limit: api.Int32Value(value: limit),
         maxSize: maxSize != null ? api.Int32Value(value: maxSize) : null,
@@ -1223,7 +1187,9 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
 
-    return res.matches.map((e) => model.Match.fromDto(e)).toList(growable: false);
+    return res.matches
+        .map((e) => model.Match.fromDto(e))
+        .toList(growable: false);
   }
 
   @override
@@ -1232,9 +1198,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required String tournamentId,
   }) async {
     await _client.joinTournament(
-      api.JoinTournamentRequest(
-        tournamentId: tournamentId,
-      ),
+      api.JoinTournamentRequest(tournamentId: tournamentId),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1251,11 +1215,19 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }) async {
     final res = await _client.listTournaments(
       api.ListTournamentsRequest(
-        categoryEnd: categoryEnd != null ? api.UInt32Value(value: categoryEnd) : null,
-        categoryStart: categoryStart != null ? api.UInt32Value(value: categoryStart) : null,
+        categoryEnd: categoryEnd != null
+            ? api.UInt32Value(value: categoryEnd)
+            : null,
+        categoryStart: categoryStart != null
+            ? api.UInt32Value(value: categoryStart)
+            : null,
         cursor: cursor,
-        startTime: startTime != null ? api.UInt32Value(value: startTime.millisecondsSinceEpoch ~/ 1000) : null,
-        endTime: endTime != null ? api.UInt32Value(value: endTime.millisecondsSinceEpoch ~/ 1000) : null,
+        startTime: startTime != null
+            ? api.UInt32Value(value: startTime.millisecondsSinceEpoch ~/ 1000)
+            : null,
+        endTime: endTime != null
+            ? api.UInt32Value(value: endTime.millisecondsSinceEpoch ~/ 1000)
+            : null,
         limit: api.Int32Value(value: limit),
       ),
       options: _getSessionCallOptions(session),
@@ -1339,9 +1311,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     required String tournamentId,
   }) async {
     await _client.deleteTournamentRecord(
-      api.DeleteTournamentRecordRequest(
-        tournamentId: tournamentId,
-      ),
+      api.DeleteTournamentRecordRequest(tournamentId: tournamentId),
       options: _getSessionCallOptions(session),
     );
   }
@@ -1403,10 +1373,7 @@ class NakamaGrpcClient extends NakamaBaseClient {
     String? payload,
   }) async {
     final res = await _client.rpcFunc(
-      api.Rpc(
-        id: id,
-        payload: payload,
-      ),
+      api.Rpc(id: id, payload: payload),
       options: _getSessionCallOptions(session),
     );
 
@@ -1421,11 +1388,13 @@ class NakamaGrpcClient extends NakamaBaseClient {
     await _client.deleteStorageObjects(
       api.DeleteStorageObjectsRequest(
         objectIds: objectIds
-            .map((e) => api.DeleteStorageObjectId(
-                  collection: e.collection,
-                  key: e.key,
-                  version: e.version,
-                ))
+            .map(
+              (e) => api.DeleteStorageObjectId(
+                collection: e.collection,
+                key: e.key,
+                version: e.version,
+              ),
+            )
             .toList(),
       ),
       options: _getSessionCallOptions(session),
@@ -1440,17 +1409,21 @@ class NakamaGrpcClient extends NakamaBaseClient {
     final res = await _client.readStorageObjects(
       api.ReadStorageObjectsRequest(
         objectIds: objectIds
-            .map((e) => api.ReadStorageObjectId(
-                  collection: e.collection,
-                  key: e.key,
-                  userId: e.userId,
-                ))
+            .map(
+              (e) => api.ReadStorageObjectId(
+                collection: e.collection,
+                key: e.key,
+                userId: e.userId,
+              ),
+            )
             .toList(),
       ),
       options: _getSessionCallOptions(session),
     );
 
-    return res.objects.map((e) => model.StorageObject.fromDto(e)).toList(growable: false);
+    return res.objects
+        .map((e) => model.StorageObject.fromDto(e))
+        .toList(growable: false);
   }
 
   @override
@@ -1467,8 +1440,12 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<void> importFacebookFriends(
-      {required model.Session session, required String token, bool reset = false, Map<String, String>? vars}) async {
+  Future<void> importFacebookFriends({
+    required model.Session session,
+    required String token,
+    bool reset = false,
+    Map<String, String>? vars,
+  }) async {
     await _client.importFacebookFriends(
       api.ImportFacebookFriendsRequest(
         account: AccountFacebook(token: token, vars: vars?.entries),

--- a/nakama/lib/src/nakama_client/stub/api_client.dart
+++ b/nakama/lib/src/nakama_client/stub/api_client.dart
@@ -10,11 +10,10 @@ NakamaBaseClient getNakamaClient({
   int httpPort = 7350,
   int grpcPort = 7349,
   bool ssl = false,
-}) =>
-    NakamaRestApiClient.init(
-      host: host,
-      key: key,
-      port: httpPort,
-      serverKey: serverKey,
-      ssl: ssl,
-    );
+}) => NakamaRestApiClient.init(
+  host: host,
+  key: key,
+  port: httpPort,
+  serverKey: serverKey,
+  ssl: ssl,
+);

--- a/nakama/lib/src/nakama_client/stub/grpc_client.dart
+++ b/nakama/lib/src/nakama_client/stub/grpc_client.dart
@@ -10,11 +10,10 @@ NakamaBaseClient getNakamaClient({
   int httpPort = 7350,
   int grpcPort = 7349,
   bool ssl = false,
-}) =>
-    NakamaGrpcClient.init(
-      host: host,
-      key: key,
-      port: grpcPort,
-      serverKey: serverKey,
-      ssl: ssl,
-    );
+}) => NakamaGrpcClient.init(
+  host: host,
+  key: key,
+  port: grpcPort,
+  serverKey: serverKey,
+  ssl: ssl,
+);

--- a/nakama/lib/src/nakama_client/stub/nakama_client_stub.dart
+++ b/nakama/lib/src/nakama_client/stub/nakama_client_stub.dart
@@ -9,7 +9,6 @@ NakamaBaseClient getNakamaClient({
   int httpPort = 7350,
   int grpcPort = 7349,
   bool ssl = false,
-}) =>
-    throw UnsupportedError(
-      'Nakama is not supported outside IO/JS/WASM runtime.',
-    );
+}) => throw UnsupportedError(
+  'Nakama is not supported outside IO/JS/WASM runtime.',
+);

--- a/nakama/lib/src/nakama_websocket_client.dart
+++ b/nakama/lib/src/nakama_websocket_client.dart
@@ -26,14 +26,20 @@ class NakamaWebsocketClient {
 
   late final WebSocketChannel _channel;
 
-  final _onChannelPresenceController = StreamController<ChannelPresenceEvent>.broadcast();
-  Stream<ChannelPresenceEvent> get onChannelPresence => _onChannelPresenceController.stream;
+  final _onChannelPresenceController =
+      StreamController<ChannelPresenceEvent>.broadcast();
+  Stream<ChannelPresenceEvent> get onChannelPresence =>
+      _onChannelPresenceController.stream;
 
-  final _onMatchmakerMatchedController = StreamController<MatchmakerMatched>.broadcast();
-  Stream<MatchmakerMatched> get onMatchmakerMatched => _onMatchmakerMatchedController.stream;
+  final _onMatchmakerMatchedController =
+      StreamController<MatchmakerMatched>.broadcast();
+  Stream<MatchmakerMatched> get onMatchmakerMatched =>
+      _onMatchmakerMatchedController.stream;
 
-  final _onMatchmakerTicketController = StreamController<MatchmakerTicket>.broadcast();
-  Stream<MatchmakerTicket> get onMatchmakerTicket => _onMatchmakerTicketController.stream;
+  final _onMatchmakerTicketController =
+      StreamController<MatchmakerTicket>.broadcast();
+  Stream<MatchmakerTicket> get onMatchmakerTicket =>
+      _onMatchmakerTicketController.stream;
 
   final _onMatchDataController = StreamController<MatchData>.broadcast();
   Stream<MatchData> get onMatchData => _onMatchDataController.stream;
@@ -44,14 +50,20 @@ class NakamaWebsocketClient {
   final _onPartyCloseController = StreamController<PartyClose>.broadcast();
   Stream<PartyClose> get onPartyClose => _onPartyCloseController.stream;
 
-  final _onPartyJoinRequestController = StreamController<PartyJoinRequest>.broadcast();
-  Stream<PartyJoinRequest> get onPartyJoinRequest => _onPartyJoinRequestController.stream;
+  final _onPartyJoinRequestController =
+      StreamController<PartyJoinRequest>.broadcast();
+  Stream<PartyJoinRequest> get onPartyJoinRequest =>
+      _onPartyJoinRequestController.stream;
 
-  final _onPartyMatchmakerTicketController = StreamController<PartyMatchmakerTicket>.broadcast();
-  Stream<PartyMatchmakerTicket> get onPartyMatchmakerTicket => _onPartyMatchmakerTicketController.stream;
+  final _onPartyMatchmakerTicketController =
+      StreamController<PartyMatchmakerTicket>.broadcast();
+  Stream<PartyMatchmakerTicket> get onPartyMatchmakerTicket =>
+      _onPartyMatchmakerTicketController.stream;
 
-  final _onPartyPresenceController = StreamController<PartyPresenceEvent>.broadcast();
-  Stream<PartyPresenceEvent> get onPartyPresence => _onPartyPresenceController.stream;
+  final _onPartyPresenceController =
+      StreamController<PartyPresenceEvent>.broadcast();
+  Stream<PartyPresenceEvent> get onPartyPresence =>
+      _onPartyPresenceController.stream;
 
   final _onPartyLeaderController = StreamController<PartyLeader>.broadcast();
   Stream<PartyLeader> get onPartyLeader => _onPartyLeaderController.stream;
@@ -59,23 +71,32 @@ class NakamaWebsocketClient {
   final _onPartyDataController = StreamController<PartyData>.broadcast();
   Stream<PartyData> get onPartyData => _onPartyDataController.stream;
 
-  final _onMatchPresenceController = StreamController<MatchPresenceEvent>.broadcast();
-  Stream<MatchPresenceEvent> get onMatchPresence => _onMatchPresenceController.stream;
+  final _onMatchPresenceController =
+      StreamController<MatchPresenceEvent>.broadcast();
+  Stream<MatchPresenceEvent> get onMatchPresence =>
+      _onMatchPresenceController.stream;
 
   final _onNotificationsController = StreamController<Notification>.broadcast();
   Stream<Notification> get onNotifications => _onNotificationsController.stream;
 
-  final _onStatusPresenceController = StreamController<StatusPresenceEvent>.broadcast();
-  Stream<StatusPresenceEvent> get onStatusPresence => _onStatusPresenceController.stream;
+  final _onStatusPresenceController =
+      StreamController<StatusPresenceEvent>.broadcast();
+  Stream<StatusPresenceEvent> get onStatusPresence =>
+      _onStatusPresenceController.stream;
 
-  final _onStreamPresenceController = StreamController<StreamPresenceEvent>.broadcast();
-  Stream<StreamPresenceEvent> get onStreamPresence => _onStreamPresenceController.stream;
+  final _onStreamPresenceController =
+      StreamController<StreamPresenceEvent>.broadcast();
+  Stream<StreamPresenceEvent> get onStreamPresence =>
+      _onStreamPresenceController.stream;
 
-  final _onStreamDataController = StreamController<RealtimeStreamData>.broadcast();
+  final _onStreamDataController =
+      StreamController<RealtimeStreamData>.broadcast();
   Stream<RealtimeStreamData> get onStreamData => _onStreamDataController.stream;
 
-  final _onChannelMessageController = StreamController<api.ChannelMessage>.broadcast();
-  Stream<api.ChannelMessage> get onChannelMessage => _onChannelMessageController.stream;
+  final _onChannelMessageController =
+      StreamController<api.ChannelMessage>.broadcast();
+  Stream<api.ChannelMessage> get onChannelMessage =>
+      _onChannelMessageController.stream;
 
   final List<Completer> _futures = [];
 
@@ -133,10 +154,7 @@ class NakamaWebsocketClient {
       port: port,
       scheme: ssl ? 'wss' : 'ws',
       path: '/ws',
-      queryParameters: {
-        'token': token,
-        'format': 'protobuf',
-      },
+      queryParameters: {'token': token, 'format': 'protobuf'},
     );
     _channel = WebSocketChannel.connect(uri);
     _log.info('connected');
@@ -215,43 +233,78 @@ class NakamaWebsocketClient {
         // map server messages
         switch (receivedEnvelope.whichMessage()) {
           case rtpb.Envelope_Message.channelPresenceEvent:
-            return _onChannelPresenceController
-                .add(ChannelPresenceEvent.fromDto(receivedEnvelope.channelPresenceEvent));
+            return _onChannelPresenceController.add(
+              ChannelPresenceEvent.fromDto(
+                receivedEnvelope.channelPresenceEvent,
+              ),
+            );
           case rtpb.Envelope_Message.matchmakerMatched:
-            return _onMatchmakerMatchedController.add(MatchmakerMatched.fromDto(receivedEnvelope.matchmakerMatched));
+            return _onMatchmakerMatchedController.add(
+              MatchmakerMatched.fromDto(receivedEnvelope.matchmakerMatched),
+            );
           case rtpb.Envelope_Message.matchmakerTicket:
-            return _onMatchmakerTicketController.add(MatchmakerTicket.fromDto(receivedEnvelope.matchmakerTicket));
+            return _onMatchmakerTicketController.add(
+              MatchmakerTicket.fromDto(receivedEnvelope.matchmakerTicket),
+            );
           case rtpb.Envelope_Message.matchData:
-            return _onMatchDataController.add(MatchData.fromDto(receivedEnvelope.matchData));
+            return _onMatchDataController.add(
+              MatchData.fromDto(receivedEnvelope.matchData),
+            );
           case rtpb.Envelope_Message.partyData:
-            return _onPartyDataController.add(PartyData.fromDto(receivedEnvelope.partyData));
+            return _onPartyDataController.add(
+              PartyData.fromDto(receivedEnvelope.partyData),
+            );
           case rtpb.Envelope_Message.partyPresenceEvent:
-            return _onPartyPresenceController.add(PartyPresenceEvent.fromDto(receivedEnvelope.partyPresenceEvent));
+            return _onPartyPresenceController.add(
+              PartyPresenceEvent.fromDto(receivedEnvelope.partyPresenceEvent),
+            );
           case rtpb.Envelope_Message.partyLeader:
-            return _onPartyLeaderController.add(PartyLeader.fromDto(receivedEnvelope.partyLeader));
+            return _onPartyLeaderController.add(
+              PartyLeader.fromDto(receivedEnvelope.partyLeader),
+            );
           case rtpb.Envelope_Message.party:
-            return _onPartyController.add(Party.fromDto(receivedEnvelope.party));
+            return _onPartyController.add(
+              Party.fromDto(receivedEnvelope.party),
+            );
           case rtpb.Envelope_Message.partyClose:
-            return _onPartyCloseController.add(PartyClose.fromDto(receivedEnvelope.partyClose));
+            return _onPartyCloseController.add(
+              PartyClose.fromDto(receivedEnvelope.partyClose),
+            );
           case rtpb.Envelope_Message.partyJoinRequest:
-            return _onPartyJoinRequestController.add(PartyJoinRequest.fromDto(receivedEnvelope.partyJoinRequest));
+            return _onPartyJoinRequestController.add(
+              PartyJoinRequest.fromDto(receivedEnvelope.partyJoinRequest),
+            );
           case rtpb.Envelope_Message.partyMatchmakerTicket:
-            return _onPartyMatchmakerTicketController.add(PartyMatchmakerTicket.fromDto(receivedEnvelope.partyMatchmakerTicket));
+            return _onPartyMatchmakerTicketController.add(
+              PartyMatchmakerTicket.fromDto(
+                receivedEnvelope.partyMatchmakerTicket,
+              ),
+            );
           case rtpb.Envelope_Message.matchPresenceEvent:
-            return _onMatchPresenceController.add(MatchPresenceEvent.fromDto(receivedEnvelope.matchPresenceEvent));
+            return _onMatchPresenceController.add(
+              MatchPresenceEvent.fromDto(receivedEnvelope.matchPresenceEvent),
+            );
           case rtpb.Envelope_Message.notifications:
             receivedEnvelope.notifications.notifications
                 .map((e) => Notification.fromDto(e))
                 .forEach((element) => _onNotificationsController.add(element));
             return;
           case rtpb.Envelope_Message.statusPresenceEvent:
-            return _onStatusPresenceController.add(StatusPresenceEvent.fromDto(receivedEnvelope.statusPresenceEvent));
+            return _onStatusPresenceController.add(
+              StatusPresenceEvent.fromDto(receivedEnvelope.statusPresenceEvent),
+            );
           case rtpb.Envelope_Message.streamPresenceEvent:
-            return _onStreamPresenceController.add(StreamPresenceEvent.fromDto(receivedEnvelope.streamPresenceEvent));
+            return _onStreamPresenceController.add(
+              StreamPresenceEvent.fromDto(receivedEnvelope.streamPresenceEvent),
+            );
           case rtpb.Envelope_Message.streamData:
-            return _onStreamDataController.add(RealtimeStreamData.fromDto(receivedEnvelope.streamData));
+            return _onStreamDataController.add(
+              RealtimeStreamData.fromDto(receivedEnvelope.streamData),
+            );
           case rtpb.Envelope_Message.channelMessage:
-            return _onChannelMessageController.add(receivedEnvelope.channelMessage);
+            return _onChannelMessageController.add(
+              receivedEnvelope.channelMessage,
+            );
           default:
             return _log.warning('Not implemented');
         }
@@ -274,8 +327,11 @@ class NakamaWebsocketClient {
     return _futures.length - 1;
   }
 
-  Future updateStatus(String status) =>
-      _send<void>(rtpb.Envelope(statusUpdate: rtpb.StatusUpdate(status: api.StringValue(value: status))));
+  Future updateStatus(String status) => _send<void>(
+    rtpb.Envelope(
+      statusUpdate: rtpb.StatusUpdate(status: api.StringValue(value: status)),
+    ),
+  );
 
   Future<Match> createMatch([String? name]) async {
     final res = await _send<rtpb.Match>(
@@ -290,70 +346,79 @@ class NakamaWebsocketClient {
   /// maximum number of players and can be open to automatically accept players
   /// or closed so that the party leader can accept incoming join requests.
   Future<Party> createParty({int? maxSize, bool? open}) async {
-    final res = await _send<rtpb.Party>(rtpb.Envelope(
-        partyCreate: rtpb.PartyCreate(
-      maxSize: maxSize,
-      open: open,
-    )));
+    final res = await _send<rtpb.Party>(
+      rtpb.Envelope(
+        partyCreate: rtpb.PartyCreate(maxSize: maxSize, open: open),
+      ),
+    );
 
     return Party.fromDto(res);
   }
 
   Future<void> joinParty(String partyId) async {
-    await _send<void>(rtpb.Envelope(partyJoin: rtpb.PartyJoin(partyId: partyId)));
+    await _send<void>(
+      rtpb.Envelope(partyJoin: rtpb.PartyJoin(partyId: partyId)),
+    );
   }
 
   Future<void> promotePartyMember({
     required String partyId,
     required UserPresence newLeader,
   }) async {
-    await _send(rtpb.Envelope(
+    await _send(
+      rtpb.Envelope(
         partyPromote: rtpb.PartyPromote(
-      partyId: partyId,
-      presence: rtpb.UserPresence(
-        userId: newLeader.userId,
-        sessionId: newLeader.sessionId,
-        username: newLeader.username,
-        persistence: newLeader.persistence,
-        status: api.StringValue(value: newLeader.status),
+          partyId: partyId,
+          presence: rtpb.UserPresence(
+            userId: newLeader.userId,
+            sessionId: newLeader.sessionId,
+            username: newLeader.username,
+            persistence: newLeader.persistence,
+            status: api.StringValue(value: newLeader.status),
+          ),
+        ),
       ),
-    )));
+    );
   }
 
   Future<void> leaveParty(String partyId) async {
-    await _send<rtpb.Party>(rtpb.Envelope(
-      partyLeave: rtpb.PartyLeave(partyId: partyId),
-    ));
+    await _send<rtpb.Party>(
+      rtpb.Envelope(partyLeave: rtpb.PartyLeave(partyId: partyId)),
+    );
   }
 
   Future<void> acceptPartyMember(String partyId, UserPresence presence) async {
-    await _send<rtpb.Party>(rtpb.Envelope(
-      partyAccept: rtpb.PartyAccept(
-        partyId: partyId,
-        presence: rtpb.UserPresence(
-          userId: presence.userId,
-          sessionId: presence.sessionId,
-          username: presence.username,
-          persistence: presence.persistence,
-          status: api.StringValue(value: presence.status),
+    await _send<rtpb.Party>(
+      rtpb.Envelope(
+        partyAccept: rtpb.PartyAccept(
+          partyId: partyId,
+          presence: rtpb.UserPresence(
+            userId: presence.userId,
+            sessionId: presence.sessionId,
+            username: presence.username,
+            persistence: presence.persistence,
+            status: api.StringValue(value: presence.status),
+          ),
         ),
       ),
-    ));
+    );
   }
 
   Future<void> removePartyMember(String partyId, UserPresence presence) async {
-    await _send<void>(rtpb.Envelope(
-      partyRemove: rtpb.PartyRemove(
-        partyId: partyId,
-        presence: rtpb.UserPresence(
-          userId: presence.userId,
-          sessionId: presence.sessionId,
-          username: presence.username,
-          persistence: presence.persistence,
-          status: api.StringValue(value: presence.status),
+    await _send<void>(
+      rtpb.Envelope(
+        partyRemove: rtpb.PartyRemove(
+          partyId: partyId,
+          presence: rtpb.UserPresence(
+            userId: presence.userId,
+            sessionId: presence.sessionId,
+            username: presence.username,
+            persistence: presence.persistence,
+            status: api.StringValue(value: presence.status),
+          ),
         ),
       ),
-    ));
+    );
   }
 
   Future<PartyMatchmakerTicket> addMatchmakerParty({
@@ -364,30 +429,34 @@ class NakamaWebsocketClient {
     Map<String, double>? numericProperties,
     Map<String, String>? stringProperties,
   }) async {
-    final res = await _send<rtpb.PartyMatchmakerTicket>(rtpb.Envelope(
+    final res = await _send<rtpb.PartyMatchmakerTicket>(
+      rtpb.Envelope(
         partyMatchmakerAdd: rtpb.PartyMatchmakerAdd(
-      partyId: partyId,
-      minCount: minCount,
-      maxCount: maxCount,
-      query: query,
-      numericProperties: numericProperties?.entries,
-      stringProperties: stringProperties?.entries,
-    )));
+          partyId: partyId,
+          minCount: minCount,
+          maxCount: maxCount,
+          query: query,
+          numericProperties: numericProperties?.entries,
+          stringProperties: stringProperties?.entries,
+        ),
+      ),
+    );
 
     return PartyMatchmakerTicket.fromDto(res);
   }
 
   Future<void> closeParty(String partyId) async {
-    await _send<void>(rtpb.Envelope(
-      partyClose: rtpb.PartyClose(partyId: partyId),
-    ));
+    await _send<void>(
+      rtpb.Envelope(partyClose: rtpb.PartyClose(partyId: partyId)),
+    );
   }
 
-  Future<Match> joinMatch(
-    String matchId, {
-    String? token,
-  }) async {
-    final res = await _send<rtpb.Match>(rtpb.Envelope(matchJoin: rtpb.MatchJoin(matchId: matchId, token: token)));
+  Future<Match> joinMatch(String matchId, {String? token}) async {
+    final res = await _send<rtpb.Match>(
+      rtpb.Envelope(
+        matchJoin: rtpb.MatchJoin(matchId: matchId, token: token),
+      ),
+    );
 
     return Match.fromRtpb(res);
   }
@@ -408,14 +477,17 @@ class NakamaWebsocketClient {
     assert(minCount >= 2);
     assert(maxCount == null || maxCount >= minCount);
 
-    final ticket = await _send<rtpb.MatchmakerTicket>(rtpb.Envelope(
+    final ticket = await _send<rtpb.MatchmakerTicket>(
+      rtpb.Envelope(
         matchmakerAdd: rtpb.MatchmakerAdd(
-      maxCount: maxCount,
-      minCount: minCount,
-      numericProperties: numericProperties?.entries,
-      stringProperties: stringProperties?.entries,
-      query: query,
-    )));
+          maxCount: maxCount,
+          minCount: minCount,
+          numericProperties: numericProperties?.entries,
+          stringProperties: stringProperties?.entries,
+          query: query,
+        ),
+      ),
+    );
 
     return MatchmakerTicket.fromDto(ticket);
   }
@@ -428,7 +500,9 @@ class NakamaWebsocketClient {
 
   Future<Rpc> rpc({required String id, String? payload}) async {
     final res = await _send<api.Rpc>(
-      rtpb.Envelope(rpc: api.Rpc(id: id, payload: payload)),
+      rtpb.Envelope(
+        rpc: api.Rpc(id: id, payload: payload),
+      ),
     );
 
     return Rpc.fromDto(res);
@@ -438,11 +512,11 @@ class NakamaWebsocketClient {
     List<String>? userIds,
     List<String>? usernames,
   }) async {
-    final res = await _send<rtpb.Status>(rtpb.Envelope(
-        statusFollow: rtpb.StatusFollow(
-      userIds: userIds,
-      usernames: usernames,
-    )));
+    final res = await _send<rtpb.Status>(
+      rtpb.Envelope(
+        statusFollow: rtpb.StatusFollow(userIds: userIds, usernames: usernames),
+      ),
+    );
 
     return res.presences.map(UserPresence.fromDto).toList();
   }
@@ -451,10 +525,9 @@ class NakamaWebsocketClient {
     List<String> list, {
     List<String>? userIds,
   }) async {
-    final res = await _send<rtpb.Status>(rtpb.Envelope(
-        statusUnfollow: rtpb.StatusUnfollow(
-      userIds: userIds,
-    )));
+    final res = await _send<rtpb.Status>(
+      rtpb.Envelope(statusUnfollow: rtpb.StatusUnfollow(userIds: userIds)),
+    );
 
     return res.presences.map(UserPresence.fromDto).toList();
   }
@@ -465,21 +538,24 @@ class NakamaWebsocketClient {
     required List<int> data,
     Iterable<UserPresence>? presences,
   }) async {
-    _send<void>(rtpb.Envelope(
+    _send<void>(
+      rtpb.Envelope(
         matchDataSend: rtpb.MatchDataSend(
-      matchId: matchId,
-      opCode: api.Int64(opCode),
-      data: data,
-      presences: presences?.map((e) {
-        return rtpb.UserPresence(
-          userId: e.userId,
-          sessionId: e.sessionId,
-          username: e.username,
-          persistence: e.persistence,
-          status: api.StringValue(value: e.status),
-        );
-      }).toList(),
-    )));
+          matchId: matchId,
+          opCode: api.Int64(opCode),
+          data: data,
+          presences: presences?.map((e) {
+            return rtpb.UserPresence(
+              userId: e.userId,
+              sessionId: e.sessionId,
+              username: e.username,
+              persistence: e.persistence,
+              status: api.StringValue(value: e.status),
+            );
+          }).toList(),
+        ),
+      ),
+    );
   }
 
   Future<List<UserPresence>> sendPartyData({
@@ -487,12 +563,15 @@ class NakamaWebsocketClient {
     required int opCode,
     required List<int> data,
   }) async {
-    final res = await _send<rtpb.Status>(rtpb.Envelope(
+    final res = await _send<rtpb.Status>(
+      rtpb.Envelope(
         partyDataSend: rtpb.PartyDataSend(
-      partyId: partyId,
-      opCode: api.Int64(opCode),
-      data: data,
-    )));
+          partyId: partyId,
+          opCode: api.Int64(opCode),
+          data: data,
+        ),
+      ),
+    );
 
     return res.presences.map(UserPresence.fromDto).toList();
   }
@@ -503,30 +582,30 @@ class NakamaWebsocketClient {
     required bool persistence,
     required bool hidden,
   }) async {
-    final res = await _send<rtpb.Channel>(rtpb.Envelope(
+    final res = await _send<rtpb.Channel>(
+      rtpb.Envelope(
         channelJoin: rtpb.ChannelJoin(
-      target: target,
-      type: () {
-        switch (type) {
-          case ChannelType.room:
-            return rtpb.ChannelJoin_Type.ROOM;
-          case ChannelType.group:
-            return rtpb.ChannelJoin_Type.GROUP;
-          case ChannelType.directMessage:
-            return rtpb.ChannelJoin_Type.DIRECT_MESSAGE;
-        }
-      }()
-          .value,
-      persistence: api.BoolValue(value: persistence),
-      hidden: api.BoolValue(value: hidden),
-    )));
+          target: target,
+          type: () {
+            switch (type) {
+              case ChannelType.room:
+                return rtpb.ChannelJoin_Type.ROOM;
+              case ChannelType.group:
+                return rtpb.ChannelJoin_Type.GROUP;
+              case ChannelType.directMessage:
+                return rtpb.ChannelJoin_Type.DIRECT_MESSAGE;
+            }
+          }().value,
+          persistence: api.BoolValue(value: persistence),
+          hidden: api.BoolValue(value: hidden),
+        ),
+      ),
+    );
 
     return Channel.fromDto(res);
   }
 
-  Future<void> leaveChannel({
-    required String channelId,
-  }) async {
+  Future<void> leaveChannel({required String channelId}) async {
     await _send(
       rtpb.Envelope(channelLeave: rtpb.ChannelLeave(channelId: channelId)),
     );
@@ -536,11 +615,14 @@ class NakamaWebsocketClient {
     required String channelId,
     required Map<String, String> content,
   }) async {
-    final res = await _send<rtpb.ChannelMessageAck>(rtpb.Envelope(
+    final res = await _send<rtpb.ChannelMessageAck>(
+      rtpb.Envelope(
         channelMessageSend: rtpb.ChannelMessageSend(
-      channelId: channelId,
-      content: jsonEncode(content),
-    )));
+          channelId: channelId,
+          content: jsonEncode(content),
+        ),
+      ),
+    );
 
     return ChannelMessageAck.fromDto(res);
   }
@@ -550,12 +632,15 @@ class NakamaWebsocketClient {
     required String messageId,
     required Map<String, String> content,
   }) async {
-    final res = await _send<rtpb.ChannelMessageAck>(rtpb.Envelope(
+    final res = await _send<rtpb.ChannelMessageAck>(
+      rtpb.Envelope(
         channelMessageUpdate: rtpb.ChannelMessageUpdate(
-      channelId: channelId,
-      messageId: messageId,
-      content: jsonEncode(content),
-    )));
+          channelId: channelId,
+          messageId: messageId,
+          content: jsonEncode(content),
+        ),
+      ),
+    );
 
     return ChannelMessageAck.fromDto(res);
   }

--- a/nakama/lib/src/utils/platform_normalizer.dart
+++ b/nakama/lib/src/utils/platform_normalizer.dart
@@ -1,5 +1,5 @@
 /// Utility to handle platform-specific null/empty string inconsistencies.
-/// 
+///
 /// Some properties return null on web but empty strings on native platforms.
 /// This utility normalizes these values for consistent behavior.
 class PlatformNormalizer {

--- a/nakama/pubspec.lock
+++ b/nakama/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f0bb5d1648339c8308cc0b9838d8456b3cfe5c91f9dc1a735b4d003269e5da9a
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
       url: "https://pub.dev"
     source: hosted
-    version: "88.0.0"
+    version: "92.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "0b7b9c329d2879f8f05d6c05b32ee9ec025f39b077864bdb5ac9a7b63418a98f"
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.1"
+    version: "9.0.0"
   ansicolor:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,34 +53,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: dfb67ccc9a78c642193e0c2d94cb9e48c2c818b3178a86097d644acdcde6a8d9
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "04f69b1502f66e22ae7990bbd01eb552b7f12793c4d3ea6e715d0ac5e98bcdac"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.2"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.12.6"
   checked_yaml:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
+      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
@@ -165,26 +165,26 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.0"
+    version: "5.11.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
   faker:
     dependency: "direct dev"
     description:
@@ -221,10 +221,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
+      sha256: f23ea33b3863f119b58ed1b586e881a46bd28715ddcc4dbc33104524e3434131
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.5"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -249,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_cloud:
+    dependency: transitive
+    description:
+      name: google_cloud
+      sha256: b385e20726ef5315d302c5933bfb728103116c5be2d3d17094b01a82da538c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -261,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: googleapis_auth
-      sha256: b81fe352cc4a330b3710d2b7ad258d9bcef6f909bb759b306bf42973a7d046db
+      sha256: ea53b290aaf1fdff615c8d79091b02c9150ff81c48f7f3b7460598c444f3c50a
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.3.3"
   graphs:
     dependency: transitive
     description:
@@ -285,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: hotreloader
-      sha256: bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b
+      sha256: "66871df468fc24eee81f1a0a7cb98acc104716f9b7376d355437b48d633c4ebf"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   http:
     dependency: transitive
     description:
@@ -329,30 +337,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.11.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "33a040668b31b320aafa4822b7b1e177e163fc3c1e835c6750319d4ab23aa6fe"
+      sha256: "44729f5c45748e6748f6b9a57ab8f7e4336edc8ae41fc295070e3814e616a6c0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.1"
+    version: "6.13.0"
   jwt_decoder:
     dependency: "direct main"
     description:
@@ -365,18 +365,18 @@ packages:
     dependency: transitive
     description:
       name: lean_builder
-      sha256: ef5cd5f907157eb7aa87d1704504b5a6386d2cbff88a3c2b3344477bab323ee9
+      sha256: "6af3cfbf34400eb14b89fe20111e5981e7083362f00ea10b9ed2a6e833250d76"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.6"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   logging:
     dependency: "direct main"
     description:
@@ -389,18 +389,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -469,18 +469,18 @@ packages:
     dependency: "direct main"
     description:
       name: retrofit
-      sha256: "7d78824afa6eeeaf6ac58220910ee7a97597b39e93360d4bda230b7c6df45089"
+      sha256: "0f629ed26b2c48c66fe54bd548313c6fdf7955be18bff37e08a46dd3f97f8eaf"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.9.2"
   retrofit_generator:
     dependency: "direct dev"
     description:
       name: retrofit_generator
-      sha256: "56df50afab95199dada9e1afbfe5ec228612d03859b250e5e4846c3ebfe50bf7"
+      sha256: "7ec323f3329ad2ca0bcdc96fe02ec7f2486ecfac6cd2d035b03c398ef6f42308"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.4"
+    version: "10.2.0"
   shelf:
     dependency: transitive
     description:
@@ -517,18 +517,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "9098ab86015c4f1d8af6486b547b11100e73b193e1899015033cb3e14ad20243"
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.2.4"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.8"
+    version: "1.3.12"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -549,10 +549,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -597,26 +597,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8f0eb7fa76b7d05a4f3707e0dbd581babef5b0915ca508b757cf15d0cabb56cb"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.27.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: bad9916601a4f2ef6e4dbc466fb712e4b42cf4917c3fd428b018f51984fce13b
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.13"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -629,10 +629,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
@@ -690,4 +690,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/nakama/test/grpc/account_test.dart
+++ b/nakama/test/grpc/account_test.dart
@@ -12,8 +12,8 @@ void main() {
 
     setUpAll(() async {
       client = getNakamaClient(
-          host: kTestHost,
-          ssl: false,
+        host: kTestHost,
+        ssl: false,
         serverKey: kTestServerKey,
       );
 
@@ -50,8 +50,9 @@ void main() {
 
     test('deleting my account', () async {
       // Use a dedicated user so the shared session is not destroyed.
-      final disposableSession =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final disposableSession = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
       await client.deleteAccount(session: disposableSession);
 

--- a/nakama/test/grpc/friends_test.dart
+++ b/nakama/test/grpc/friends_test.dart
@@ -20,20 +20,19 @@ void main() {
     });
 
     test('lists friends correctly', () async {
-      final otherUserA =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
-      final otherUserB =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final otherUserA = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
+      final otherUserB = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
       await client.addFriends(
         session: session,
         ids: [otherUserA.userId, otherUserB.userId],
       );
 
-      await client.addFriends(
-        session: otherUserA,
-        ids: [session.userId],
-      );
+      await client.addFriends(session: otherUserA, ids: [session.userId]);
 
       final friends = await client.listFriends(session: session);
 
@@ -42,36 +41,31 @@ void main() {
     });
 
     test('lists friends of friends correctly', () async {
-      final userB = await client.authenticateDevice(deviceId: faker.guid.guid());
-      final userC = await client.authenticateDevice(deviceId: faker.guid.guid());
+      final userB = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
+      final userC = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
-      await client.addFriends(
+      await client.addFriends(session: session, ids: [userB.userId]);
+
+      await client.addFriends(session: userB, ids: [session.userId]);
+
+      await client.addFriends(session: userB, ids: [userC.userId]);
+
+      await client.addFriends(session: userC, ids: [userB.userId]);
+
+      final friendsOfFriends = await client.listFriendsOfFriends(
         session: session,
-        ids: [userB.userId],
+        limit: 100,
       );
-
-      await client.addFriends(
-        session: userB,
-        ids: [session.userId],
-      );
-
-      await client.addFriends(
-        session: userB,
-        ids: [userC.userId],
-      );
-
-      await client.addFriends(
-        session: userC,
-        ids: [userB.userId],
-      );
-
-      final friendsOfFriends =
-          await client.listFriendsOfFriends(session: session, limit: 100);
 
       expect(friendsOfFriends, isA<FriendsOfFriendsList>());
       expect(
-        friendsOfFriends.friendsOfFriends
-            .any((entry) => entry.user.id == userC.userId),
+        friendsOfFriends.friendsOfFriends.any(
+          (entry) => entry.user.id == userC.userId,
+        ),
         isTrue,
       );
     });

--- a/nakama/test/grpc/group_test.dart
+++ b/nakama/test/grpc/group_test.dart
@@ -21,19 +21,13 @@ void main() {
 
     test('can create group', () async {
       final name = faker.guid.guid();
-      final result = await client.createGroup(
-        session: session,
-        name: name,
-      );
+      final result = await client.createGroup(session: session, name: name);
 
       expect(result, isA<Group>());
       expect(result.name, equals(name));
 
       // Cleanup created group
-      await client.deleteGroup(
-        session: session,
-        groupId: result.id,
-      );
+      await client.deleteGroup(session: session, groupId: result.id);
     });
 
     test('it can list groups', () async {
@@ -47,18 +41,12 @@ void main() {
       expect(result, isA<GroupList>());
 
       // Cleanup created group
-      await client.deleteGroup(
-        session: session,
-        groupId: group.id,
-      );
+      await client.deleteGroup(session: session, groupId: group.id);
     });
 
     test('it can search group by name', () async {
       final name = faker.guid.guid();
-      final group = await client.createGroup(
-        session: session,
-        name: name,
-      );
+      final group = await client.createGroup(session: session, name: name);
 
       final result = await client.listGroups(session: session, name: name);
 
@@ -66,10 +54,7 @@ void main() {
       expect(result.groups, hasLength(1));
 
       // Cleanup created group
-      await client.deleteGroup(
-        session: session,
-        groupId: group.id,
-      );
+      await client.deleteGroup(session: session, groupId: group.id);
     });
 
     test('correctly lists user\'s groups', () async {
@@ -84,8 +69,9 @@ void main() {
       }
 
       // Create group where user is a member
-      final otherUserSession =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final otherUserSession = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
       final memberGroup = await client.createGroup(
         session: otherUserSession,
         name: faker.guid.guid(),
@@ -107,10 +93,7 @@ void main() {
 
       // Cleanup created groups
       for (final group in groups) {
-        await client.deleteGroup(
-          session: session,
-          groupId: group.id,
-        );
+        await client.deleteGroup(session: session, groupId: group.id);
       }
       await client.deleteGroup(
         session: otherUserSession,
@@ -124,8 +107,9 @@ void main() {
         name: faker.guid.guid(),
       );
 
-      final otherUserSession =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final otherUserSession = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
       await client.addGroupUsers(
         session: session,
@@ -142,10 +126,7 @@ void main() {
       expect(result.groupUsers, hasLength(2));
 
       // Cleanup created group
-      await client.deleteGroup(
-        session: session,
-        groupId: group.id,
-      );
+      await client.deleteGroup(session: session, groupId: group.id);
     });
   });
 }

--- a/nakama/test/grpc/leaderboard_test.dart
+++ b/nakama/test/grpc/leaderboard_test.dart
@@ -24,16 +24,19 @@ void main() {
 
       // Create leaderboard via RPC
       await client.rpc(
-          id: 'create_leaderboard_rpc',
-          session: session,
-          payload: jsonEncode({'id': leaderboardName}));
+        id: 'create_leaderboard_rpc',
+        session: session,
+        payload: jsonEncode({'id': leaderboardName}),
+      );
     });
 
     tearDown(() async {
       // Clean up any records created during tests
       try {
         await client.deleteLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName);
+          session: session,
+          leaderboardName: leaderboardName,
+        );
       } catch (e) {
         // Ignore errors if record doesn't exist
       }
@@ -55,7 +58,10 @@ void main() {
       test('should list leaderboard records with proper structure', () async {
         // First create a record
         final writtenRecord = await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 100);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 100,
+        );
 
         final result = await client.listLeaderboardRecords(
           session: session,
@@ -81,13 +87,15 @@ void main() {
         // Create multiple records with different users
         final sessions = <Session>[];
         for (int i = 0; i < 3; i++) {
-          final tempSession =
-              await client.authenticateDevice(deviceId: faker.guid.guid());
+          final tempSession = await client.authenticateDevice(
+            deviceId: faker.guid.guid(),
+          );
           sessions.add(tempSession);
           await client.writeLeaderboardRecord(
-              session: tempSession,
-              leaderboardName: leaderboardName,
-              score: 50 + i * 10);
+            session: tempSession,
+            leaderboardName: leaderboardName,
+            score: 50 + i * 10,
+          );
         }
 
         final result = await client.listLeaderboardRecords(
@@ -102,7 +110,9 @@ void main() {
         for (final tempSession in sessions) {
           try {
             await client.deleteLeaderboardRecord(
-                session: tempSession, leaderboardName: leaderboardName);
+              session: tempSession,
+              leaderboardName: leaderboardName,
+            );
           } catch (e) {
             // Ignore cleanup errors
           }
@@ -113,7 +123,10 @@ void main() {
     group('Write leaderboard record', () {
       test('should write leaderboard record successfully', () async {
         final result = await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 150);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 150,
+        );
 
         expect(result, isA<LeaderboardRecord>());
         expect(result.ownerId, equals(session.userId));
@@ -124,7 +137,10 @@ void main() {
 
       test('should handle zero score', () async {
         final result = await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 0);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 0,
+        );
 
         expect(result.score, equals(0));
         expect(result.ownerId, equals(session.userId));
@@ -135,7 +151,10 @@ void main() {
       test('should list records around specific owner', () async {
         // Write a record for current user
         await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 500);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 500,
+        );
 
         final result = await client.listLeaderboardRecordsAroundOwner(
           session: session,
@@ -155,7 +174,10 @@ void main() {
 
       test('should handle limit parameter for records around owner', () async {
         await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 250);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 250,
+        );
 
         final result = await client.listLeaderboardRecordsAroundOwner(
           session: session,
@@ -169,8 +191,9 @@ void main() {
 
       test('should return empty when owner has no records', () async {
         // Create a new user that hasn't written any records
-        final newSession =
-            await client.authenticateDevice(deviceId: faker.guid.guid());
+        final newSession = await client.authenticateDevice(
+          deviceId: faker.guid.guid(),
+        );
 
         final result = await client.listLeaderboardRecordsAroundOwner(
           session: session,
@@ -187,27 +210,36 @@ void main() {
       test('should delete leaderboard record successfully', () async {
         // First write a record
         await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 75);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 75,
+        );
 
         // Verify it exists
         final beforeDelete = await client.listLeaderboardRecords(
           session: session,
           leaderboardName: leaderboardName,
         );
-        expect(beforeDelete.records.any((r) => r.ownerId == session.userId),
-            isTrue);
+        expect(
+          beforeDelete.records.any((r) => r.ownerId == session.userId),
+          isTrue,
+        );
 
         // Delete the record
         await client.deleteLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName);
+          session: session,
+          leaderboardName: leaderboardName,
+        );
 
         // Verify it's gone
         final afterDelete = await client.listLeaderboardRecords(
           session: session,
           leaderboardName: leaderboardName,
         );
-        expect(afterDelete.records.any((r) => r.ownerId == session.userId),
-            isFalse);
+        expect(
+          afterDelete.records.any((r) => r.ownerId == session.userId),
+          isFalse,
+        );
       });
     });
 
@@ -223,28 +255,31 @@ void main() {
         );
       });
 
-      test('should throw for invalid tournament id on deleteTournamentRecord',
-          () async {
-        expect(
-          () async => await client.deleteTournamentRecord(
-            session: session,
-            tournamentId: '',
-          ),
-          throwsA(isA<Exception>()),
-        );
-      });
+      test(
+        'should throw for invalid tournament id on deleteTournamentRecord',
+        () async {
+          expect(
+            () async => await client.deleteTournamentRecord(
+              session: session,
+              tournamentId: '',
+            ),
+            throwsA(isA<Exception>()),
+          );
+        },
+      );
 
       test(
-          'should throw for invalid signedRequest on validatePurchaseFacebookInstant',
-          () async {
-        expect(
-          () async => await client.validatePurchaseFacebookInstant(
-            session: session,
-            signedRequest: '',
-          ),
-          throwsA(isA<Exception>()),
-        );
-      });
+        'should throw for invalid signedRequest on validatePurchaseFacebookInstant',
+        () async {
+          expect(
+            () async => await client.validatePurchaseFacebookInstant(
+              session: session,
+              signedRequest: '',
+            ),
+            throwsA(isA<Exception>()),
+          );
+        },
+      );
     });
 
     group('Additional wrappers', () {

--- a/nakama/test/grpc/rpc_test.dart
+++ b/nakama/test/grpc/rpc_test.dart
@@ -18,16 +18,11 @@ void main() {
         serverKey: kTestServerKey,
       );
 
-      session = await client.authenticateDevice(
-        deviceId: faker.guid.guid(),
-      );
+      session = await client.authenticateDevice(deviceId: faker.guid.guid());
     });
 
     test('can call RPC without payload', () async {
-      final result = await client.rpc(
-        session: session,
-        id: 'hello_world',
-      );
+      final result = await client.rpc(session: session, id: 'hello_world');
 
       expect(result, isNotNull);
       final decoded = jsonDecode(result!);

--- a/nakama/test/grpc/session_test.dart
+++ b/nakama/test/grpc/session_test.dart
@@ -18,8 +18,9 @@ void main() {
     });
 
     test('logging out of session works', () async {
-      final session =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final session = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
       await client.sessionLogout(session: session);
 

--- a/nakama/test/grpc/storage_test.dart
+++ b/nakama/test/grpc/storage_test.dart
@@ -49,9 +49,10 @@ void main() {
       );
 
       // Cleanup created object
-      await client.deleteStorageObjects(session: session, objectIds: [
-        const StorageObjectId(collection: 'stats', key: 'scores'),
-      ]);
+      await client.deleteStorageObjects(
+        session: session,
+        objectIds: [const StorageObjectId(collection: 'stats', key: 'scores')],
+      );
     });
 
     test('read storage object', () async {
@@ -146,9 +147,10 @@ void main() {
       expect(res.first.value, equals('{"skill": 100}'));
 
       // Delete object
-      await client.deleteStorageObjects(session: session, objectIds: [
-        const StorageObjectId(collection: 'stats', key: 'skills'),
-      ]);
+      await client.deleteStorageObjects(
+        session: session,
+        objectIds: [const StorageObjectId(collection: 'stats', key: 'skills')],
+      );
 
       final afterRes = await client.readStorageObjects(
         session: session,

--- a/nakama/test/rest/account_test.dart
+++ b/nakama/test/rest/account_test.dart
@@ -48,8 +48,9 @@ void main() {
 
     test('deleting my account', () async {
       // Use a dedicated user so the shared session is not destroyed.
-      final disposableSession =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final disposableSession = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
       await client.deleteAccount(session: disposableSession);
 

--- a/nakama/test/rest/friends_test.dart
+++ b/nakama/test/rest/friends_test.dart
@@ -20,20 +20,19 @@ void main() {
     });
 
     test('lists friends correctly', () async {
-      final otherUserA =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
-      final otherUserB =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final otherUserA = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
+      final otherUserB = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
       await client.addFriends(
         session: session,
         ids: [otherUserA.userId, otherUserB.userId],
       );
 
-      await client.addFriends(
-        session: otherUserA,
-        ids: [session.userId],
-      );
+      await client.addFriends(session: otherUserA, ids: [session.userId]);
 
       final friends = await client.listFriends(session: session);
 
@@ -42,36 +41,31 @@ void main() {
     });
 
     test('lists friends of friends correctly', () async {
-      final userB = await client.authenticateDevice(deviceId: faker.guid.guid());
-      final userC = await client.authenticateDevice(deviceId: faker.guid.guid());
+      final userB = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
+      final userC = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
-      await client.addFriends(
+      await client.addFriends(session: session, ids: [userB.userId]);
+
+      await client.addFriends(session: userB, ids: [session.userId]);
+
+      await client.addFriends(session: userB, ids: [userC.userId]);
+
+      await client.addFriends(session: userC, ids: [userB.userId]);
+
+      final friendsOfFriends = await client.listFriendsOfFriends(
         session: session,
-        ids: [userB.userId],
+        limit: 100,
       );
-
-      await client.addFriends(
-        session: userB,
-        ids: [session.userId],
-      );
-
-      await client.addFriends(
-        session: userB,
-        ids: [userC.userId],
-      );
-
-      await client.addFriends(
-        session: userC,
-        ids: [userB.userId],
-      );
-
-      final friendsOfFriends =
-          await client.listFriendsOfFriends(session: session, limit: 100);
 
       expect(friendsOfFriends, isA<FriendsOfFriendsList>());
       expect(
-        friendsOfFriends.friendsOfFriends
-            .any((entry) => entry.user.id == userC.userId),
+        friendsOfFriends.friendsOfFriends.any(
+          (entry) => entry.user.id == userC.userId,
+        ),
         isTrue,
       );
     });

--- a/nakama/test/rest/group_test.dart
+++ b/nakama/test/rest/group_test.dart
@@ -21,19 +21,13 @@ void main() {
 
     test('can create group', () async {
       final gid = faker.guid.guid();
-      final result = await client.createGroup(
-        session: session,
-        name: gid,
-      );
+      final result = await client.createGroup(session: session, name: gid);
 
       expect(result, isA<Group>());
       expect(result.name, equals(gid));
 
       // Cleanup created group
-      await client.deleteGroup(
-        session: session,
-        groupId: result.id,
-      );
+      await client.deleteGroup(session: session, groupId: result.id);
     });
 
     test('it can list groups', () async {
@@ -46,28 +40,19 @@ void main() {
       expect(groups, isA<GroupList>());
 
       // Cleanup created group
-      await client.deleteGroup(
-        session: session,
-        groupId: group.id,
-      );
+      await client.deleteGroup(session: session, groupId: group.id);
     });
 
     test('it can search group by name', () async {
       final name = faker.guid.guid();
-      final group = await client.createGroup(
-        session: session,
-        name: name,
-      );
+      final group = await client.createGroup(session: session, name: name);
 
       final groups = await client.listGroups(session: session, name: name);
       expect(groups, isA<GroupList>());
       expect(groups.groups, hasLength(1));
 
       // Cleanup created group
-      await client.deleteGroup(
-        session: session,
-        groupId: group.id,
-      );
+      await client.deleteGroup(session: session, groupId: group.id);
     });
 
     test('correctly lists user\'s groups', () async {
@@ -82,8 +67,9 @@ void main() {
       }
 
       // Create group where user is a member
-      final otherUserSession =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final otherUserSession = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
       final memberGroup = await client.createGroup(
         session: otherUserSession,
         name: faker.guid.guid(),
@@ -105,10 +91,7 @@ void main() {
 
       // Cleanup created groups
       for (final group in groups) {
-        await client.deleteGroup(
-          session: session,
-          groupId: group.id,
-        );
+        await client.deleteGroup(session: session, groupId: group.id);
       }
       await client.deleteGroup(
         session: otherUserSession,
@@ -122,8 +105,9 @@ void main() {
         name: faker.guid.guid(),
       );
 
-      final otherUserSession =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final otherUserSession = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
       await client.addGroupUsers(
         session: session,
@@ -140,10 +124,7 @@ void main() {
       expect(result.groupUsers, hasLength(2));
 
       // Cleanup created group
-      await client.deleteGroup(
-        session: session,
-        groupId: group.id,
-      );
+      await client.deleteGroup(session: session, groupId: group.id);
     });
   });
 }

--- a/nakama/test/rest/leaderboard_test.dart
+++ b/nakama/test/rest/leaderboard_test.dart
@@ -24,16 +24,19 @@ void main() {
 
       // Create leaderboard via RPC
       await client.rpc(
-          id: 'create_leaderboard_rpc',
-          session: session,
-          payload: jsonEncode({'id': leaderboardName}));
+        id: 'create_leaderboard_rpc',
+        session: session,
+        payload: jsonEncode({'id': leaderboardName}),
+      );
     });
 
     tearDown(() async {
       // Clean up any records created during tests
       try {
         await client.deleteLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName);
+          session: session,
+          leaderboardName: leaderboardName,
+        );
       } catch (e) {
         // Ignore errors if record doesn't exist
       }
@@ -54,7 +57,10 @@ void main() {
 
       test('should list leaderboard records with proper structure', () async {
         final writtenRecord = await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 100);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 100,
+        );
 
         final result = await client.listLeaderboardRecords(
           session: session,
@@ -78,13 +84,15 @@ void main() {
       test('should handle pagination with limit parameter', () async {
         final sessions = <Session>[];
         for (int i = 0; i < 3; i++) {
-          final tempSession =
-              await client.authenticateDevice(deviceId: faker.guid.guid());
+          final tempSession = await client.authenticateDevice(
+            deviceId: faker.guid.guid(),
+          );
           sessions.add(tempSession);
           await client.writeLeaderboardRecord(
-              session: tempSession,
-              leaderboardName: leaderboardName,
-              score: 50 + i * 10);
+            session: tempSession,
+            leaderboardName: leaderboardName,
+            score: 50 + i * 10,
+          );
         }
 
         final result = await client.listLeaderboardRecords(
@@ -98,7 +106,9 @@ void main() {
         for (final tempSession in sessions) {
           try {
             await client.deleteLeaderboardRecord(
-                session: tempSession, leaderboardName: leaderboardName);
+              session: tempSession,
+              leaderboardName: leaderboardName,
+            );
           } catch (e) {
             // Ignore cleanup errors
           }
@@ -109,7 +119,10 @@ void main() {
     group('Write leaderboard record', () {
       test('should write leaderboard record successfully', () async {
         final result = await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 150);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 150,
+        );
 
         expect(result, isA<LeaderboardRecord>());
         expect(result.ownerId, equals(session.userId));
@@ -120,7 +133,10 @@ void main() {
 
       test('should handle zero score', () async {
         final result = await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 0);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 0,
+        );
 
         expect(result.score, equals(0));
         expect(result.ownerId, equals(session.userId));
@@ -130,7 +146,10 @@ void main() {
     group('List leaderboard records around owner', () {
       test('should list records around specific owner', () async {
         await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 500);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 500,
+        );
 
         final result = await client.listLeaderboardRecordsAroundOwner(
           session: session,
@@ -149,7 +168,10 @@ void main() {
 
       test('should handle limit parameter for records around owner', () async {
         await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 250);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 250,
+        );
 
         final result = await client.listLeaderboardRecordsAroundOwner(
           session: session,
@@ -162,8 +184,9 @@ void main() {
       });
 
       test('should return empty when owner has no records', () async {
-        final newSession =
-            await client.authenticateDevice(deviceId: faker.guid.guid());
+        final newSession = await client.authenticateDevice(
+          deviceId: faker.guid.guid(),
+        );
 
         final result = await client.listLeaderboardRecordsAroundOwner(
           session: session,
@@ -179,24 +202,33 @@ void main() {
     group('Delete leaderboard record', () {
       test('should delete leaderboard record successfully', () async {
         await client.writeLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName, score: 75);
+          session: session,
+          leaderboardName: leaderboardName,
+          score: 75,
+        );
 
         final beforeDelete = await client.listLeaderboardRecords(
           session: session,
           leaderboardName: leaderboardName,
         );
-        expect(beforeDelete.records.any((r) => r.ownerId == session.userId),
-            isTrue);
+        expect(
+          beforeDelete.records.any((r) => r.ownerId == session.userId),
+          isTrue,
+        );
 
         await client.deleteLeaderboardRecord(
-            session: session, leaderboardName: leaderboardName);
+          session: session,
+          leaderboardName: leaderboardName,
+        );
 
         final afterDelete = await client.listLeaderboardRecords(
           session: session,
           leaderboardName: leaderboardName,
         );
-        expect(afterDelete.records.any((r) => r.ownerId == session.userId),
-            isFalse);
+        expect(
+          afterDelete.records.any((r) => r.ownerId == session.userId),
+          isFalse,
+        );
       });
     });
 
@@ -212,28 +244,31 @@ void main() {
         );
       });
 
-      test('should throw for invalid tournament id on deleteTournamentRecord',
-          () async {
-        expect(
-          () async => await client.deleteTournamentRecord(
-            session: session,
-            tournamentId: '',
-          ),
-          throwsA(isA<Exception>()),
-        );
-      });
+      test(
+        'should throw for invalid tournament id on deleteTournamentRecord',
+        () async {
+          expect(
+            () async => await client.deleteTournamentRecord(
+              session: session,
+              tournamentId: '',
+            ),
+            throwsA(isA<Exception>()),
+          );
+        },
+      );
 
       test(
-          'should throw for invalid signedRequest on validatePurchaseFacebookInstant',
-          () async {
-        expect(
-          () async => await client.validatePurchaseFacebookInstant(
-            session: session,
-            signedRequest: '',
-          ),
-          throwsA(isA<Exception>()),
-        );
-      });
+        'should throw for invalid signedRequest on validatePurchaseFacebookInstant',
+        () async {
+          expect(
+            () async => await client.validatePurchaseFacebookInstant(
+              session: session,
+              signedRequest: '',
+            ),
+            throwsA(isA<Exception>()),
+          );
+        },
+      );
     });
 
     group('Additional wrappers', () {

--- a/nakama/test/rest/rpc_test.dart
+++ b/nakama/test/rest/rpc_test.dart
@@ -18,16 +18,11 @@ void main() {
         serverKey: kTestServerKey,
       );
 
-      session = await client.authenticateDevice(
-        deviceId: faker.guid.guid(),
-      );
+      session = await client.authenticateDevice(deviceId: faker.guid.guid());
     });
 
     test('can call RPC without payload', () async {
-      final result = await client.rpc(
-        session: session,
-        id: 'hello_world',
-      );
+      final result = await client.rpc(session: session, id: 'hello_world');
 
       expect(result, isNotNull);
       final decoded = jsonDecode(result!);

--- a/nakama/test/rest/session_test.dart
+++ b/nakama/test/rest/session_test.dart
@@ -18,16 +18,15 @@ void main() {
     });
 
     test('logging out of session works', () async {
-      final session =
-          await client.authenticateDevice(deviceId: faker.guid.guid());
+      final session = await client.authenticateDevice(
+        deviceId: faker.guid.guid(),
+      );
 
       await client.sessionLogout(session: session);
 
       await expectLater(
         client.sessionRefresh(session: session),
-        throwsA(
-          isA<ResponseError>(),
-        ),
+        throwsA(isA<ResponseError>()),
       );
     });
   });

--- a/nakama/test/rest/storage_test.dart
+++ b/nakama/test/rest/storage_test.dart
@@ -47,9 +47,10 @@ void main() {
       );
 
       // Cleanup written objects
-      await client.deleteStorageObjects(session: session, objectIds: [
-        const StorageObjectId(collection: 'stats', key: 'scores'),
-      ]);
+      await client.deleteStorageObjects(
+        session: session,
+        objectIds: [const StorageObjectId(collection: 'stats', key: 'scores')],
+      );
     });
 
     test('read storage object', () async {
@@ -144,9 +145,10 @@ void main() {
       expect(res.first.value, equals('{"skill": 100}'));
 
       // Delete object
-      await client.deleteStorageObjects(session: session, objectIds: [
-        const StorageObjectId(collection: 'stats', key: 'skills'),
-      ]);
+      await client.deleteStorageObjects(
+        session: session,
+        objectIds: [const StorageObjectId(collection: 'stats', key: 'skills')],
+      );
 
       final afterRes = await client.readStorageObjects(
         session: session,

--- a/nakama/test/rt/chat_test.dart
+++ b/nakama/test/rt/chat_test.dart
@@ -186,8 +186,10 @@ void main() {
       );
 
       // Send 40 test messages
-      for (final msg
-          in List.generate(40, (index) => {'message': 'PING $index'})) {
+      for (final msg in List.generate(
+        40,
+        (index) => {'message': 'PING $index'},
+      )) {
         await socket.sendMessage(channelId: senderChannelForA.id, content: msg);
       }
 
@@ -216,8 +218,10 @@ void main() {
       );
 
       // Send 40 test messages
-      for (final msg
-          in List.generate(40, (index) => {'message': 'PING $index'})) {
+      for (final msg in List.generate(
+        40,
+        (index) => {'message': 'PING $index'},
+      )) {
         await socket.sendMessage(channelId: senderChannelForA.id, content: msg);
       }
 
@@ -247,8 +251,10 @@ void main() {
       );
 
       // Send 40 test messages
-      for (final msg
-          in List.generate(40, (index) => {'message': 'PING $index'})) {
+      for (final msg in List.generate(
+        40,
+        (index) => {'message': 'PING $index'},
+      )) {
         await socket.sendMessage(channelId: senderChannelForA.id, content: msg);
       }
 
@@ -304,10 +310,14 @@ void main() {
         );
 
         // Send 20+15 test messages
-        for (final msg
-            in List.generate(20 + 15, (index) => {'message': 'PING $index'})) {
+        for (final msg in List.generate(
+          20 + 15,
+          (index) => {'message': 'PING $index'},
+        )) {
           await cursorSocketA.sendMessage(
-              channelId: senderChannel.id, content: msg);
+            channelId: senderChannel.id,
+            content: msg,
+          );
         }
 
         // Check on B's side

--- a/nakama/test/rt/match_test.dart
+++ b/nakama/test/rt/match_test.dart
@@ -101,19 +101,19 @@ void main() {
       final realtimeData = 'test'.codeUnits;
 
       // B starts listening for match data, A sends some data after B joined
-      b.onMatchData.listen(expectAsync1((matchData) {
-        expect(matchData, isNotNull);
-        expect(matchData.presence?.userId, equals(sessionA.userId));
-        expect(matchData.data, equals(realtimeData));
-      }, count: 1));
+      b.onMatchData.listen(
+        expectAsync1((matchData) {
+          expect(matchData, isNotNull);
+          expect(matchData.presence?.userId, equals(sessionA.userId));
+          expect(matchData.data, equals(realtimeData));
+        }, count: 1),
+      );
 
       // A creates match, B joins
-      await a.createMatch().then((value) => b.joinMatch(value.matchId)).then((value) {
-        a.sendMatchData(
-          matchId: value.matchId,
-          opCode: 0,
-          data: realtimeData,
-        );
+      await a.createMatch().then((value) => b.joinMatch(value.matchId)).then((
+        value,
+      ) {
+        a.sendMatchData(matchId: value.matchId, opCode: 0, data: realtimeData);
       });
     });
   });

--- a/nakama/test/rt/party_test.dart
+++ b/nakama/test/rt/party_test.dart
@@ -90,7 +90,8 @@ void main() {
       expect(
         joinedParty.self.userId,
         equals(sessionB.userId),
-        reason: 'Joined party event should identify the joining socket as self.',
+        reason:
+            'Joined party event should identify the joining socket as self.',
       );
       expect(
         joinedParty.leader.userId,

--- a/nakama/test/rt/status_test.dart
+++ b/nakama/test/rt/status_test.dart
@@ -60,10 +60,12 @@ void main() {
 
       // B now received updates over A's status changes
       const statusText = 'Running some tests...';
-      a.onStatusPresence.listen(expectAsync1((event) {
-        expect(event.joins, hasLength(1));
-        expect(event.joins.first.status, equals(statusText));
-      }, count: 1));
+      a.onStatusPresence.listen(
+        expectAsync1((event) {
+          expect(event.joins, hasLength(1));
+          expect(event.joins.first.status, equals(statusText));
+        }, count: 1),
+      );
 
       await a.updateStatus(statusText);
     });

--- a/nakama/test/utils/platform_normalizer_test.dart
+++ b/nakama/test/utils/platform_normalizer_test.dart
@@ -13,7 +13,10 @@ void main() {
       });
 
       test('should return the string for non-empty input', () {
-        expect(PlatformNormalizer.normalizeNullableString('test'), equals('test'));
+        expect(
+          PlatformNormalizer.normalizeNullableString('test'),
+          equals('test'),
+        );
       });
 
       test('should return the string for whitespace input', () {
@@ -38,7 +41,10 @@ void main() {
 
       test('should parse numeric strings (proto3 int64 encoding)', () {
         expect(PlatformNormalizer.normalizeInt('100'), equals(100));
-        expect(PlatformNormalizer.normalizeInt('9223372036854775807'), equals(9223372036854775807));
+        expect(
+          PlatformNormalizer.normalizeInt('9223372036854775807'),
+          equals(9223372036854775807),
+        );
       });
 
       test('should return 0 for invalid string', () {

--- a/nakama/tool/build-protobuf.sh
+++ b/nakama/tool/build-protobuf.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Prerequisites: protoc (apt: protobuf-compiler / brew: protobuf), dart pub global activate protoc_plugin
 set -e
 
 # Get the absolute path to the tool directory
@@ -35,6 +36,13 @@ cp -r src/api-common-protos/google/api build/google
 
 mkdir -p build/github.com/heroiclabs/nakama-common
 cp -r src/nakama-common/api build/github.com/heroiclabs/nakama-common
+
+# TODO(#186): remove this pin once grpc and protobuf are bumped to ^5.0.0/^6.0.0.
+# protoc_plugin >=25.0.0 emits `package:protobuf/well_known_types/...` imports that require protobuf ^6.0.0,
+# which would break compilation against the current protobuf ^5.1.0 constraint and cost 10 pana points.
+echo "[*] Activating protoc_plugin 24.0.0..."
+dart pub global activate protoc_plugin 24.0.0
+export PATH="$PATH:$HOME/.pub-cache/bin"
 
 echo "[*] Compiling Proto..."
 cd build
@@ -73,7 +81,10 @@ rm -rf .proto-build
 # protoc emits relative imports between generated files, which the repo lints forbid.
 echo "[*] Suppressing always_use_package_imports in generated files..."
 cd "$NAKAMA_DIR/lib/src/api/proto"
-find . -name '*.dart' -exec sed -i '0,/^\/\/ ignore_for_file:/s//\/\/ ignore_for_file: always_use_package_imports\n&/' {} +
+find . -name '*.dart' -exec perl -i -pe '
+  if (!$done && /^\/\/ ignore_for_file:/) { $_ = "// ignore_for_file: always_use_package_imports\n$_"; $done = 1; }
+  $done = 0 if eof;
+' {} +
 
 echo "[*] Format dart files"
 dart format --set-exit-if-changed .

--- a/nakama/tool/build-protobuf.sh
+++ b/nakama/tool/build-protobuf.sh
@@ -70,8 +70,12 @@ echo "[*] Cleanup..."
 cd "$TOOL_DIR"
 rm -rf .proto-build
 
-echo "[*] Format dart files"
+# protoc emits relative imports between generated files, which the repo lints forbid.
+echo "[*] Suppressing always_use_package_imports in generated files..."
 cd "$NAKAMA_DIR/lib/src/api/proto"
+find . -name '*.dart' -exec sed -i '0,/^\/\/ ignore_for_file:/s//\/\/ ignore_for_file: always_use_package_imports\n&/' {} +
+
+echo "[*] Format dart files"
 dart format --set-exit-if-changed .
 
 echo "[+] Done"

--- a/satori/example/lib/features/authentication/views/pages/authentication_page.dart
+++ b/satori/example/lib/features/authentication/views/pages/authentication_page.dart
@@ -39,7 +39,7 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
       );
 
       ref.read(sessionProvider.notifier).state = session;
-      
+
       if (mounted) {
         Navigator.of(context).pushReplacementNamed(Routes.home);
       }

--- a/satori/example/lib/features/events/views/pages/events_page.dart
+++ b/satori/example/lib/features/events/views/pages/events_page.dart
@@ -45,17 +45,20 @@ class _EventsPageState extends ConsumerState<EventsPage> {
 
     try {
       final client = ref.read(satoriClientProvider);
-      
+
       final event = Event(
         name: _eventNameController.text.trim(),
-        value: _eventValueController.text.isNotEmpty ? _eventValueController.text : null,
+        value: _eventValueController.text.isNotEmpty
+            ? _eventValueController.text
+            : null,
         timestamp: DateTime.now().toUtc(),
       );
 
       await client.event(session: session, event: event);
 
       setState(() {
-        _sentEvents.add('${event.name}: ${event.value ?? 'no value'} at ${event.timestamp}');
+        _sentEvents.add(
+            '${event.name}: ${event.value ?? 'no value'} at ${event.timestamp}');
       });
 
       _eventNameController.clear();
@@ -131,12 +134,14 @@ class _EventsPageState extends ConsumerState<EventsPage> {
               runSpacing: 8.0,
               children: [
                 ElevatedButton.icon(
-                  onPressed: () => _setEventExample('achievementUnlocked', 'ACHIEVEMENT_ID'),
+                  onPressed: () =>
+                      _setEventExample('achievementUnlocked', 'ACHIEVEMENT_ID'),
                   icon: const Icon(Icons.emoji_events, size: 16),
                   label: const Text('Achievement Unlocked'),
                 ),
                 ElevatedButton.icon(
-                  onPressed: () => _setEventExample('awardReceived', 'AWARD_ID'),
+                  onPressed: () =>
+                      _setEventExample('awardReceived', 'AWARD_ID'),
                   icon: const Icon(Icons.card_giftcard, size: 16),
                   label: const Text('Award Received'),
                 ),
@@ -151,22 +156,26 @@ class _EventsPageState extends ConsumerState<EventsPage> {
                   label: const Text('Guild Joined'),
                 ),
                 ElevatedButton.icon(
-                  onPressed: () => _setEventExample('guildMemberAccepted', 'MEMBER_ID'),
+                  onPressed: () =>
+                      _setEventExample('guildMemberAccepted', 'MEMBER_ID'),
                   icon: const Icon(Icons.person_add_alt_1, size: 16),
                   label: const Text('Guild Member Accepted'),
                 ),
                 ElevatedButton.icon(
-                  onPressed: () => _setEventExample('guildRewardsClaimed', 'REWARD_ID'),
+                  onPressed: () =>
+                      _setEventExample('guildRewardsClaimed', 'REWARD_ID'),
                   icon: const Icon(Icons.redeem, size: 16),
                   label: const Text('Guild Rewards Claimed'),
                 ),
                 ElevatedButton.icon(
-                  onPressed: () => _setEventExample('guildRoleUpdated', 'ROLE_ID'),
+                  onPressed: () =>
+                      _setEventExample('guildRoleUpdated', 'ROLE_ID'),
                   icon: const Icon(Icons.admin_panel_settings, size: 16),
                   label: const Text('Guild Role Updated'),
                 ),
                 ElevatedButton.icon(
-                  onPressed: () => _setEventExample('inventoryUpdated', 'ITEM_ID'),
+                  onPressed: () =>
+                      _setEventExample('inventoryUpdated', 'ITEM_ID'),
                   icon: const Icon(Icons.inventory, size: 16),
                   label: const Text('Inventory Updated'),
                 ),
@@ -217,7 +226,8 @@ class _EventsPageState extends ConsumerState<EventsPage> {
                         return Card(
                           child: ListTile(
                             leading: const Icon(Icons.event),
-                            title: Text(_sentEvents[_sentEvents.length - 1 - index]),
+                            title: Text(
+                                _sentEvents[_sentEvents.length - 1 - index]),
                           ),
                         );
                       },

--- a/satori/example/lib/features/flags/views/pages/flags_page.dart
+++ b/satori/example/lib/features/flags/views/pages/flags_page.dart
@@ -56,7 +56,7 @@ class _FlagsPageState extends ConsumerState<FlagsPage> {
   @override
   Widget build(BuildContext context) {
     final flags = _flagList?.flags ?? [];
-    
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Feature Flags'),

--- a/satori/example/lib/features/home/views/pages/home_page.dart
+++ b/satori/example/lib/features/home/views/pages/home_page.dart
@@ -38,11 +38,13 @@ class HomePage extends ConsumerWidget {
                     children: [
                       const Text(
                         'Session Info',
-                        style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                        style: TextStyle(
+                            fontSize: 18, fontWeight: FontWeight.bold),
                       ),
                       const SizedBox(height: 8),
                       Text('User ID: ${session.identityId}'),
-                      Text('Session Token: ${session.token.substring(0, 20)}...'),
+                      Text(
+                          'Session Token: ${session.token.substring(0, 20)}...'),
                     ],
                   ),
                 ),
@@ -70,7 +72,8 @@ class HomePage extends ConsumerWidget {
                     title: 'Experiments',
                     description: 'A/B testing experiments',
                     icon: Icons.science,
-                    onTap: () => Navigator.of(context).pushNamed(Routes.experiments),
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(Routes.experiments),
                   ),
                   _FeatureCard(
                     title: 'Flags',
@@ -82,19 +85,22 @@ class HomePage extends ConsumerWidget {
                     title: 'Live Events',
                     description: 'Live operational events',
                     icon: Icons.live_tv,
-                    onTap: () => Navigator.of(context).pushNamed(Routes.liveEvents),
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(Routes.liveEvents),
                   ),
                   _FeatureCard(
                     title: 'Properties',
                     description: 'Manage user properties',
                     icon: Icons.settings,
-                    onTap: () => Navigator.of(context).pushNamed(Routes.properties),
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(Routes.properties),
                   ),
                   _FeatureCard(
                     title: 'Messages',
                     description: 'View scheduled messages',
                     icon: Icons.message,
-                    onTap: () => Navigator.of(context).pushNamed(Routes.messages),
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(Routes.messages),
                   ),
                 ],
               ),
@@ -134,7 +140,8 @@ class _FeatureCard extends StatelessWidget {
               const SizedBox(height: 8),
               Text(
                 title,
-                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                style:
+                    const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 4),

--- a/satori/example/lib/features/live_events/views/pages/live_events_page.dart
+++ b/satori/example/lib/features/live_events/views/pages/live_events_page.dart
@@ -56,7 +56,7 @@ class _LiveEventsPageState extends ConsumerState<LiveEventsPage> {
   @override
   Widget build(BuildContext context) {
     final liveEvents = _liveEventList?.liveEvents ?? [];
-    
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Live Events'),
@@ -117,7 +117,8 @@ class _LiveEventsPageState extends ConsumerState<LiveEventsPage> {
                             if (liveEvent.description?.isNotEmpty == true)
                               Text('Description: ${liveEvent.description}'),
                             if (liveEvent.activeStartTimeSec != null)
-                              Text('Active: ${liveEvent.activeStartTimeSec} - ${liveEvent.activeEndTimeSec ?? 'ongoing'}'),
+                              Text(
+                                  'Active: ${liveEvent.activeStartTimeSec} - ${liveEvent.activeEndTimeSec ?? 'ongoing'}'),
                           ],
                         ),
                         children: [
@@ -133,13 +134,17 @@ class _LiveEventsPageState extends ConsumerState<LiveEventsPage> {
                                 const SizedBox(height: 8),
                                 _buildDetailRow('Name', liveEvent.name),
                                 if (liveEvent.description?.isNotEmpty == true)
-                                  _buildDetailRow('Description', liveEvent.description),
+                                  _buildDetailRow(
+                                      'Description', liveEvent.description),
                                 if (liveEvent.activeStartTimeSec != null)
-                                  _buildDetailRow('Start Time', liveEvent.activeStartTimeSec),
+                                  _buildDetailRow('Start Time',
+                                      liveEvent.activeStartTimeSec),
                                 if (liveEvent.activeEndTimeSec != null)
-                                  _buildDetailRow('End Time', liveEvent.activeEndTimeSec),
+                                  _buildDetailRow(
+                                      'End Time', liveEvent.activeEndTimeSec),
                                 if (liveEvent.value != null)
-                                  _buildDetailRow('Value', liveEvent.value.toString()),
+                                  _buildDetailRow(
+                                      'Value', liveEvent.value.toString()),
                               ],
                             ),
                           ),

--- a/satori/example/lib/features/messages/views/pages/messages_page.dart
+++ b/satori/example/lib/features/messages/views/pages/messages_page.dart
@@ -27,13 +27,13 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
       final client = ref.read(satoriClientProvider);
       final session = ref.read(sessionProvider);
       if (session == null || client is! SatoriRestApiClient) return;
-      
+
       final messages = await client.getMessages(
         session: session,
         limit: 20,
         cursor: loadMore ? _cursor : null,
       );
-      
+
       setState(() {
         if (loadMore) {
           _messages.addAll(messages);
@@ -58,19 +58,19 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
       final client = ref.read(satoriClientProvider);
       final session = ref.read(sessionProvider);
       if (session == null || client is! SatoriRestApiClient) return;
-      
+
       await client.updateMessage(
         session: session,
         id: message.id!,
         readTime: DateTime.now().toUtc().toIso8601String(),
       );
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Message marked as read')),
         );
       }
-      
+
       await _loadMessages();
     } catch (e) {
       if (mounted) {
@@ -86,19 +86,19 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
       final client = ref.read(satoriClientProvider);
       final session = ref.read(sessionProvider);
       if (session == null || client is! SatoriRestApiClient) return;
-      
+
       await client.updateMessage(
         session: session,
         id: message.id!,
         consumeTime: DateTime.now().toUtc().toIso8601String(),
       );
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Message marked as consumed')),
         );
       }
-      
+
       await _loadMessages();
     } catch (e) {
       if (mounted) {
@@ -134,18 +134,18 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
       final client = ref.read(satoriClientProvider);
       final session = ref.read(sessionProvider);
       if (session == null || client is! SatoriRestApiClient) return;
-      
+
       await client.deleteMessage(
         session: session,
         id: message.id!,
       );
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Message deleted')),
         );
       }
-      
+
       await _loadMessages();
     } catch (e) {
       if (mounted) {
@@ -181,7 +181,9 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
                       return Padding(
                         padding: const EdgeInsets.all(16),
                         child: ElevatedButton(
-                          onPressed: _loading ? null : () => _loadMessages(loadMore: true),
+                          onPressed: _loading
+                              ? null
+                              : () => _loadMessages(loadMore: true),
                           child: const Text('Load More'),
                         ),
                       );
@@ -189,7 +191,8 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
 
                     final message = _messages[index];
                     return Card(
-                      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      margin: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 8),
                       child: ExpansionTile(
                         title: Text(message.title ?? 'No Title'),
                         subtitle: Column(
@@ -222,21 +225,31 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
                                 if (message.imageUrl != null) ...[
                                   Image.network(
                                     message.imageUrl!,
-                                    errorBuilder: (context, error, stackTrace) =>
-                                        const Text('Failed to load image'),
+                                    errorBuilder:
+                                        (context, error, stackTrace) =>
+                                            const Text('Failed to load image'),
                                   ),
                                   const SizedBox(height: 16),
                                 ],
-                                _buildInfoRow('Schedule ID', message.scheduleId),
-                                _buildInfoRow('Send Time', message.sendTime?.toString()),
-                                _buildInfoRow('Create Time', message.createTime?.toString()),
-                                _buildInfoRow('Update Time', message.updateTime?.toString()),
-                                _buildInfoRow('Read Time', message.readTime?.toString()),
-                                _buildInfoRow('Consume Time', message.consumeTime?.toString()),
+                                _buildInfoRow(
+                                    'Schedule ID', message.scheduleId),
+                                _buildInfoRow(
+                                    'Send Time', message.sendTime?.toString()),
+                                _buildInfoRow('Create Time',
+                                    message.createTime?.toString()),
+                                _buildInfoRow('Update Time',
+                                    message.updateTime?.toString()),
+                                _buildInfoRow(
+                                    'Read Time', message.readTime?.toString()),
+                                _buildInfoRow('Consume Time',
+                                    message.consumeTime?.toString()),
                                 if (message.metadata?.isNotEmpty == true) ...[
                                   const Divider(),
-                                  const Text('Metadata:', style: TextStyle(fontWeight: FontWeight.bold)),
-                                  ...message.metadata!.entries.map((e) => Text('${e.key}: ${e.value}')),
+                                  const Text('Metadata:',
+                                      style: TextStyle(
+                                          fontWeight: FontWeight.bold)),
+                                  ...message.metadata!.entries
+                                      .map((e) => Text('${e.key}: ${e.value}')),
                                 ],
                                 const SizedBox(height: 16),
                                 Wrap(
@@ -252,7 +265,8 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
                                       ElevatedButton.icon(
                                         icon: const Icon(Icons.check_circle),
                                         label: const Text('Mark Consumed'),
-                                        onPressed: () => _markAsConsumed(message),
+                                        onPressed: () =>
+                                            _markAsConsumed(message),
                                       ),
                                     ElevatedButton.icon(
                                       icon: const Icon(Icons.delete),

--- a/satori/example/lib/features/properties/views/pages/properties_page.dart
+++ b/satori/example/lib/features/properties/views/pages/properties_page.dart
@@ -31,12 +31,14 @@ class _PropertiesPageState extends ConsumerState<PropertiesPage> {
       final client = ref.read(satoriClientProvider);
       final session = ref.read(sessionProvider);
       if (session == null) return;
-      
+
       final properties = await client.listProperties(session: session);
       setState(() {
         // Create mutable copies of the maps
-        _defaultProperties = Map<String, String>.from(properties.$default ?? {});
-        _computedProperties = Map<String, String>.from(properties.computed ?? {});
+        _defaultProperties =
+            Map<String, String>.from(properties.$default ?? {});
+        _computedProperties =
+            Map<String, String>.from(properties.computed ?? {});
       });
     } catch (e) {
       if (mounted) {
@@ -48,8 +50,6 @@ class _PropertiesPageState extends ConsumerState<PropertiesPage> {
       setState(() => _loading = false);
     }
   }
-
-
 
   @override
   Widget build(BuildContext context) {

--- a/satori/example/lib/services/env_service.dart
+++ b/satori/example/lib/services/env_service.dart
@@ -1,10 +1,13 @@
 class EnvService {
   static String get satoriBaseUrl =>
-      const String.fromEnvironment('SATORI_BASE_URL', defaultValue: 'localhost');
-  static String get satoriApiKey => 
+      const String.fromEnvironment('SATORI_BASE_URL',
+          defaultValue: 'localhost');
+  static String get satoriApiKey =>
       const String.fromEnvironment('SATORI_API_KEY', defaultValue: 'apikey');
-  static int get satoriPort =>
-      int.parse(const String.fromEnvironment('SATORI_PORT', defaultValue: '7350'));
+  static int get satoriPort => int.parse(
+      const String.fromEnvironment('SATORI_PORT', defaultValue: '7350'));
   static bool get satoriSsl =>
-      const String.fromEnvironment('SATORI_SSL', defaultValue: 'false').toLowerCase() == 'true';
+      const String.fromEnvironment('SATORI_SSL', defaultValue: 'false')
+          .toLowerCase() ==
+      'true';
 }

--- a/satori/lib/src/models/event.dart
+++ b/satori/lib/src/models/event.dart
@@ -33,7 +33,8 @@ abstract class Event with _$Event {
         name: dto.name,
         id: dto.id,
         metadata: dto.metadata?.cast<String, dynamic>(),
-        timestamp: dto.timestamp != null ? DateTime.parse(dto.timestamp!) : null,
+        timestamp:
+            dto.timestamp != null ? DateTime.parse(dto.timestamp!) : null,
         value: dto.value,
       );
 

--- a/satori/lib/src/models/experiment.dart
+++ b/satori/lib/src/models/experiment.dart
@@ -13,10 +13,12 @@ abstract class ExperimentList with _$ExperimentList {
     required List<Experiment> experiments,
   }) = _ExperimentList;
 
-  factory ExperimentList.fromJson(Map<String, dynamic> json) => _$ExperimentListFromJson(json);
+  factory ExperimentList.fromJson(Map<String, dynamic> json) =>
+      _$ExperimentListFromJson(json);
 
   factory ExperimentList.fromDto(ApiExperimentList dto) => ExperimentList(
-        experiments: dto.experiments!.map((e) => Experiment.fromDto(e)).toList(),
+        experiments:
+            dto.experiments!.map((e) => Experiment.fromDto(e)).toList(),
       );
 }
 
@@ -33,7 +35,8 @@ abstract class Experiment with _$Experiment {
     String? value,
   }) = _Experiment;
 
-  factory Experiment.fromJson(Map<String, dynamic> json) => _$ExperimentFromJson(json);
+  factory Experiment.fromJson(Map<String, dynamic> json) =>
+      _$ExperimentFromJson(json);
 
   factory Experiment.fromDto(ApiExperiment dto) => Experiment(
         name: dto.name,

--- a/satori/lib/src/models/flag.dart
+++ b/satori/lib/src/models/flag.dart
@@ -13,7 +13,8 @@ abstract class FlagList with _$FlagList {
     required List<Flag> flags,
   }) = _FlagList;
 
-  factory FlagList.fromJson(Map<String, dynamic> json) => _$FlagListFromJson(json);
+  factory FlagList.fromJson(Map<String, dynamic> json) =>
+      _$FlagListFromJson(json);
 
   factory FlagList.fromDto(ApiFlagList dto) => FlagList(
         flags: dto.flags!.map((e) => Flag.fromDto(e)).toList(),

--- a/satori/lib/src/models/live_event.dart
+++ b/satori/lib/src/models/live_event.dart
@@ -13,7 +13,8 @@ abstract class LiveEventList with _$LiveEventList {
     required List<LiveEvent> liveEvents,
   }) = _LiveEventList;
 
-  factory LiveEventList.fromJson(Map<String, dynamic> json) => _$LiveEventListFromJson(json);
+  factory LiveEventList.fromJson(Map<String, dynamic> json) =>
+      _$LiveEventListFromJson(json);
 
   factory LiveEventList.fromDto(ApiLiveEventList dto) => LiveEventList(
         liveEvents: dto.liveEvents!.map((e) => LiveEvent.fromDto(e)).toList(),
@@ -42,7 +43,8 @@ abstract class LiveEvent with _$LiveEvent {
     String? value,
   }) = _LiveEvent;
 
-  factory LiveEvent.fromJson(Map<String, dynamic> json) => _$LiveEventFromJson(json);
+  factory LiveEvent.fromJson(Map<String, dynamic> json) =>
+      _$LiveEventFromJson(json);
 
   factory LiveEvent.fromDto(ApiLiveEvent dto) => LiveEvent(
         activeEndTimeSec: dto.activeEndTimeSec,

--- a/satori/lib/src/models/message.dart
+++ b/satori/lib/src/models/message.dart
@@ -23,7 +23,8 @@ abstract class Message with _$Message {
     DateTime? consumeTime,
   }) = _Message;
 
-  factory Message.fromJson(Map<String, dynamic> json) => _$MessageFromJson(json);
+  factory Message.fromJson(Map<String, dynamic> json) =>
+      _$MessageFromJson(json);
 
   factory Message.fromDto(ApiMessage dto) => Message(
         id: dto.id,
@@ -33,9 +34,12 @@ abstract class Message with _$Message {
         imageUrl: dto.imageUrl,
         metadata: dto.metadata,
         sendTime: dto.sendTime != null ? DateTime.parse(dto.sendTime!) : null,
-        createTime: dto.createTime != null ? DateTime.parse(dto.createTime!) : null,
-        updateTime: dto.updateTime != null ? DateTime.parse(dto.updateTime!) : null,
+        createTime:
+            dto.createTime != null ? DateTime.parse(dto.createTime!) : null,
+        updateTime:
+            dto.updateTime != null ? DateTime.parse(dto.updateTime!) : null,
         readTime: dto.readTime != null ? DateTime.parse(dto.readTime!) : null,
-        consumeTime: dto.consumeTime != null ? DateTime.parse(dto.consumeTime!) : null,
+        consumeTime:
+            dto.consumeTime != null ? DateTime.parse(dto.consumeTime!) : null,
       );
 }

--- a/satori/lib/src/models/properties.dart
+++ b/satori/lib/src/models/properties.dart
@@ -20,7 +20,8 @@ abstract class Properties with _$Properties {
     Map<String, String>? computed,
   }) = _Properties;
 
-  factory Properties.fromJson(Map<String, dynamic> json) => _$PropertiesFromJson(json);
+  factory Properties.fromJson(Map<String, dynamic> json) =>
+      _$PropertiesFromJson(json);
 
   factory Properties.fromDto(ApiProperties dto) => Properties(
         $default: dto.defaultValue?.cast<String, String>(),

--- a/satori/lib/src/models/session.dart
+++ b/satori/lib/src/models/session.dart
@@ -30,14 +30,20 @@ abstract class Session with _$Session {
     final token = JwtDecoder.decode(session.token!);
     assert(token.containsKey('iid'));
 
-    final refreshToken = session.refreshToken != null ? JwtDecoder.decode(session.refreshToken!) : null;
-    final refreshExpiresAt = refreshToken != null ? DateTime.fromMillisecondsSinceEpoch((refreshToken['exp'] as int) * 1000) : DateTime.now();
+    final refreshToken = session.refreshToken != null
+        ? JwtDecoder.decode(session.refreshToken!)
+        : null;
+    final refreshExpiresAt = refreshToken != null
+        ? DateTime.fromMillisecondsSinceEpoch(
+            (refreshToken['exp'] as int) * 1000)
+        : DateTime.now();
 
     return Session(
       token: session.token!,
       refreshToken: session.refreshToken ?? '',
       identityId: token['iid'] as String,
-      expiresAt: DateTime.fromMillisecondsSinceEpoch((token['exp'] as int) * 1000),
+      expiresAt:
+          DateTime.fromMillisecondsSinceEpoch((token['exp'] as int) * 1000),
       refreshExpiresAt: refreshExpiresAt,
     );
   }

--- a/satori/lib/src/rest/satori_api.gen.dart
+++ b/satori/lib/src/rest/satori_api.gen.dart
@@ -13,745 +13,760 @@ part 'satori_api.gen.g.dart';
 /// The request to update the status of a message.
 @JsonSerializable(explicitToJson: true)
 class ApiUpdateMessageRequest {
-    @JsonKey(name: 'consume_time')
-    final String? consumeTime;
-    @JsonKey(name: 'read_time')
-    final String? readTime;
-    
-    const ApiUpdateMessageRequest({
-        required this.consumeTime,
-        required this.readTime,
-    });
+  @JsonKey(name: 'consume_time')
+  final String? consumeTime;
+  @JsonKey(name: 'read_time')
+  final String? readTime;
 
-    factory ApiUpdateMessageRequest.fromJson(Map<String, dynamic> json) => _$ApiUpdateMessageRequestFromJson(json);
+  const ApiUpdateMessageRequest({
+    required this.consumeTime,
+    required this.readTime,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiUpdateMessageRequestToJson(this);
+  factory ApiUpdateMessageRequest.fromJson(Map<String, dynamic> json) =>
+      _$ApiUpdateMessageRequestFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiUpdateMessageRequestToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
-/// 
+///
 @JsonSerializable(explicitToJson: true)
 class FlagValueChangeReason {
-    @JsonKey(name: 'name')
-    final String? name;
-    @JsonKey(name: 'type')
-    @FlagValueChangeReasonTypeConverter()
-    final FlagValueChangeReasonType? type;
-    @JsonKey(name: 'variant_name')
-    final String? variantName;
-    
-    const FlagValueChangeReason({
-        required this.name,
-        required this.type,
-        required this.variantName,
-    });
+  @JsonKey(name: 'name')
+  final String? name;
+  @JsonKey(name: 'type')
+  @FlagValueChangeReasonTypeConverter()
+  final FlagValueChangeReasonType? type;
+  @JsonKey(name: 'variant_name')
+  final String? variantName;
 
-    factory FlagValueChangeReason.fromJson(Map<String, dynamic> json) => _$FlagValueChangeReasonFromJson(json);
+  const FlagValueChangeReason({
+    required this.name,
+    required this.type,
+    required this.variantName,
+  });
 
-    Map<String, dynamic> toJson() => _$FlagValueChangeReasonToJson(this);
+  factory FlagValueChangeReason.fromJson(Map<String, dynamic> json) =>
+      _$FlagValueChangeReasonFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$FlagValueChangeReasonToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 enum FlagValueChangeReasonType {
-    @JsonValue('UNKNOWN')
-    unknown,
-    @JsonValue('FLAG_VARIANT')
-    flagVariant,
-    @JsonValue('LIVE_EVENT')
-    liveEvent,
-    @JsonValue('EXPERIMENT')
-    experiment,
+  @JsonValue('UNKNOWN')
+  unknown,
+  @JsonValue('FLAG_VARIANT')
+  flagVariant,
+  @JsonValue('LIVE_EVENT')
+  liveEvent,
+  @JsonValue('EXPERIMENT')
+  experiment,
 }
 
 /// Log out a session, invalidate a refresh token, or log out all sessions/refresh tokens for a user.
 @JsonSerializable(explicitToJson: true)
 class ApiAuthenticateLogoutRequest {
-    @JsonKey(name: 'refresh_token')
-    final String? refreshToken;
-    @JsonKey(name: 'token')
-    final String? token;
-    
-    const ApiAuthenticateLogoutRequest({
-        required this.refreshToken,
-        required this.token,
-    });
+  @JsonKey(name: 'refresh_token')
+  final String? refreshToken;
+  @JsonKey(name: 'token')
+  final String? token;
 
-    factory ApiAuthenticateLogoutRequest.fromJson(Map<String, dynamic> json) => _$ApiAuthenticateLogoutRequestFromJson(json);
+  const ApiAuthenticateLogoutRequest({
+    required this.refreshToken,
+    required this.token,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiAuthenticateLogoutRequestToJson(this);
+  factory ApiAuthenticateLogoutRequest.fromJson(Map<String, dynamic> json) =>
+      _$ApiAuthenticateLogoutRequestFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiAuthenticateLogoutRequestToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// Authenticate against the server with a refresh token.
 @JsonSerializable(explicitToJson: true)
 class ApiAuthenticateRefreshRequest {
-    @JsonKey(name: 'refresh_token')
-    final String? refreshToken;
-    
-    const ApiAuthenticateRefreshRequest({
-        required this.refreshToken,
-    });
+  @JsonKey(name: 'refresh_token')
+  final String? refreshToken;
 
-    factory ApiAuthenticateRefreshRequest.fromJson(Map<String, dynamic> json) => _$ApiAuthenticateRefreshRequestFromJson(json);
+  const ApiAuthenticateRefreshRequest({
+    required this.refreshToken,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiAuthenticateRefreshRequestToJson(this);
+  factory ApiAuthenticateRefreshRequest.fromJson(Map<String, dynamic> json) =>
+      _$ApiAuthenticateRefreshRequestFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiAuthenticateRefreshRequestToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// Authentication request
 @JsonSerializable(explicitToJson: true)
 class ApiAuthenticateRequest {
-    @JsonKey(name: 'custom')
-    final Map<String, String>? custom;
-    @JsonKey(name: 'default')
-    final Map<String, String>? defaultValue;
-    @JsonKey(name: 'id')
-    final String? id;
-    @JsonKey(name: 'no_session')
-    final bool? noSession;
-    
-    const ApiAuthenticateRequest({
-        required this.custom,
-        required this.defaultValue,
-        required this.id,
-        required this.noSession,
-    });
+  @JsonKey(name: 'custom')
+  final Map<String, String>? custom;
+  @JsonKey(name: 'default')
+  final Map<String, String>? defaultValue;
+  @JsonKey(name: 'id')
+  final String? id;
+  @JsonKey(name: 'no_session')
+  final bool? noSession;
 
-    factory ApiAuthenticateRequest.fromJson(Map<String, dynamic> json) => _$ApiAuthenticateRequestFromJson(json);
+  const ApiAuthenticateRequest({
+    required this.custom,
+    required this.defaultValue,
+    required this.id,
+    required this.noSession,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiAuthenticateRequestToJson(this);
+  factory ApiAuthenticateRequest.fromJson(Map<String, dynamic> json) =>
+      _$ApiAuthenticateRequestFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiAuthenticateRequestToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// A single event. Usually, but not necessarily, part of a batch.
 @JsonSerializable(explicitToJson: true)
 class ApiEvent {
-    @JsonKey(name: 'id')
-    final String? id;
-    @JsonKey(name: 'metadata')
-    final Map<String, String>? metadata;
-    @JsonKey(name: 'name')
-    final String? name;
-    @JsonKey(name: 'timestamp')
-    final String? timestamp;
-    @JsonKey(name: 'value')
-    final String? value;
-    
-    const ApiEvent({
-        required this.id,
-        required this.metadata,
-        required this.name,
-        required this.timestamp,
-        required this.value,
-    });
+  @JsonKey(name: 'id')
+  final String? id;
+  @JsonKey(name: 'metadata')
+  final Map<String, String>? metadata;
+  @JsonKey(name: 'name')
+  final String? name;
+  @JsonKey(name: 'timestamp')
+  final String? timestamp;
+  @JsonKey(name: 'value')
+  final String? value;
 
-    factory ApiEvent.fromJson(Map<String, dynamic> json) => _$ApiEventFromJson(json);
+  const ApiEvent({
+    required this.id,
+    required this.metadata,
+    required this.name,
+    required this.timestamp,
+    required this.value,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiEventToJson(this);
+  factory ApiEvent.fromJson(Map<String, dynamic> json) =>
+      _$ApiEventFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiEventToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// Publish an event to the server
 @JsonSerializable(explicitToJson: true)
 class ApiEventRequest {
-    @JsonKey(name: 'events')
-    final List<ApiEvent>? events;
-    
-    const ApiEventRequest({
-        required this.events,
-    });
+  @JsonKey(name: 'events')
+  final List<ApiEvent>? events;
 
-    factory ApiEventRequest.fromJson(Map<String, dynamic> json) => _$ApiEventRequestFromJson(json);
+  const ApiEventRequest({
+    required this.events,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiEventRequestToJson(this);
+  factory ApiEventRequest.fromJson(Map<String, dynamic> json) =>
+      _$ApiEventRequestFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiEventRequestToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// An experiment that this user is partaking.
 @JsonSerializable(explicitToJson: true)
 class ApiExperiment {
-    @JsonKey(name: 'name')
-    final String? name;
-    @JsonKey(name: 'value')
-    final String? value;
-    
-    const ApiExperiment({
-        required this.name,
-        required this.value,
-    });
+  @JsonKey(name: 'name')
+  final String? name;
+  @JsonKey(name: 'value')
+  final String? value;
 
-    factory ApiExperiment.fromJson(Map<String, dynamic> json) => _$ApiExperimentFromJson(json);
+  const ApiExperiment({
+    required this.name,
+    required this.value,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiExperimentToJson(this);
+  factory ApiExperiment.fromJson(Map<String, dynamic> json) =>
+      _$ApiExperimentFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiExperimentToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// All experiments that this identity is involved with.
 @JsonSerializable(explicitToJson: true)
 class ApiExperimentList {
-    @JsonKey(name: 'experiments')
-    final List<ApiExperiment>? experiments;
-    
-    const ApiExperimentList({
-        required this.experiments,
-    });
+  @JsonKey(name: 'experiments')
+  final List<ApiExperiment>? experiments;
 
-    factory ApiExperimentList.fromJson(Map<String, dynamic> json) => _$ApiExperimentListFromJson(json);
+  const ApiExperimentList({
+    required this.experiments,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiExperimentListToJson(this);
+  factory ApiExperimentList.fromJson(Map<String, dynamic> json) =>
+      _$ApiExperimentListFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiExperimentListToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// Feature flag available to the identity.
 @JsonSerializable(explicitToJson: true)
 class ApiFlag {
-    @JsonKey(name: 'change_reason')
-    final FlagValueChangeReason? changeReason;
-    @JsonKey(name: 'condition_changed')
-    final bool? conditionChanged;
-    @JsonKey(name: 'name')
-    final String? name;
-    @JsonKey(name: 'value')
-    final String? value;
-    
-    const ApiFlag({
-        required this.changeReason,
-        required this.conditionChanged,
-        required this.name,
-        required this.value,
-    });
+  @JsonKey(name: 'change_reason')
+  final FlagValueChangeReason? changeReason;
+  @JsonKey(name: 'condition_changed')
+  final bool? conditionChanged;
+  @JsonKey(name: 'name')
+  final String? name;
+  @JsonKey(name: 'value')
+  final String? value;
 
-    factory ApiFlag.fromJson(Map<String, dynamic> json) => _$ApiFlagFromJson(json);
+  const ApiFlag({
+    required this.changeReason,
+    required this.conditionChanged,
+    required this.name,
+    required this.value,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiFlagToJson(this);
+  factory ApiFlag.fromJson(Map<String, dynamic> json) =>
+      _$ApiFlagFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiFlagToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// All flags available to the identity
 @JsonSerializable(explicitToJson: true)
 class ApiFlagList {
-    @JsonKey(name: 'flags')
-    final List<ApiFlag>? flags;
-    
-    const ApiFlagList({
-        required this.flags,
-    });
+  @JsonKey(name: 'flags')
+  final List<ApiFlag>? flags;
 
-    factory ApiFlagList.fromJson(Map<String, dynamic> json) => _$ApiFlagListFromJson(json);
+  const ApiFlagList({
+    required this.flags,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiFlagListToJson(this);
+  factory ApiFlagList.fromJson(Map<String, dynamic> json) =>
+      _$ApiFlagListFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiFlagListToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// Feature flag available to the identity.
 @JsonSerializable(explicitToJson: true)
 class ApiFlagOverride {
-    @JsonKey(name: 'flag_name')
-    final String? flagName;
-    @JsonKey(name: 'overrides')
-    final List<ApiFlagOverrideValue>? overrides;
-    
-    const ApiFlagOverride({
-        required this.flagName,
-        required this.overrides,
-    });
+  @JsonKey(name: 'flag_name')
+  final String? flagName;
+  @JsonKey(name: 'overrides')
+  final List<ApiFlagOverrideValue>? overrides;
 
-    factory ApiFlagOverride.fromJson(Map<String, dynamic> json) => _$ApiFlagOverrideFromJson(json);
+  const ApiFlagOverride({
+    required this.flagName,
+    required this.overrides,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiFlagOverrideToJson(this);
+  factory ApiFlagOverride.fromJson(Map<String, dynamic> json) =>
+      _$ApiFlagOverrideFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiFlagOverrideToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// All flags available to the identity and their value overrides
 @JsonSerializable(explicitToJson: true)
 class ApiFlagOverrideList {
-    @JsonKey(name: 'flags')
-    final List<ApiFlagOverride>? flags;
-    
-    const ApiFlagOverrideList({
-        required this.flags,
-    });
+  @JsonKey(name: 'flags')
+  final List<ApiFlagOverride>? flags;
 
-    factory ApiFlagOverrideList.fromJson(Map<String, dynamic> json) => _$ApiFlagOverrideListFromJson(json);
+  const ApiFlagOverrideList({
+    required this.flags,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiFlagOverrideListToJson(this);
+  factory ApiFlagOverrideList.fromJson(Map<String, dynamic> json) =>
+      _$ApiFlagOverrideListFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiFlagOverrideListToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 enum ApiFlagOverrideType {
-    @JsonValue('FLAG')
-    flag,
-    @JsonValue('FLAG_VARIANT')
-    flagVariant,
-    @JsonValue('LIVE_EVENT_FLAG')
-    liveEventFlag,
-    @JsonValue('LIVE_EVENT_FLAG_VARIANT')
-    liveEventFlagVariant,
-    @JsonValue('EXPERIMENT_PHASE_VARIANT_FLAG')
-    experimentPhaseVariantFlag,
+  @JsonValue('FLAG')
+  flag,
+  @JsonValue('FLAG_VARIANT')
+  flagVariant,
+  @JsonValue('LIVE_EVENT_FLAG')
+  liveEventFlag,
+  @JsonValue('LIVE_EVENT_FLAG_VARIANT')
+  liveEventFlagVariant,
+  @JsonValue('EXPERIMENT_PHASE_VARIANT_FLAG')
+  experimentPhaseVariantFlag,
 }
 
 /// The details of a flag value override.
 @JsonSerializable(explicitToJson: true)
 class ApiFlagOverrideValue {
-    @JsonKey(name: 'create_time_sec')
-    final String? createTimeSec;
-    @JsonKey(name: 'name')
-    final String? name;
-    @JsonKey(name: 'type')
-    final ApiFlagOverrideType? type;
-    @JsonKey(name: 'value')
-    final String? value;
-    @JsonKey(name: 'variant_name')
-    final String? variantName;
-    
-    const ApiFlagOverrideValue({
-        required this.createTimeSec,
-        required this.name,
-        required this.type,
-        required this.value,
-        required this.variantName,
-    });
+  @JsonKey(name: 'create_time_sec')
+  final String? createTimeSec;
+  @JsonKey(name: 'name')
+  final String? name;
+  @JsonKey(name: 'type')
+  final ApiFlagOverrideType? type;
+  @JsonKey(name: 'value')
+  final String? value;
+  @JsonKey(name: 'variant_name')
+  final String? variantName;
 
-    factory ApiFlagOverrideValue.fromJson(Map<String, dynamic> json) => _$ApiFlagOverrideValueFromJson(json);
+  const ApiFlagOverrideValue({
+    required this.createTimeSec,
+    required this.name,
+    required this.type,
+    required this.value,
+    required this.variantName,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiFlagOverrideValueToJson(this);
+  factory ApiFlagOverrideValue.fromJson(Map<String, dynamic> json) =>
+      _$ApiFlagOverrideValueFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiFlagOverrideValueToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// A response containing all the messages for an identity.
 @JsonSerializable(explicitToJson: true)
 class ApiGetMessageListResponse {
-    @JsonKey(name: 'cacheable_cursor')
-    final String? cacheableCursor;
-    @JsonKey(name: 'messages')
-    final List<ApiMessage>? messages;
-    @JsonKey(name: 'next_cursor')
-    final String? nextCursor;
-    @JsonKey(name: 'prev_cursor')
-    final String? prevCursor;
-    
-    const ApiGetMessageListResponse({
-        required this.cacheableCursor,
-        required this.messages,
-        required this.nextCursor,
-        required this.prevCursor,
-    });
+  @JsonKey(name: 'cacheable_cursor')
+  final String? cacheableCursor;
+  @JsonKey(name: 'messages')
+  final List<ApiMessage>? messages;
+  @JsonKey(name: 'next_cursor')
+  final String? nextCursor;
+  @JsonKey(name: 'prev_cursor')
+  final String? prevCursor;
 
-    factory ApiGetMessageListResponse.fromJson(Map<String, dynamic> json) => _$ApiGetMessageListResponseFromJson(json);
+  const ApiGetMessageListResponse({
+    required this.cacheableCursor,
+    required this.messages,
+    required this.nextCursor,
+    required this.prevCursor,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiGetMessageListResponseToJson(this);
+  factory ApiGetMessageListResponse.fromJson(Map<String, dynamic> json) =>
+      _$ApiGetMessageListResponseFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiGetMessageListResponseToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// Enrich/replace the current session with a new ID.
 @JsonSerializable(explicitToJson: true)
 class ApiIdentifyRequest {
-    @JsonKey(name: 'custom')
-    final Map<String, String>? custom;
-    @JsonKey(name: 'default')
-    final Map<String, String>? defaultValue;
-    @JsonKey(name: 'id')
-    final String? id;
-    
-    const ApiIdentifyRequest({
-        required this.custom,
-        required this.defaultValue,
-        required this.id,
-    });
+  @JsonKey(name: 'custom')
+  final Map<String, String>? custom;
+  @JsonKey(name: 'default')
+  final Map<String, String>? defaultValue;
+  @JsonKey(name: 'id')
+  final String? id;
 
-    factory ApiIdentifyRequest.fromJson(Map<String, dynamic> json) => _$ApiIdentifyRequestFromJson(json);
+  const ApiIdentifyRequest({
+    required this.custom,
+    required this.defaultValue,
+    required this.id,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiIdentifyRequestToJson(this);
+  factory ApiIdentifyRequest.fromJson(Map<String, dynamic> json) =>
+      _$ApiIdentifyRequestFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiIdentifyRequestToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// A single live event.
 @JsonSerializable(explicitToJson: true)
 class ApiLiveEvent {
-    @JsonKey(name: 'active_end_time_sec')
-    final String? activeEndTimeSec;
-    @JsonKey(name: 'active_start_time_sec')
-    final String? activeStartTimeSec;
-    @JsonKey(name: 'description')
-    final String? description;
-    @JsonKey(name: 'duration_sec')
-    final String? durationSec;
-    @JsonKey(name: 'end_time_sec')
-    final String? endTimeSec;
-    @JsonKey(name: 'id')
-    final String? id;
-    @JsonKey(name: 'name')
-    final String? name;
-    @JsonKey(name: 'reset_cron')
-    final String? resetCron;
-    @JsonKey(name: 'start_time_sec')
-    final String? startTimeSec;
-    @JsonKey(name: 'value')
-    final String? value;
-    
-    const ApiLiveEvent({
-        required this.activeEndTimeSec,
-        required this.activeStartTimeSec,
-        required this.description,
-        required this.durationSec,
-        required this.endTimeSec,
-        required this.id,
-        required this.name,
-        required this.resetCron,
-        required this.startTimeSec,
-        required this.value,
-    });
+  @JsonKey(name: 'active_end_time_sec')
+  final String? activeEndTimeSec;
+  @JsonKey(name: 'active_start_time_sec')
+  final String? activeStartTimeSec;
+  @JsonKey(name: 'description')
+  final String? description;
+  @JsonKey(name: 'duration_sec')
+  final String? durationSec;
+  @JsonKey(name: 'end_time_sec')
+  final String? endTimeSec;
+  @JsonKey(name: 'id')
+  final String? id;
+  @JsonKey(name: 'name')
+  final String? name;
+  @JsonKey(name: 'reset_cron')
+  final String? resetCron;
+  @JsonKey(name: 'start_time_sec')
+  final String? startTimeSec;
+  @JsonKey(name: 'value')
+  final String? value;
 
-    factory ApiLiveEvent.fromJson(Map<String, dynamic> json) => _$ApiLiveEventFromJson(json);
+  const ApiLiveEvent({
+    required this.activeEndTimeSec,
+    required this.activeStartTimeSec,
+    required this.description,
+    required this.durationSec,
+    required this.endTimeSec,
+    required this.id,
+    required this.name,
+    required this.resetCron,
+    required this.startTimeSec,
+    required this.value,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiLiveEventToJson(this);
+  factory ApiLiveEvent.fromJson(Map<String, dynamic> json) =>
+      _$ApiLiveEventFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiLiveEventToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// List of Live events.
 @JsonSerializable(explicitToJson: true)
 class ApiLiveEventList {
-    @JsonKey(name: 'live_events')
-    final List<ApiLiveEvent>? liveEvents;
-    
-    const ApiLiveEventList({
-        required this.liveEvents,
-    });
+  @JsonKey(name: 'live_events')
+  final List<ApiLiveEvent>? liveEvents;
 
-    factory ApiLiveEventList.fromJson(Map<String, dynamic> json) => _$ApiLiveEventListFromJson(json);
+  const ApiLiveEventList({
+    required this.liveEvents,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiLiveEventListToJson(this);
+  factory ApiLiveEventList.fromJson(Map<String, dynamic> json) =>
+      _$ApiLiveEventListFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiLiveEventListToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// A scheduled message.
 @JsonSerializable(explicitToJson: true)
 class ApiMessage {
-    @JsonKey(name: 'consume_time')
-    final String? consumeTime;
-    @JsonKey(name: 'create_time')
-    final String? createTime;
-    @JsonKey(name: 'id')
-    final String? id;
-    @JsonKey(name: 'image_url')
-    final String? imageUrl;
-    @JsonKey(name: 'metadata')
-    final Map<String, String>? metadata;
-    @JsonKey(name: 'read_time')
-    final String? readTime;
-    @JsonKey(name: 'schedule_id')
-    final String? scheduleId;
-    @JsonKey(name: 'send_time')
-    final String? sendTime;
-    @JsonKey(name: 'text')
-    final String? text;
-    @JsonKey(name: 'title')
-    final String? title;
-    @JsonKey(name: 'update_time')
-    final String? updateTime;
-    
-    const ApiMessage({
-        required this.consumeTime,
-        required this.createTime,
-        required this.id,
-        required this.imageUrl,
-        required this.metadata,
-        required this.readTime,
-        required this.scheduleId,
-        required this.sendTime,
-        required this.text,
-        required this.title,
-        required this.updateTime,
-    });
+  @JsonKey(name: 'consume_time')
+  final String? consumeTime;
+  @JsonKey(name: 'create_time')
+  final String? createTime;
+  @JsonKey(name: 'id')
+  final String? id;
+  @JsonKey(name: 'image_url')
+  final String? imageUrl;
+  @JsonKey(name: 'metadata')
+  final Map<String, String>? metadata;
+  @JsonKey(name: 'read_time')
+  final String? readTime;
+  @JsonKey(name: 'schedule_id')
+  final String? scheduleId;
+  @JsonKey(name: 'send_time')
+  final String? sendTime;
+  @JsonKey(name: 'text')
+  final String? text;
+  @JsonKey(name: 'title')
+  final String? title;
+  @JsonKey(name: 'update_time')
+  final String? updateTime;
 
-    factory ApiMessage.fromJson(Map<String, dynamic> json) => _$ApiMessageFromJson(json);
+  const ApiMessage({
+    required this.consumeTime,
+    required this.createTime,
+    required this.id,
+    required this.imageUrl,
+    required this.metadata,
+    required this.readTime,
+    required this.scheduleId,
+    required this.sendTime,
+    required this.text,
+    required this.title,
+    required this.updateTime,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiMessageToJson(this);
+  factory ApiMessage.fromJson(Map<String, dynamic> json) =>
+      _$ApiMessageFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiMessageToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// Properties associated with an identity.
 @JsonSerializable(explicitToJson: true)
 class ApiProperties {
-    @JsonKey(name: 'computed')
-    final Map<String, String>? computed;
-    @JsonKey(name: 'custom')
-    final Map<String, String>? custom;
-    @JsonKey(name: 'default')
-    final Map<String, String>? defaultValue;
-    
-    const ApiProperties({
-        required this.computed,
-        required this.custom,
-        required this.defaultValue,
-    });
+  @JsonKey(name: 'computed')
+  final Map<String, String>? computed;
+  @JsonKey(name: 'custom')
+  final Map<String, String>? custom;
+  @JsonKey(name: 'default')
+  final Map<String, String>? defaultValue;
 
-    factory ApiProperties.fromJson(Map<String, dynamic> json) => _$ApiPropertiesFromJson(json);
+  const ApiProperties({
+    required this.computed,
+    required this.custom,
+    required this.defaultValue,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiPropertiesToJson(this);
+  factory ApiProperties.fromJson(Map<String, dynamic> json) =>
+      _$ApiPropertiesFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiPropertiesToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// A session.
 @JsonSerializable(explicitToJson: true)
 class ApiSession {
-    @JsonKey(name: 'properties')
-    final ApiProperties? properties;
-    @JsonKey(name: 'refresh_token')
-    final String? refreshToken;
-    @JsonKey(name: 'token')
-    final String? token;
-    
-    const ApiSession({
-        required this.properties,
-        required this.refreshToken,
-        required this.token,
-    });
+  @JsonKey(name: 'properties')
+  final ApiProperties? properties;
+  @JsonKey(name: 'refresh_token')
+  final String? refreshToken;
+  @JsonKey(name: 'token')
+  final String? token;
 
-    factory ApiSession.fromJson(Map<String, dynamic> json) => _$ApiSessionFromJson(json);
+  const ApiSession({
+    required this.properties,
+    required this.refreshToken,
+    required this.token,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiSessionToJson(this);
+  factory ApiSession.fromJson(Map<String, dynamic> json) =>
+      _$ApiSessionFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiSessionToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
 /// Update Properties associated with this identity.
 @JsonSerializable(explicitToJson: true)
 class ApiUpdatePropertiesRequest {
-    @JsonKey(name: 'custom')
-    final Map<String, String>? custom;
-    @JsonKey(name: 'default')
-    final Map<String, String>? defaultValue;
-    @JsonKey(name: 'recompute')
-    final bool? recompute;
-    
-    const ApiUpdatePropertiesRequest({
-        required this.custom,
-        required this.defaultValue,
-        required this.recompute,
-    });
+  @JsonKey(name: 'custom')
+  final Map<String, String>? custom;
+  @JsonKey(name: 'default')
+  final Map<String, String>? defaultValue;
+  @JsonKey(name: 'recompute')
+  final bool? recompute;
 
-    factory ApiUpdatePropertiesRequest.fromJson(Map<String, dynamic> json) => _$ApiUpdatePropertiesRequestFromJson(json);
+  const ApiUpdatePropertiesRequest({
+    required this.custom,
+    required this.defaultValue,
+    required this.recompute,
+  });
 
-    Map<String, dynamic> toJson() => _$ApiUpdatePropertiesRequestToJson(this);
+  factory ApiUpdatePropertiesRequest.fromJson(Map<String, dynamic> json) =>
+      _$ApiUpdatePropertiesRequestFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ApiUpdatePropertiesRequestToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
-/// 
+///
 @JsonSerializable(explicitToJson: true)
 class ProtobufAny {
-    @JsonKey(name: '@type')
-    final String? type;
-    
-    const ProtobufAny({
-        required this.type,
-    });
+  @JsonKey(name: '@type')
+  final String? type;
 
-    factory ProtobufAny.fromJson(Map<String, dynamic> json) => _$ProtobufAnyFromJson(json);
+  const ProtobufAny({
+    required this.type,
+  });
 
-    Map<String, dynamic> toJson() => _$ProtobufAnyToJson(this);
+  factory ProtobufAny.fromJson(Map<String, dynamic> json) =>
+      _$ProtobufAnyFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$ProtobufAnyToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
 
-/// 
+///
 @JsonSerializable(explicitToJson: true)
 class RpcStatus {
-    @JsonKey(name: 'code')
-    final int? code;
-    @JsonKey(name: 'details')
-    final List<ProtobufAny>? details;
-    @JsonKey(name: 'message')
-    final String? message;
-    
-    const RpcStatus({
-        required this.code,
-        required this.details,
-        required this.message,
-    });
+  @JsonKey(name: 'code')
+  final int? code;
+  @JsonKey(name: 'details')
+  final List<ProtobufAny>? details;
+  @JsonKey(name: 'message')
+  final String? message;
 
-    factory RpcStatus.fromJson(Map<String, dynamic> json) => _$RpcStatusFromJson(json);
+  const RpcStatus({
+    required this.code,
+    required this.details,
+    required this.message,
+  });
 
-    Map<String, dynamic> toJson() => _$RpcStatusToJson(this);
+  factory RpcStatus.fromJson(Map<String, dynamic> json) =>
+      _$RpcStatusFromJson(json);
 
-    @override
-    String toString() => jsonEncode(this);
+  Map<String, dynamic> toJson() => _$RpcStatusToJson(this);
+
+  @override
+  String toString() => jsonEncode(this);
 }
-
 
 /// The low level client for the Satori API.
 @RestApi()
-abstract class SatoriApiClient
-{
-    factory SatoriApiClient(Dio dio, {String baseUrl}) = _SatoriApiClient;
+abstract class SatoriApiClient {
+  factory SatoriApiClient(Dio dio, {String baseUrl}) = _SatoriApiClient;
 
-    /// A healthcheck which load balancers can use to check the service.
-    @GET('/healthcheck')
-    Future<void> healthcheck({
-        @Header('Authorization') String? authorization,
-	  });
+  /// A healthcheck which load balancers can use to check the service.
+  @GET('/healthcheck')
+  Future<void> healthcheck({
+    @Header('Authorization') String? authorization,
+  });
 
-    /// A readycheck which load balancers can use to check the service.
-    @GET('/readycheck')
-    Future<void> readycheck({
-        @Header('Authorization') String? authorization,
-	  });
+  /// A readycheck which load balancers can use to check the service.
+  @GET('/readycheck')
+  Future<void> readycheck({
+    @Header('Authorization') String? authorization,
+  });
 
-    /// Authenticate against the server.
-    @POST('/v1/authenticate')
-    Future<ApiSession> authenticate({
-        @Header('Authorization') String? authorization,
-        @Body() required ApiAuthenticateRequest body,
-	  });
+  /// Authenticate against the server.
+  @POST('/v1/authenticate')
+  Future<ApiSession> authenticate({
+    @Header('Authorization') String? authorization,
+    @Body() required ApiAuthenticateRequest body,
+  });
 
-    /// Log out a session, invalidate a refresh token, or log out all sessions/refresh tokens for a user.
-    @POST('/v1/authenticate/logout')
-    Future<void> authenticateLogout({
-        @Header('Authorization') String? authorization,
-        @Body() required ApiAuthenticateLogoutRequest body,
-	  });
+  /// Log out a session, invalidate a refresh token, or log out all sessions/refresh tokens for a user.
+  @POST('/v1/authenticate/logout')
+  Future<void> authenticateLogout({
+    @Header('Authorization') String? authorization,
+    @Body() required ApiAuthenticateLogoutRequest body,
+  });
 
-    /// Refresh a user's session using a refresh token retrieved from a previous authentication request.
-    @POST('/v1/authenticate/refresh')
-    Future<ApiSession> authenticateRefresh({
-        @Header('Authorization') String? authorization,
-        @Body() required ApiAuthenticateRefreshRequest body,
-	  });
+  /// Refresh a user's session using a refresh token retrieved from a previous authentication request.
+  @POST('/v1/authenticate/refresh')
+  Future<ApiSession> authenticateRefresh({
+    @Header('Authorization') String? authorization,
+    @Body() required ApiAuthenticateRefreshRequest body,
+  });
 
-    /// Publish an event for this session.
-    @POST('/v1/event')
-    Future<void> event({
-        @Header('Authorization') String? authorization,
-        @Body() required ApiEventRequest body,
-	  });
+  /// Publish an event for this session.
+  @POST('/v1/event')
+  Future<void> event({
+    @Header('Authorization') String? authorization,
+    @Body() required ApiEventRequest body,
+  });
 
-    /// Get or list all available experiments for this identity.
-    @GET('/v1/experiment')
-    Future<ApiExperimentList> getExperiments({
-        @Header('Authorization') String? authorization,
-		@Query('names')
-    		required List<String> names,
-	  });
+  /// Get or list all available experiments for this identity.
+  @GET('/v1/experiment')
+  Future<ApiExperimentList> getExperiments({
+    @Header('Authorization') String? authorization,
+    @Query('names') required List<String> names,
+  });
 
-    /// List all available flags for this identity.
-    @GET('/v1/flag')
-    Future<ApiFlagList> getFlags({
-        @Header('Authorization') String? authorization,
-		@Query('names')
-    		required List<String> names,
-	  });
+  /// List all available flags for this identity.
+  @GET('/v1/flag')
+  Future<ApiFlagList> getFlags({
+    @Header('Authorization') String? authorization,
+    @Query('names') required List<String> names,
+  });
 
-    /// List all available flags and their value overrides for this identity.
-    @GET('/v1/flag/override')
-    Future<ApiFlagOverrideList> getFlagOverrides({
-        @Header('Authorization') String? authorization,
-		@Query('names')
-    		required List<String> names,
-	  });
+  /// List all available flags and their value overrides for this identity.
+  @GET('/v1/flag/override')
+  Future<ApiFlagOverrideList> getFlagOverrides({
+    @Header('Authorization') String? authorization,
+    @Query('names') required List<String> names,
+  });
 
-    /// Enrich/replace the current session with new identifier.
-    @PUT('/v1/identify')
-    Future<ApiSession> identify({
-        @Header('Authorization') String? authorization,
-        @Body() required ApiIdentifyRequest body,
-	  });
+  /// Enrich/replace the current session with new identifier.
+  @PUT('/v1/identify')
+  Future<ApiSession> identify({
+    @Header('Authorization') String? authorization,
+    @Body() required ApiIdentifyRequest body,
+  });
 
-    /// Delete the caller's identity and associated data.
-    @DELETE('/v1/identity')
-    Future<void> deleteIdentity({
-        @Header('Authorization') String? authorization,
-	  });
+  /// Delete the caller's identity and associated data.
+  @DELETE('/v1/identity')
+  Future<void> deleteIdentity({
+    @Header('Authorization') String? authorization,
+  });
 
-    /// List available live events.
-    @GET('/v1/live-event')
-    Future<ApiLiveEventList> getLiveEvents({
-        @Header('Authorization') String? authorization,
-		@Query('names')
-    		required List<String> names,
-	  });
+  /// List available live events.
+  @GET('/v1/live-event')
+  Future<ApiLiveEventList> getLiveEvents({
+    @Header('Authorization') String? authorization,
+    @Query('names') required List<String> names,
+  });
 
-    /// Get the list of messages for the identity.
-    @GET('/v1/message')
-    Future<ApiGetMessageListResponse> getMessageList({
-        @Header('Authorization') String? authorization,
-		@Query('limit')
-        int? limit,
-		@Query('forward')
-        bool? forward,
-		@Query('cursor')
-        String? cursor,
-	  });
+  /// Get the list of messages for the identity.
+  @GET('/v1/message')
+  Future<ApiGetMessageListResponse> getMessageList({
+    @Header('Authorization') String? authorization,
+    @Query('limit') int? limit,
+    @Query('forward') bool? forward,
+    @Query('cursor') String? cursor,
+  });
 
-    /// Deletes a message for an identity.
-    @DELETE('/v1/message/{id}')
-    Future<void> deleteMessage({
-        @Header('Authorization') String? authorization,
-        @Path('id')required String id,
-	  });
+  /// Deletes a message for an identity.
+  @DELETE('/v1/message/{id}')
+  Future<void> deleteMessage({
+    @Header('Authorization') String? authorization,
+    @Path('id') required String id,
+  });
 
-    /// Updates a message for an identity.
-    @PUT('/v1/message/{id}')
-    Future<void> updateMessage({
-        @Header('Authorization') String? authorization,
-        @Path('id')required String id,
-        @Body() required ApiUpdateMessageRequest body,
-	  });
+  /// Updates a message for an identity.
+  @PUT('/v1/message/{id}')
+  Future<void> updateMessage({
+    @Header('Authorization') String? authorization,
+    @Path('id') required String id,
+    @Body() required ApiUpdateMessageRequest body,
+  });
 
-    /// List properties associated with this identity.
-    @GET('/v1/properties')
-    Future<ApiProperties> listProperties({
-        @Header('Authorization') String? authorization,
-	  });
+  /// List properties associated with this identity.
+  @GET('/v1/properties')
+  Future<ApiProperties> listProperties({
+    @Header('Authorization') String? authorization,
+  });
 
-    /// Update identity properties.
-    @PUT('/v1/properties')
-    Future<void> updateProperties({
-        @Header('Authorization') String? authorization,
-        @Body() required ApiUpdatePropertiesRequest body,
-	  });
+  /// Update identity properties.
+  @PUT('/v1/properties')
+  Future<void> updateProperties({
+    @Header('Authorization') String? authorization,
+    @Body() required ApiUpdatePropertiesRequest body,
+  });
 }

--- a/satori/lib/src/satori_client/satori_api_client.dart
+++ b/satori/lib/src/satori_client/satori_api_client.dart
@@ -40,23 +40,26 @@ class SatoriRestApiClient extends SatoriBaseClient {
     required this.apiKey,
     required int port,
     required bool ssl,
-  }) : _host = host,
-       _port = port,
-       _ssl = ssl,
-       super() {
+  })  : _host = host,
+        _port = port,
+        _ssl = ssl,
+        super() {
     _initializeApi();
   }
 
   void _initializeApi() {
-    final baseUrl = Uri(scheme: _ssl ? 'https' : 'http', host: _host, port: _port);
+    final baseUrl =
+        Uri(scheme: _ssl ? 'https' : 'http', host: _host, port: _port);
     final dio = Dio(BaseOptions(baseUrl: baseUrl.toString()));
-    
+
     dio.interceptors.add(InterceptorsWrapper(
       onRequest: (options, handler) {
         if (_session != null) {
-          options.headers.putIfAbsent('Authorization', () => 'Bearer ${_session!.token}');
+          options.headers
+              .putIfAbsent('Authorization', () => 'Bearer ${_session!.token}');
         } else {
-          options.headers.putIfAbsent('Authorization', () => 'Basic ${base64Encode('$apiKey:'.codeUnits)}');
+          options.headers.putIfAbsent('Authorization',
+              () => 'Basic ${base64Encode('$apiKey:'.codeUnits)}');
         }
         handler.next(options);
       },
@@ -73,7 +76,7 @@ class SatoriRestApiClient extends SatoriBaseClient {
   }) async {
     // Clear any existing session to ensure Basic auth is used
     _session = null;
-    
+
     final response = await _api.authenticate(
       body: ApiAuthenticateRequest(
         id: id,
@@ -98,7 +101,7 @@ class SatoriRestApiClient extends SatoriBaseClient {
         refreshToken: session.refreshToken,
       ),
     );
-    
+
     // Clear session after logout
     _session = null;
   }
@@ -159,7 +162,9 @@ class SatoriRestApiClient extends SatoriBaseClient {
 
     final response = await _api.getExperiments(names: []);
     return ExperimentList(
-      experiments: response.experiments?.map((e) => Experiment.fromDto(e)).toList() ?? [],
+      experiments:
+          response.experiments?.map((e) => Experiment.fromDto(e)).toList() ??
+              [],
     );
   }
 
@@ -172,7 +177,9 @@ class SatoriRestApiClient extends SatoriBaseClient {
 
     final response = await _api.getExperiments(names: names);
     return ExperimentList(
-      experiments: response.experiments?.map((e) => Experiment.fromDto(e)).toList() ?? [],
+      experiments:
+          response.experiments?.map((e) => Experiment.fromDto(e)).toList() ??
+              [],
     );
   }
 

--- a/satori/pubspec.lock
+++ b/satori/pubspec.lock
@@ -5,26 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "96.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
-  ansicolor:
-    dependency: transitive
-    description:
-      name: ansicolor
-      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
+    version: "10.2.0"
   args:
     dependency: transitive
     description:
@@ -37,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,34 +45,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3"
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b4d854962a32fd9f8efc0b76f98214790b833af8b2e9b2df6bfc927c0415a072
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.5"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -93,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "7931c90b84bc573fef103548e354258ae4c9d28d140e41961df6843c5d60d4d8"
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.3"
+    version: "8.12.6"
   checked_yaml:
     dependency: "direct dev"
     description:
@@ -141,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
@@ -157,26 +149,26 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.7"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.0"
+    version: "5.11.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
   file:
     dependency: transitive
     description:
@@ -197,10 +189,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "03dd9b7423ff0e31b7e01b2204593e5e1ac5ee553b6ea9d8184dff4a26b9fb07"
+      sha256: f23ea33b3863f119b58ed1b586e881a46bd28715ddcc4dbc33104524e3434131
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.4"
+    version: "3.2.5"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -233,14 +225,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  hotreloader:
-    dependency: transitive
-    description:
-      name: hotreloader
-      sha256: bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.3.0"
   http:
     dependency: "direct main"
     description:
@@ -277,18 +261,18 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "5b89c1e32ae3840bb20a1b3434e3a590173ad3cb605896fb0f60487ce2f8104e"
+      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.4"
+    version: "6.14.0"
   jwt_decoder:
     dependency: "direct main"
     description:
@@ -297,14 +281,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
-  lean_builder:
-    dependency: transitive
-    description:
-      name: lean_builder
-      sha256: "6af3cfbf34400eb14b89fe20111e5981e7083362f00ea10b9ed2a6e833250d76"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.6"
   logging:
     dependency: transitive
     description:
@@ -317,18 +293,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.20"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -405,10 +381,10 @@ packages:
     dependency: "direct dev"
     description:
       name: retrofit_generator
-      sha256: fed2c4e4ed6dab084c00d25c739988aa3cec1acd2b168771136188cced8d967d
+      sha256: e836270d06083ff3e90a0428732c750ed4a7ef2e99ff26d1af9865a3aa20968a
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.1"
+    version: "10.2.8"
   shelf:
     dependency: transitive
     description:
@@ -445,18 +421,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "1d562a3c1f713904ebbed50d2760217fd8a51ca170ac4b05b0db490699dbac17"
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.4"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "4a85e90b50694e652075cbe4575665539d253e6ec10e46e76b45368ab5e3caae"
+      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.10"
+    version: "1.3.12"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -477,10 +453,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -525,26 +501,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -557,18 +533,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.1"
   web:
     dependency: transitive
     description:
@@ -601,14 +577,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  xxh3:
-    dependency: transitive
-    description:
-      name: xxh3
-      sha256: "399a0438f5d426785723c99da6b16e136f4953fb1e9db0bf270bd41dd4619916"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -618,4 +586,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/satori/pubspec.yaml
+++ b/satori/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   http: ^1.6.0
   json_annotation: ^4.9.0
   jwt_decoder: ^2.0.1
-  retrofit: '>=4.0.0 <5.0.0'
+  retrofit: ^4.9.2
   
 dev_dependencies:
   build_runner: ^2.5.4

--- a/satori/regenerate.sh
+++ b/satori/regenerate.sh
@@ -41,6 +41,11 @@ dart run build_runner build --delete-conflicting-outputs
 echo "✓ Build runner complete"
 
 echo ""
+echo "4. Formatting generated code..."
+dart format lib > /dev/null
+echo "✓ Formatting complete"
+
+echo ""
 echo "=========================================="
 echo "✓ Code generation completed!"
 echo "=========================================="

--- a/satori/test/client_test.dart
+++ b/satori/test/client_test.dart
@@ -11,17 +11,21 @@ void main() {
 
     test('authenticate and logout', () async {
       // Authenticate
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
 
       expect(session, isA<Session>());
 
       // Logout
       await client.authenticateLogout(session: session);
-      expect(() async => await client.getExperiments(session: session, names: []), throwsA(isA<Exception>()));
+      expect(
+          () async => await client.getExperiments(session: session, names: []),
+          throwsA(isA<Exception>()));
     });
 
     test('get experiments', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
       final experiments = await client.getAllExperiments(session: session);
 
       expect(experiments, isA<ExperimentList>());
@@ -30,25 +34,27 @@ void main() {
     });
 
     test('get experiments with names', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
-      
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+
       // First get all experiments to find existing ones
       final allExperiments = await client.getAllExperiments(session: session);
-      
+
       if (allExperiments.experiments.isNotEmpty) {
         final experimentNames = allExperiments.experiments
             .take(2) // Take first 2 experiments
             .map((e) => e.name)
             .toList();
-        
+
         final specificExperiments = await client.getExperiments(
           session: session,
           names: experimentNames.whereType<String>().toList(),
         );
-        
+
         expect(specificExperiments, isA<ExperimentList>());
-        expect(specificExperiments.experiments.length, lessThanOrEqualTo(experimentNames.length));
-        
+        expect(specificExperiments.experiments.length,
+            lessThanOrEqualTo(experimentNames.length));
+
         // Verify returned experiments match requested names
         for (final experiment in specificExperiments.experiments) {
           expect(experimentNames.contains(experiment.name), isTrue);
@@ -57,7 +63,8 @@ void main() {
     });
 
     test('get flags', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
       final flags = await client.getFlags(session: session, names: []);
 
       expect(flags, isA<FlagList>());
@@ -66,15 +73,17 @@ void main() {
     });
 
     test('get flag', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
-      
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+
       // First get all flags to find an existing one
       final allFlags = await client.getFlags(session: session, names: []);
-      
+
       if (allFlags.flags.isNotEmpty) {
         final existingFlagName = allFlags.flags.first.name;
-        final flag = await client.getFlag(session: session, name: existingFlagName!);
-        
+        final flag =
+            await client.getFlag(session: session, name: existingFlagName!);
+
         expect(flag, isA<Flag>());
         expect(flag.name, equals(existingFlagName));
         expect(flag.value, isNotNull);
@@ -82,34 +91,38 @@ void main() {
     });
 
     test('get flag with default value', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
       const nonExistentFlagName = 'non-existent-flag-12345';
       const defaultValue = 'default-test-value';
-      
+
       final flag = await client.getFlag(
-        session: session, 
+        session: session,
         name: nonExistentFlagName,
         defaultValue: defaultValue,
       );
-      
+
       expect(flag, isA<Flag>());
       expect(flag.name, equals(nonExistentFlagName));
       expect(flag.value, equals(defaultValue));
     });
 
     test('get flag without default', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
       const nonExistentFlagName = 'non-existent-flag-67890';
-      
-      final flag = await client.getFlag(session: session, name: nonExistentFlagName);
-      
+
+      final flag =
+          await client.getFlag(session: session, name: nonExistentFlagName);
+
       expect(flag, isA<Flag>());
       expect(flag.name, equals(nonExistentFlagName));
       expect(flag.value, isNull);
     });
 
     test('test send events', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
       await client.event(
         session: session,
         event: Event(
@@ -129,19 +142,21 @@ void main() {
     });
 
     test('test get live events', () async {
-      final session = await client.authenticate(id: 'test-user-${DateTime.now().millisecondsSinceEpoch}');
+      final session = await client.authenticate(
+          id: 'test-user-${DateTime.now().millisecondsSinceEpoch}');
       final liveEvents = await client.getLiveEvents(session: session);
-      
+
       expect(liveEvents, isA<LiveEventList>());
-      
-      if (!liveEvents.liveEvents.isEmpty) {        
+
+      if (!liveEvents.liveEvents.isEmpty) {
         // Validate live events are properly deserialized
         for (var i = 0; i < liveEvents.liveEvents.length; i++) {
           final event = liveEvents.liveEvents[i];
 
           // Validate fields are properly deserialized from snake_case JSON
           if (event.name != null) {
-            expect(event.name, isNotEmpty, reason: 'Live event name should not be empty if present');
+            expect(event.name, isNotEmpty,
+                reason: 'Live event name should not be empty if present');
           }
           // If timestamps are present, they should be valid numbers
           if (event.activeStartTimeSec != null) {
@@ -153,13 +168,14 @@ void main() {
     });
 
     test('get live events with names', () async {
-      final session = await client.authenticate(id: 'live-events-test-${DateTime.now().millisecondsSinceEpoch}');
-      
+      final session = await client.authenticate(
+          id: 'live-events-test-${DateTime.now().millisecondsSinceEpoch}');
+
       // Test with empty names list (should return all)
       final allLiveEvents = await client.getLiveEvents(session: session);
       expect(allLiveEvents, isA<LiveEventList>());
       expect(allLiveEvents.liveEvents.length, greaterThanOrEqualTo(0));
-      
+
       // Test with specific names
       final specificLiveEvents = await client.getLiveEvents(
         session: session,
@@ -171,31 +187,33 @@ void main() {
     });
 
     test('send event with metadata', () async {
-      final session = await client.authenticate(id: 'event-metadata-test-${DateTime.now().millisecondsSinceEpoch}');
-      
+      final session = await client.authenticate(
+          id: 'event-metadata-test-${DateTime.now().millisecondsSinceEpoch}');
+
       final eventWithMetadata = Event(
         name: 'gameFinished',
         timestamp: DateTime.now(),
         metadata: {'score': '100'},
       );
-      
+
       // Should not throw an exception
       await client.event(session: session, event: eventWithMetadata);
     });
 
     test('send events batch', () async {
-      final session = await client.authenticate(id: 'batch-events-test-${DateTime.now().millisecondsSinceEpoch}');
-      
+      final session = await client.authenticate(
+          id: 'batch-events-test-${DateTime.now().millisecondsSinceEpoch}');
+
       final batchEvents = [
         Event(name: 'appLaunched', timestamp: DateTime.now()),
         Event(name: 'adStarted', timestamp: DateTime.now()),
         Event(
-          name: 'gameFinished', 
+          name: 'gameFinished',
           timestamp: DateTime.now(),
           metadata: {'score': '100'},
         ),
       ];
-      
+
       // Should process all events without throwing
       await client.events(session: session, events: batchEvents);
     });

--- a/satori/test/identify_test.dart
+++ b/satori/test/identify_test.dart
@@ -10,7 +10,8 @@ void main() {
     });
 
     test('identify tests', () async {
-      final session1 = await client.authenticate(id: '11111111-1111-0000-0000-000000000000');
+      final session1 =
+          await client.authenticate(id: '11111111-1111-0000-0000-000000000000');
 
       final props1 = {'email': 'a@b.com', 'pushTokenIos': 'foo'};
       final customProps1 = {'earlyAccess': 'true'};
@@ -30,7 +31,8 @@ void main() {
       // Sleep for 2 seconds
       await Future.delayed(const Duration(seconds: 2));
 
-      final session2 = await client.authenticate(id: '22222222-2222-0000-0000-000000000000');
+      final session2 =
+          await client.authenticate(id: '22222222-2222-0000-0000-000000000000');
 
       final props2 = {'email': 'a@b.com', 'pushTokenAndroid': 'bar'};
       final customProps2 = {'earlyAccess': 'false'};
@@ -87,13 +89,13 @@ void main() {
       // Create a unique test user
       final testUserId = 'delete-test-${DateTime.now().millisecondsSinceEpoch}';
       final session = await client.authenticate(id: testUserId);
-      
+
       expect(session, isA<Session>());
       expect(session.identityId, equals(testUserId));
-      
+
       // Delete the identity
       await client.deleteIdentity(session: session);
-      
+
       // Try to use the session after deletion - should fail
       expect(
         () async => await client.getFlags(session: session, names: []),
@@ -103,11 +105,12 @@ void main() {
     });
 
     test('update properties with recompute', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
-      
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+
       final defaultProps = {'email': 'test@example.com'};
       final customProps = {'earlyAccess': 'true'};
-      
+
       // Update properties with recompute = true
       await client.updateProperties(
         session: session,
@@ -115,7 +118,7 @@ void main() {
         customProperties: customProps,
         recompute: true,
       );
-      
+
       // Verify properties were set
       final properties = await client.listProperties(session: session);
       expect(properties.$default, isNotNull);
@@ -129,18 +132,19 @@ void main() {
     });
 
     test('update properties without recompute (default)', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
-      
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+
       final defaultProps = {'level': '5'};
       final customProps = {'premium': 'false'};
-      
+
       // Update properties without recompute (default behavior)
       await client.updateProperties(
         session: session,
         defaultProperties: defaultProps,
         customProperties: customProps,
       );
-      
+
       // Verify properties were set
       final properties = await client.listProperties(session: session);
       expect(properties.$default, isNotNull);
@@ -154,12 +158,13 @@ void main() {
     });
 
     test('update properties with recompute false explicitly', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
-      
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+
       final nameCustomProp = DateTime.now().toIso8601String();
       final defaultProps = {'score': '100'};
       final customProps = {'name': nameCustomProp};
-      
+
       // Update properties with recompute = false explicitly
       await client.updateProperties(
         session: session,
@@ -167,7 +172,7 @@ void main() {
         customProperties: customProps,
         recompute: false,
       );
-      
+
       // Verify properties were set
       final properties = await client.listProperties(session: session);
       expect(properties.$default, isNotNull);
@@ -184,16 +189,16 @@ void main() {
       final modifiedCity = 'Modified ${DateTime.now()}';
       final defaultProps = {'city': modifiedCity};
       final customProps = {'earlyAccess': 'true'};
-      
+
       final session = await client.authenticate(
         id: '7d9c476a-0000-0000-0000-000000000000',
         defaultProperties: defaultProps,
         customProperties: customProps,
       );
-      
+
       expect(session, isA<Session>());
       expect(session.token, isNotEmpty);
-      
+
       // Verify properties were set during authentication
       final properties = await client.listProperties(session: session);
       expect(properties.$default, isNotNull);

--- a/satori/test/session_test.dart
+++ b/satori/test/session_test.dart
@@ -11,39 +11,45 @@ void main() {
 
     test('session refresh maintains valid authentication state', () async {
       // First get a valid session
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
-      
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+
       // Perform session refresh
       final newSession = await client.sessionRefresh(session: session);
-      
+
       // Core validation - we got back a valid session
       expect(newSession, isA<Session>());
       expect(newSession.token, isNotEmpty);
       expect(newSession.identityId, equals(session.identityId));
-      expect(session.refreshToken.isNotEmpty, isTrue, reason: 'Authenticated session should have a refresh token');
-      
+      expect(session.refreshToken.isNotEmpty, isTrue,
+          reason: 'Authenticated session should have a refresh token');
+
       // Verify session dates are valid
       expect(newSession.expiresAt.isAfter(DateTime.now()), isTrue,
           reason: 'Refreshed session should have a future expiration date');
-          
+
       // Verify token components (assumes JWT format)
       final tokenParts = newSession.token.split('.');
-      expect(tokenParts.length, equals(3), reason: 'Token should be a valid JWT with 3 parts');
-      expect(newSession.refreshToken.isNotEmpty, isTrue, reason: 'Refresh token should not be empty after refresh');
+      expect(tokenParts.length, equals(3),
+          reason: 'Token should be a valid JWT with 3 parts');
+      expect(newSession.refreshToken.isNotEmpty, isTrue,
+          reason: 'Refresh token should not be empty after refresh');
       expect(newSession.refreshExpiresAt.isAfter(DateTime.now()), isTrue,
           reason: 'Refresh token should have a future expiration date');
     });
 
     test('authenticate creates valid session', () async {
-      final session = await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
-      
+      final session =
+          await client.authenticate(id: '7d9c476a-0000-0000-0000-000000000000');
+
       expect(session, isA<Session>());
       expect(session.token, isNotEmpty);
       expect(session.identityId, isNotEmpty);
       expect(session.isExpired, isFalse);
       expect(session.expiresAt.isAfter(DateTime.now()), isTrue,
           reason: 'Authenticated session should have a future expiration date');
-      expect(session.refreshToken.isNotEmpty, isTrue, reason: 'Authenticated session should have a refresh token');
+      expect(session.refreshToken.isNotEmpty, isTrue,
+          reason: 'Authenticated session should have a refresh token');
       expect(session.refreshExpiresAt.isAfter(DateTime.now()), isTrue,
           reason: 'Refresh token should have a future expiration date');
     });


### PR DESCRIPTION
Addresses all the remaining pub.dev static analysis and dependency points for both packages. No API or behavioural changes.

## nakama (140 → 150 / 160)

- `dart format` in lib, test, example. Dart 3.8 formatter changed trailing-comma style.
- generated protobuf files must carry their own suppression header. pana replaces `analysis_options.yaml` with `lints/core` at analysis time making `analyzer: exclude:` blocks silently ignored. Update `tool/build-protobuf.sh` to inject the header automatically.

Remaining 10 points (outdated grpc/protobuf) will be subject of another PR.

## satori (130 → 160 / 160)

- `dart format` across lib, test, example. As for above.
- Raise `retrofit` lower bound from `>=4.0.0 <5.0.0` to `^4.9.2`. Lower version was causing pana's downgrade analysis to fail and lose 20 points.
- Add `dart format lib` step to `regenerate.sh` so generated code stays formatted after each regen.