### PR TITLE
Add HTTP retry mechanism for Nakama and Satori REST clients

### DIFF
--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:dio/dio.dart';
 import 'package:nakama/nakama.dart';
@@ -19,6 +21,67 @@ import 'package:nakama/src/models/tournament.dart' as model;
 import 'package:nakama/src/rest/api_client.gen.dart';
 
 const _kDefaultAppKey = 'default';
+const _kRetryAttemptKey = 'nakama_retry_attempt';
+const _kRetryConfigKey = 'nakama_retry_configuration';
+const _kRetryTotalDelayMsKey = 'nakama_retry_total_delay_ms';
+const _kRetryConfigZoneKey = #nakamaRetryConfigurationZoneKey;
+
+typedef NakamaRetryListener = void Function(
+  int attempt,
+  Duration delay,
+  DioException error,
+);
+
+/// Retry behavior for transient HTTP failures in the REST API client.
+class NakamaRetryConfiguration {
+  static final Random _random = Random();
+
+  final int maxRetries;
+  final Duration baseDelay;
+  final Duration maxDelay;
+  final Duration maxTotalDelay;
+  final double jitterFactor;
+  final Set<int> retryStatusCodes;
+  final bool retryOnConnectionError;
+  final bool retryOnTimeout;
+  final bool retryNonIdempotentRequests;
+  final NakamaRetryListener? onRetry;
+
+  const NakamaRetryConfiguration({
+    this.maxRetries = 4,
+    this.baseDelay = const Duration(milliseconds: 500),
+    this.maxDelay = const Duration(seconds: 5),
+    this.maxTotalDelay = const Duration(milliseconds: 1500),
+    this.jitterFactor = 0.2,
+    this.retryStatusCodes = const {408, 429, 500, 502, 503, 504},
+    this.retryOnConnectionError = true,
+    this.retryOnTimeout = true,
+    this.retryNonIdempotentRequests = false,
+    this.onRetry,
+  }) : assert(maxRetries >= 0),
+       assert(jitterFactor >= 0);
+
+  Duration getDelay(int attempt) {
+    final exponentialDelay = baseDelay * (1 << (attempt - 1));
+    final cappedDelay = exponentialDelay > maxDelay ? maxDelay : exponentialDelay;
+
+    if (jitterFactor <= 0 || cappedDelay.inMilliseconds == 0) {
+      return cappedDelay;
+    }
+
+    final maxJitter = (cappedDelay.inMilliseconds * jitterFactor).round();
+    if (maxJitter == 0) {
+      return cappedDelay;
+    }
+
+    final jitter = _random.nextInt((maxJitter * 2) + 1) - maxJitter;
+    final delayMs = cappedDelay.inMilliseconds + jitter;
+    final boundedMs = delayMs < 0
+        ? 0
+        : (delayMs > maxDelay.inMilliseconds ? maxDelay.inMilliseconds : delayMs);
+    return Duration(milliseconds: boundedMs);
+  }
+}
 
 /// Base class for communicating with Nakama via API.
 /// [NakamaGrpcClient] abstracts the API calls and handles authentication
@@ -38,6 +101,26 @@ class NakamaRestApiClient extends NakamaBaseClient {
   /// interceptor for JWT auth.
   model.Session? _session;
 
+  late NakamaRetryConfiguration _globalRetryConfiguration;
+
+  /// Global retry behavior used by all requests unless overridden per call.
+  NakamaRetryConfiguration get globalRetryConfiguration => _globalRetryConfiguration;
+
+  set globalRetryConfiguration(NakamaRetryConfiguration value) {
+    _globalRetryConfiguration = value;
+  }
+
+  /// Run a single operation with a temporary retry override.
+  Future<T> withRetryConfiguration<T>(
+    NakamaRetryConfiguration retryConfiguration,
+    Future<T> Function() operation,
+  ) {
+    return runZoned(
+      operation,
+      zoneValues: {_kRetryConfigZoneKey: retryConfiguration},
+    );
+  }
+
   /// Either inits and returns a new instance of [NakamaRestApiClient] or
   /// returns a already initialized one.
   factory NakamaRestApiClient.init({
@@ -47,8 +130,10 @@ class NakamaRestApiClient extends NakamaBaseClient {
     int port = 7350,
     String path = '',
     bool ssl = false,
+    NakamaRetryConfiguration retryConfiguration = const NakamaRetryConfiguration(),
   }) {
     if (_clients.containsKey(key)) {
+      _clients[key]!.globalRetryConfiguration = retryConfiguration;
       return _clients[key]!;
     }
 
@@ -66,6 +151,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
       path: path,
       serverKey: serverKey,
       ssl: ssl,
+      retryConfiguration: retryConfiguration,
     );
   }
 
@@ -75,7 +161,9 @@ class NakamaRestApiClient extends NakamaBaseClient {
     required int port,
     required String path,
     required bool ssl,
+    required NakamaRetryConfiguration retryConfiguration,
   }) {
+    _globalRetryConfiguration = retryConfiguration;
     apiBaseUrl = Uri(
       host: host,
       scheme: ssl ? 'https' : 'http',
@@ -86,6 +174,12 @@ class NakamaRestApiClient extends NakamaBaseClient {
     dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {
+          final zoneRetryConfiguration = Zone.current[_kRetryConfigZoneKey];
+          final retryConfiguration = zoneRetryConfiguration is NakamaRetryConfiguration
+              ? zoneRetryConfiguration
+              : _globalRetryConfiguration;
+          options.extra[_kRetryConfigKey] = retryConfiguration;
+
           if (_session != null) {
             options.headers.putIfAbsent(
               'Authorization',
@@ -102,7 +196,96 @@ class NakamaRestApiClient extends NakamaBaseClient {
         },
       ),
     );
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onError: (error, handler) async {
+          final requestOptions = error.requestOptions;
+          final retryConfiguration = requestOptions.extra[_kRetryConfigKey] is NakamaRetryConfiguration
+              ? requestOptions.extra[_kRetryConfigKey] as NakamaRetryConfiguration
+              : _globalRetryConfiguration;
+
+          if (retryConfiguration.maxRetries <= 0) {
+            handler.next(error);
+            return;
+          }
+
+          final currentAttempt = (requestOptions.extra[_kRetryAttemptKey] as int?) ?? 0;
+          if (currentAttempt >= retryConfiguration.maxRetries ||
+              !_shouldRetry(error, requestOptions, retryConfiguration)) {
+            handler.next(error);
+            return;
+          }
+
+          final nextAttempt = currentAttempt + 1;
+          final delay = retryConfiguration.getDelay(nextAttempt);
+          final accumulatedDelayMs = (requestOptions.extra[_kRetryTotalDelayMsKey] as int?) ?? 0;
+          final newTotalDelayMs = accumulatedDelayMs + delay.inMilliseconds;
+
+          if (newTotalDelayMs > retryConfiguration.maxTotalDelay.inMilliseconds) {
+            handler.next(error);
+            return;
+          }
+
+          requestOptions.extra[_kRetryAttemptKey] = nextAttempt;
+          requestOptions.extra[_kRetryTotalDelayMsKey] = newTotalDelayMs;
+          retryConfiguration.onRetry?.call(nextAttempt, delay, error);
+
+          await Future<void>.delayed(delay);
+
+          try {
+            final response = await dio.fetch<dynamic>(requestOptions);
+            handler.resolve(response);
+          } on DioException catch (e) {
+            handler.next(e);
+          } catch (_) {
+            handler.next(error);
+          }
+        },
+      ),
+    );
     _api = ApiClient(dio, baseUrl: apiBaseUrl.toString());
+  }
+
+  bool _isIdempotentMethod(String method) {
+    switch (method.toUpperCase()) {
+      case 'GET':
+      case 'HEAD':
+      case 'OPTIONS':
+      case 'TRACE':
+      case 'PUT':
+      case 'DELETE':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  bool _shouldRetry(
+    DioException error,
+    RequestOptions requestOptions,
+    NakamaRetryConfiguration retryConfiguration,
+  ) {
+    if (requestOptions.cancelToken?.isCancelled == true || error.type == DioExceptionType.cancel) {
+      return false;
+    }
+
+    if (!retryConfiguration.retryNonIdempotentRequests && !_isIdempotentMethod(requestOptions.method)) {
+      return false;
+    }
+
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+        return retryConfiguration.retryOnTimeout;
+      case DioExceptionType.connectionError:
+        return retryConfiguration.retryOnConnectionError;
+      case DioExceptionType.badResponse:
+        final statusCode = error.response?.statusCode;
+        return statusCode != null && retryConfiguration.retryStatusCodes.contains(statusCode);
+      default:
+        return false;
+    }
   }
 
   /// Handles errors and returns a [ResponseError] if the error is a [DioException] and the response data is not null.

--- a/nakama/lib/src/nakama_client/nakama_api_client.dart
+++ b/nakama/lib/src/nakama_client/nakama_api_client.dart
@@ -24,27 +24,61 @@ const _kDefaultAppKey = 'default';
 const _kRetryAttemptKey = 'nakama_retry_attempt';
 const _kRetryConfigKey = 'nakama_retry_configuration';
 const _kRetryTotalDelayMsKey = 'nakama_retry_total_delay_ms';
-const _kRetryConfigZoneKey = #nakamaRetryConfigurationZoneKey;
+final _retryConfigZoneKey = Object();
 
-typedef NakamaRetryListener = void Function(
-  int attempt,
-  Duration delay,
-  DioException error,
-);
+/// Called before a retry attempt is scheduled.
+///
+/// - [attempt] The 1-based number of the upcoming retry.
+/// - [delay] The delay that is awaited before the upcoming retry.
+/// - [error] The error that triggered the retry.
+typedef NakamaRetryListener =
+    void Function(int attempt, Duration delay, DioException error);
 
-/// Retry behavior for transient HTTP failures in the REST API client.
+/// Retry behavior for transient failures in the REST API client.
+///
+/// The defaults mirror the other Nakama client libraries: up to [maxRetries]
+/// retries with exponential backoff, capped by [maxTotalDelay].
 class NakamaRetryConfiguration {
   static final Random _random = Random();
 
+  /// Maximum number of retries made in addition to the initial attempt.
   final int maxRetries;
+
+  /// Delay before the first retry. It is doubled on every following retry.
   final Duration baseDelay;
+
+  /// Upper bound for the delay of a single retry.
   final Duration maxDelay;
+
+  /// Budget for the sum of all retry delays of a single request.
+  ///
+  /// A request stops retrying as soon as the next delay would exceed this
+  /// budget, even if [maxRetries] has not been reached yet. With the default
+  /// values this limits a request to two retries.
   final Duration maxTotalDelay;
+
+  /// Randomness applied to every delay, as a fraction of that delay.
+  ///
+  /// A value of `0.2` spreads the delay over ±20%.
   final double jitterFactor;
+
+  /// Response status codes that are treated as transient.
   final Set<int> retryStatusCodes;
+
+  /// Whether requests that failed without a response are retried.
   final bool retryOnConnectionError;
+
+  /// Whether requests that ran into a connect, send or receive timeout are
+  /// retried.
   final bool retryOnTimeout;
+
+  /// Whether requests using a non-idempotent method are retried.
+  ///
+  /// The Nakama REST API is `POST` based, so setting this to `false` disables
+  /// retries for almost every call.
   final bool retryNonIdempotentRequests;
+
+  /// Invoked before every retry attempt.
   final NakamaRetryListener? onRetry;
 
   const NakamaRetryConfiguration({
@@ -56,14 +90,18 @@ class NakamaRetryConfiguration {
     this.retryStatusCodes = const {408, 429, 500, 502, 503, 504},
     this.retryOnConnectionError = true,
     this.retryOnTimeout = true,
-    this.retryNonIdempotentRequests = false,
+    this.retryNonIdempotentRequests = true,
     this.onRetry,
   }) : assert(maxRetries >= 0),
-       assert(jitterFactor >= 0);
+       assert(jitterFactor >= 0 && jitterFactor <= 1);
 
+  /// Returns the delay to await before the [attempt]th (1-based) retry.
   Duration getDelay(int attempt) {
-    final exponentialDelay = baseDelay * (1 << (attempt - 1));
-    final cappedDelay = exponentialDelay > maxDelay ? maxDelay : exponentialDelay;
+    final exponent = (attempt - 1).clamp(0, 30);
+    final exponentialDelay = baseDelay * (1 << exponent);
+    final cappedDelay = exponentialDelay > maxDelay
+        ? maxDelay
+        : exponentialDelay;
 
     if (jitterFactor <= 0 || cappedDelay.inMilliseconds == 0) {
       return cappedDelay;
@@ -78,7 +116,9 @@ class NakamaRetryConfiguration {
     final delayMs = cappedDelay.inMilliseconds + jitter;
     final boundedMs = delayMs < 0
         ? 0
-        : (delayMs > maxDelay.inMilliseconds ? maxDelay.inMilliseconds : delayMs);
+        : (delayMs > maxDelay.inMilliseconds
+              ? maxDelay.inMilliseconds
+              : delayMs);
     return Duration(milliseconds: boundedMs);
   }
 }
@@ -101,23 +141,23 @@ class NakamaRestApiClient extends NakamaBaseClient {
   /// interceptor for JWT auth.
   model.Session? _session;
 
-  late NakamaRetryConfiguration _globalRetryConfiguration;
+  /// Retry behavior applied to every request that does not override it via
+  /// [withRetryConfiguration].
+  NakamaRetryConfiguration globalRetryConfiguration;
 
-  /// Global retry behavior used by all requests unless overridden per call.
-  NakamaRetryConfiguration get globalRetryConfiguration => _globalRetryConfiguration;
-
-  set globalRetryConfiguration(NakamaRetryConfiguration value) {
-    _globalRetryConfiguration = value;
-  }
-
-  /// Run a single operation with a temporary retry override.
+  /// Runs [operation] with [retryConfiguration] instead of
+  /// [globalRetryConfiguration].
+  ///
+  /// The override applies to every request that is *started* inside
+  /// [operation]; awaiting a future that was created outside of it is not
+  /// affected.
   Future<T> withRetryConfiguration<T>(
     NakamaRetryConfiguration retryConfiguration,
     Future<T> Function() operation,
   ) {
     return runZoned(
       operation,
-      zoneValues: {_kRetryConfigZoneKey: retryConfiguration},
+      zoneValues: {_retryConfigZoneKey: retryConfiguration},
     );
   }
 
@@ -130,11 +170,14 @@ class NakamaRestApiClient extends NakamaBaseClient {
     int port = 7350,
     String path = '',
     bool ssl = false,
-    NakamaRetryConfiguration retryConfiguration = const NakamaRetryConfiguration(),
+    NakamaRetryConfiguration? retryConfiguration,
   }) {
     if (_clients.containsKey(key)) {
-      _clients[key]!.globalRetryConfiguration = retryConfiguration;
-      return _clients[key]!;
+      final client = _clients[key]!;
+      if (retryConfiguration != null) {
+        client.globalRetryConfiguration = retryConfiguration;
+      }
+      return client;
     }
 
     // Not yet initialized -> check if we've got all parameters to do so
@@ -151,7 +194,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
       path: path,
       serverKey: serverKey,
       ssl: ssl,
-      retryConfiguration: retryConfiguration,
+      retryConfiguration:
+          retryConfiguration ?? const NakamaRetryConfiguration(),
     );
   }
 
@@ -162,8 +206,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     required String path,
     required bool ssl,
     required NakamaRetryConfiguration retryConfiguration,
-  }) {
-    _globalRetryConfiguration = retryConfiguration;
+  }) : globalRetryConfiguration = retryConfiguration {
     apiBaseUrl = Uri(
       host: host,
       scheme: ssl ? 'https' : 'http',
@@ -174,10 +217,11 @@ class NakamaRestApiClient extends NakamaBaseClient {
     dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {
-          final zoneRetryConfiguration = Zone.current[_kRetryConfigZoneKey];
-          final retryConfiguration = zoneRetryConfiguration is NakamaRetryConfiguration
+          final zoneRetryConfiguration = Zone.current[_retryConfigZoneKey];
+          final retryConfiguration =
+              zoneRetryConfiguration is NakamaRetryConfiguration
               ? zoneRetryConfiguration
-              : _globalRetryConfiguration;
+              : globalRetryConfiguration;
           options.extra[_kRetryConfigKey] = retryConfiguration;
 
           if (_session != null) {
@@ -200,16 +244,19 @@ class NakamaRestApiClient extends NakamaBaseClient {
       InterceptorsWrapper(
         onError: (error, handler) async {
           final requestOptions = error.requestOptions;
-          final retryConfiguration = requestOptions.extra[_kRetryConfigKey] is NakamaRetryConfiguration
-              ? requestOptions.extra[_kRetryConfigKey] as NakamaRetryConfiguration
-              : _globalRetryConfiguration;
+          final retryConfiguration =
+              requestOptions.extra[_kRetryConfigKey] is NakamaRetryConfiguration
+              ? requestOptions.extra[_kRetryConfigKey]
+                    as NakamaRetryConfiguration
+              : globalRetryConfiguration;
 
           if (retryConfiguration.maxRetries <= 0) {
             handler.next(error);
             return;
           }
 
-          final currentAttempt = (requestOptions.extra[_kRetryAttemptKey] as int?) ?? 0;
+          final currentAttempt =
+              (requestOptions.extra[_kRetryAttemptKey] as int?) ?? 0;
           if (currentAttempt >= retryConfiguration.maxRetries ||
               !_shouldRetry(error, requestOptions, retryConfiguration)) {
             handler.next(error);
@@ -218,10 +265,12 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
           final nextAttempt = currentAttempt + 1;
           final delay = retryConfiguration.getDelay(nextAttempt);
-          final accumulatedDelayMs = (requestOptions.extra[_kRetryTotalDelayMsKey] as int?) ?? 0;
+          final accumulatedDelayMs =
+              (requestOptions.extra[_kRetryTotalDelayMsKey] as int?) ?? 0;
           final newTotalDelayMs = accumulatedDelayMs + delay.inMilliseconds;
 
-          if (newTotalDelayMs > retryConfiguration.maxTotalDelay.inMilliseconds) {
+          if (newTotalDelayMs >
+              retryConfiguration.maxTotalDelay.inMilliseconds) {
             handler.next(error);
             return;
           }
@@ -237,8 +286,14 @@ class NakamaRestApiClient extends NakamaBaseClient {
             handler.resolve(response);
           } on DioException catch (e) {
             handler.next(e);
-          } catch (_) {
-            handler.next(error);
+          } catch (e, stackTrace) {
+            handler.next(
+              DioException(
+                requestOptions: requestOptions,
+                error: e,
+                stackTrace: stackTrace,
+              ),
+            );
           }
         },
       ),
@@ -265,11 +320,13 @@ class NakamaRestApiClient extends NakamaBaseClient {
     RequestOptions requestOptions,
     NakamaRetryConfiguration retryConfiguration,
   ) {
-    if (requestOptions.cancelToken?.isCancelled == true || error.type == DioExceptionType.cancel) {
+    if (requestOptions.cancelToken?.isCancelled == true ||
+        error.type == DioExceptionType.cancel) {
       return false;
     }
 
-    if (!retryConfiguration.retryNonIdempotentRequests && !_isIdempotentMethod(requestOptions.method)) {
+    if (!retryConfiguration.retryNonIdempotentRequests &&
+        !_isIdempotentMethod(requestOptions.method)) {
       return false;
     }
 
@@ -282,7 +339,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
         return retryConfiguration.retryOnConnectionError;
       case DioExceptionType.badResponse:
         final statusCode = error.response?.statusCode;
-        return statusCode != null && retryConfiguration.retryStatusCodes.contains(statusCode);
+        return statusCode != null &&
+            retryConfiguration.retryStatusCodes.contains(statusCode);
       default:
         return false;
     }
@@ -1859,7 +1917,11 @@ class NakamaRestApiClient extends NakamaBaseClient {
       if (payload == null) {
         res = await _api.rpcFunc2(id: id, httpKey: httpKey);
       } else {
-        res = await _api.rpcFunc(id: id, body: jsonEncode(payload), httpKey: httpKey);
+        res = await _api.rpcFunc(
+          id: id,
+          body: jsonEncode(payload),
+          httpKey: httpKey,
+        );
       }
 
       return res.payload;

--- a/nakama/lib/src/nakama_client/stub/api_client.dart
+++ b/nakama/lib/src/nakama_client/stub/api_client.dart
@@ -10,10 +10,12 @@ NakamaBaseClient getNakamaClient({
   int httpPort = 7350,
   int grpcPort = 7349,
   bool ssl = false,
+  NakamaRetryConfiguration? retryConfiguration,
 }) => NakamaRestApiClient.init(
   host: host,
   key: key,
   port: httpPort,
   serverKey: serverKey,
   ssl: ssl,
+  retryConfiguration: retryConfiguration,
 );

--- a/nakama/lib/src/nakama_client/stub/grpc_client.dart
+++ b/nakama/lib/src/nakama_client/stub/grpc_client.dart
@@ -1,8 +1,11 @@
+import 'package:nakama/src/nakama_client/nakama_api_client.dart';
 import 'package:nakama/src/nakama_client/nakama_client.dart';
 import 'package:nakama/src/nakama_client/nakama_grpc_client.dart';
 
 const _kDefaultAppKey = 'default';
 
+/// [retryConfiguration] is only honored by the REST transport and therefore
+/// ignored here.
 NakamaBaseClient getNakamaClient({
   String? host,
   String? serverKey,
@@ -10,6 +13,7 @@ NakamaBaseClient getNakamaClient({
   int httpPort = 7350,
   int grpcPort = 7349,
   bool ssl = false,
+  NakamaRetryConfiguration? retryConfiguration,
 }) => NakamaGrpcClient.init(
   host: host,
   key: key,

--- a/nakama/lib/src/nakama_client/stub/nakama_client_stub.dart
+++ b/nakama/lib/src/nakama_client/stub/nakama_client_stub.dart
@@ -1,3 +1,4 @@
+import 'package:nakama/src/nakama_client/nakama_api_client.dart';
 import 'package:nakama/src/nakama_client/nakama_client.dart';
 
 const _kDefaultAppKey = 'default';
@@ -9,6 +10,7 @@ NakamaBaseClient getNakamaClient({
   int httpPort = 7350,
   int grpcPort = 7349,
   bool ssl = false,
+  NakamaRetryConfiguration? retryConfiguration,
 }) => throw UnsupportedError(
   'Nakama is not supported outside IO/JS/WASM runtime.',
 );

--- a/nakama/test/rest/retry_test.dart
+++ b/nakama/test/rest/retry_test.dart
@@ -1,0 +1,111 @@
+import 'package:dio/dio.dart';
+import 'package:nakama/nakama.dart';
+import 'package:test/test.dart';
+
+const _kTestHost = '127.0.0.1';
+const _kTestServerKey = 'defaultkey';
+// Intentionally closed local port to force deterministic transport failures.
+const _kUnreachablePort = 65534;
+
+void main() {
+  group('[REST] Retry configuration', () {
+    NakamaRestApiClient _newClient({
+      required String key,
+      required NakamaRetryConfiguration retryConfiguration,
+    }) {
+      return NakamaRestApiClient.init(
+        host: _kTestHost,
+        serverKey: _kTestServerKey,
+        key: key,
+        port: _kUnreachablePort,
+        ssl: false,
+        retryConfiguration: retryConfiguration,
+      );
+    }
+
+    NakamaRetryConfiguration _fastRetryConfig({
+      required int maxRetries,
+      required bool retryNonIdempotentRequests,
+      void Function()? onRetry,
+    }) {
+      return NakamaRetryConfiguration(
+        maxRetries: maxRetries,
+        baseDelay: const Duration(milliseconds: 1),
+        maxDelay: const Duration(milliseconds: 1),
+        maxTotalDelay: const Duration(milliseconds: 10),
+        jitterFactor: 0,
+        retryNonIdempotentRequests: retryNonIdempotentRequests,
+        onRetry: onRetry == null ? null : (_, __, ___) => onRetry(),
+      );
+    }
+
+    test('global retry configuration retries non-idempotent requests when enabled', () async {
+      var retryCount = 0;
+
+      final client = _newClient(
+        key: 'retry-global-${DateTime.now().microsecondsSinceEpoch}',
+        retryConfiguration: _fastRetryConfig(
+          maxRetries: 2,
+          retryNonIdempotentRequests: true,
+          onRetry: () => retryCount++,
+        ),
+      );
+
+      await expectLater(
+        client.authenticateDevice(deviceId: 'retry-test-device'),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(retryCount, equals(2));
+    });
+
+    test('default policy does not retry non-idempotent requests', () async {
+      var retryCount = 0;
+
+      final client = _newClient(
+        key: 'retry-default-policy-${DateTime.now().microsecondsSinceEpoch}',
+        retryConfiguration: _fastRetryConfig(
+          maxRetries: 2,
+          retryNonIdempotentRequests: false,
+          onRetry: () => retryCount++,
+        ),
+      );
+
+      await expectLater(
+        client.authenticateDevice(deviceId: 'retry-test-device-default-policy'),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(retryCount, equals(0));
+    });
+
+    test('per-request retry configuration overrides global configuration', () async {
+      var globalRetryCount = 0;
+      var requestRetryCount = 0;
+
+      final client = _newClient(
+        key: 'retry-override-${DateTime.now().microsecondsSinceEpoch}',
+        retryConfiguration: _fastRetryConfig(
+          maxRetries: 0,
+          retryNonIdempotentRequests: true,
+          onRetry: () => globalRetryCount++,
+        ),
+      );
+
+      await expectLater(
+        client.withRetryConfiguration(
+          _fastRetryConfig(
+            maxRetries: 1,
+            retryNonIdempotentRequests: true,
+            onRetry: () => requestRetryCount++,
+          ),
+          () => client.authenticateDevice(deviceId: 'retry-test-device-override'),
+        ),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(globalRetryCount, equals(0));
+      expect(requestRetryCount, equals(1));
+    });
+  });
+}

--- a/nakama/test/rest/retry_test.dart
+++ b/nakama/test/rest/retry_test.dart
@@ -1,105 +1,104 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:nakama/nakama.dart';
 import 'package:test/test.dart';
 
-const _kTestHost = '127.0.0.1';
-const _kTestServerKey = 'defaultkey';
+import '../config.dart';
+
 // Intentionally closed local port to force deterministic transport failures.
 const _kUnreachablePort = 65534;
 
+String _jwt(Map<String, dynamic> claims) {
+  String encode(Map<String, dynamic> value) =>
+      base64Url.encode(utf8.encode(jsonEncode(value))).replaceAll('=', '');
+
+  return '${encode({'alg': 'HS256', 'typ': 'JWT'})}'
+      '.${encode(claims)}'
+      '.signature';
+}
+
+NakamaRetryConfiguration _fastRetryConfiguration({
+  required int maxRetries,
+  bool retryNonIdempotentRequests = true,
+  void Function()? onRetry,
+}) {
+  return NakamaRetryConfiguration(
+    maxRetries: maxRetries,
+    baseDelay: const Duration(milliseconds: 1),
+    maxDelay: const Duration(milliseconds: 1),
+    maxTotalDelay: const Duration(milliseconds: 10),
+    jitterFactor: 0,
+    retryNonIdempotentRequests: retryNonIdempotentRequests,
+    onRetry: onRetry == null ? null : (_, _, _) => onRetry(),
+  );
+}
+
 void main() {
   group('[REST] Retry configuration', () {
-    NakamaRestApiClient _newClient({
-      required String key,
-      required NakamaRetryConfiguration retryConfiguration,
-    }) {
-      return NakamaRestApiClient.init(
-        host: _kTestHost,
-        serverKey: _kTestServerKey,
-        key: key,
+    late final NakamaRestApiClient client;
+
+    setUpAll(() {
+      client = NakamaRestApiClient.init(
+        host: kTestHost,
+        serverKey: kTestServerKey,
         port: _kUnreachablePort,
         ssl: false,
-        retryConfiguration: retryConfiguration,
       );
-    }
-
-    NakamaRetryConfiguration _fastRetryConfig({
-      required int maxRetries,
-      required bool retryNonIdempotentRequests,
-      void Function()? onRetry,
-    }) {
-      return NakamaRetryConfiguration(
-        maxRetries: maxRetries,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 1),
-        maxTotalDelay: const Duration(milliseconds: 10),
-        jitterFactor: 0,
-        retryNonIdempotentRequests: retryNonIdempotentRequests,
-        onRetry: onRetry == null ? null : (_, __, ___) => onRetry(),
-      );
-    }
-
-    test('global retry configuration retries non-idempotent requests when enabled', () async {
-      var retryCount = 0;
-
-      final client = _newClient(
-        key: 'retry-global-${DateTime.now().microsecondsSinceEpoch}',
-        retryConfiguration: _fastRetryConfig(
-          maxRetries: 2,
-          retryNonIdempotentRequests: true,
-          onRetry: () => retryCount++,
-        ),
-      );
-
-      await expectLater(
-        client.authenticateDevice(deviceId: 'retry-test-device'),
-        throwsA(isA<DioException>()),
-      );
-
-      expect(retryCount, equals(2));
     });
 
-    test('default policy does not retry non-idempotent requests', () async {
-      var retryCount = 0;
-
-      final client = _newClient(
-        key: 'retry-default-policy-${DateTime.now().microsecondsSinceEpoch}',
-        retryConfiguration: _fastRetryConfig(
+    test(
+      'retries transport failures until the attempts are exhausted',
+      () async {
+        var retryCount = 0;
+        client.globalRetryConfiguration = _fastRetryConfiguration(
           maxRetries: 2,
-          retryNonIdempotentRequests: false,
           onRetry: () => retryCount++,
-        ),
+        );
+
+        await expectLater(
+          client.authenticateDevice(deviceId: 'retry-test-device'),
+          throwsA(isA<DioException>()),
+        );
+
+        expect(retryCount, equals(2));
+      },
+    );
+
+    test('does not retry non-idempotent requests when disabled', () async {
+      var retryCount = 0;
+      client.globalRetryConfiguration = _fastRetryConfiguration(
+        maxRetries: 2,
+        retryNonIdempotentRequests: false,
+        onRetry: () => retryCount++,
       );
 
       await expectLater(
-        client.authenticateDevice(deviceId: 'retry-test-device-default-policy'),
+        client.authenticateDevice(deviceId: 'retry-test-device-idempotent'),
         throwsA(isA<DioException>()),
       );
 
       expect(retryCount, equals(0));
     });
 
-    test('per-request retry configuration overrides global configuration', () async {
+    test('per-request configuration overrides the global one', () async {
       var globalRetryCount = 0;
       var requestRetryCount = 0;
-
-      final client = _newClient(
-        key: 'retry-override-${DateTime.now().microsecondsSinceEpoch}',
-        retryConfiguration: _fastRetryConfig(
-          maxRetries: 0,
-          retryNonIdempotentRequests: true,
-          onRetry: () => globalRetryCount++,
-        ),
+      client.globalRetryConfiguration = _fastRetryConfiguration(
+        maxRetries: 0,
+        onRetry: () => globalRetryCount++,
       );
 
       await expectLater(
         client.withRetryConfiguration(
-          _fastRetryConfig(
+          _fastRetryConfiguration(
             maxRetries: 1,
-            retryNonIdempotentRequests: true,
             onRetry: () => requestRetryCount++,
           ),
-          () => client.authenticateDevice(deviceId: 'retry-test-device-override'),
+          () =>
+              client.authenticateDevice(deviceId: 'retry-test-device-override'),
         ),
         throwsA(isA<DioException>()),
       );
@@ -107,5 +106,88 @@ void main() {
       expect(globalRetryCount, equals(0));
       expect(requestRetryCount, equals(1));
     });
+
+    test('stops retrying once the total delay budget is exhausted', () async {
+      var retryCount = 0;
+      client.globalRetryConfiguration = NakamaRetryConfiguration(
+        maxRetries: 10,
+        baseDelay: const Duration(milliseconds: 4),
+        maxDelay: const Duration(milliseconds: 8),
+        maxTotalDelay: const Duration(milliseconds: 12),
+        jitterFactor: 0,
+        onRetry: (_, _, _) => retryCount++,
+      );
+
+      await expectLater(
+        client.authenticateDevice(deviceId: 'retry-test-device-budget'),
+        throwsA(isA<DioException>()),
+      );
+
+      // 4ms + 8ms fit into the budget, the third delay of 8ms does not.
+      expect(retryCount, equals(2));
+    });
+
+    test(
+      'retries transient status codes and resolves the retried response',
+      () async {
+        final expiresAt =
+            DateTime.now()
+                .add(const Duration(hours: 1))
+                .millisecondsSinceEpoch ~/
+            1000;
+        final token = _jwt({'uid': 'user-id', 'exp': expiresAt});
+
+        var requestCount = 0;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+
+        unawaited(
+          Future(() async {
+            await for (final request in server) {
+              requestCount++;
+              await request.drain<void>();
+
+              if (requestCount <= 2) {
+                request.response.statusCode = HttpStatus.serviceUnavailable;
+              } else {
+                request.response
+                  ..headers.contentType = ContentType.json
+                  ..write(
+                    jsonEncode({
+                      'token': token,
+                      'refresh_token': token,
+                      'created': true,
+                    }),
+                  );
+              }
+
+              await request.response.close();
+            }
+          }),
+        );
+
+        var retryCount = 0;
+        // Own key, the default one is already bound to the unreachable port.
+        final serverClient = NakamaRestApiClient.init(
+          host: kTestHost,
+          serverKey: kTestServerKey,
+          key: 'retry-local-server',
+          port: server.port,
+          ssl: false,
+          retryConfiguration: _fastRetryConfiguration(
+            maxRetries: 3,
+            onRetry: () => retryCount++,
+          ),
+        );
+
+        final session = await serverClient.authenticateDevice(
+          deviceId: 'retry-test-device-status-code',
+        );
+
+        expect(retryCount, equals(2));
+        expect(requestCount, equals(3));
+        expect(session.userId, equals('user-id'));
+      },
+    );
   });
 }

--- a/satori/lib/src/satori_client/satori_api_client.dart
+++ b/satori/lib/src/satori_client/satori_api_client.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+import 'dart:math';
+import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:satori/src/models/event.dart';
@@ -11,6 +13,68 @@ import 'package:satori/src/models/session.dart';
 import 'package:satori/src/rest/satori_api.gen.dart';
 import 'package:satori/src/satori_client/satori_client.dart';
 
+const _kRetryAttemptKey = 'satori_retry_attempt';
+const _kRetryConfigKey = 'satori_retry_configuration';
+const _kRetryTotalDelayMsKey = 'satori_retry_total_delay_ms';
+const _kRetryConfigZoneKey = #satoriRetryConfigurationZoneKey;
+
+typedef SatoriRetryListener = void Function(
+  int attempt,
+  Duration delay,
+  DioException error,
+);
+
+/// Retry behavior for transient HTTP failures in the REST API client.
+class SatoriRetryConfiguration {
+  static final Random _random = Random();
+
+  final int maxRetries;
+  final Duration baseDelay;
+  final Duration maxDelay;
+  final Duration maxTotalDelay;
+  final double jitterFactor;
+  final Set<int> retryStatusCodes;
+  final bool retryOnConnectionError;
+  final bool retryOnTimeout;
+  final bool retryNonIdempotentRequests;
+  final SatoriRetryListener? onRetry;
+
+  const SatoriRetryConfiguration({
+    this.maxRetries = 4,
+    this.baseDelay = const Duration(milliseconds: 500),
+    this.maxDelay = const Duration(seconds: 5),
+    this.maxTotalDelay = const Duration(milliseconds: 1500),
+    this.jitterFactor = 0.2,
+    this.retryStatusCodes = const {408, 429, 500, 502, 503, 504},
+    this.retryOnConnectionError = true,
+    this.retryOnTimeout = true,
+    this.retryNonIdempotentRequests = false,
+    this.onRetry,
+  }) : assert(maxRetries >= 0),
+       assert(jitterFactor >= 0);
+
+  Duration getDelay(int attempt) {
+    final exponentialDelay = baseDelay * (1 << (attempt - 1));
+    final cappedDelay = exponentialDelay > maxDelay ? maxDelay : exponentialDelay;
+
+    if (jitterFactor <= 0 || cappedDelay.inMilliseconds == 0) {
+      return cappedDelay;
+    }
+
+    final maxJitter = (cappedDelay.inMilliseconds * jitterFactor).round();
+    if (maxJitter == 0) {
+      return cappedDelay;
+    }
+
+    final jitter = _random.nextInt((maxJitter * 2) + 1) - maxJitter;
+    final delayMs = cappedDelay.inMilliseconds + jitter;
+    final boundedMs = delayMs < 0
+        ? 0
+        : (delayMs > maxDelay.inMilliseconds ? maxDelay.inMilliseconds : delayMs);
+    return Duration(milliseconds: boundedMs);
+  }
+}
+
 /// A REST client to interact with the API in Satori.
 class SatoriRestApiClient extends SatoriBaseClient {
   late final SatoriApiClient _api;
@@ -18,20 +82,41 @@ class SatoriRestApiClient extends SatoriBaseClient {
   late final int _port;
   late final bool _ssl;
   late final String apiKey;
+  late SatoriRetryConfiguration _globalRetryConfiguration;
 
   Session? _session;
+
+  /// Global retry behavior used by all requests unless overridden per call.
+  SatoriRetryConfiguration get globalRetryConfiguration => _globalRetryConfiguration;
+
+  set globalRetryConfiguration(SatoriRetryConfiguration value) {
+    _globalRetryConfiguration = value;
+  }
+
+  /// Run a single operation with a temporary retry override.
+  Future<T> withRetryConfiguration<T>(
+    SatoriRetryConfiguration retryConfiguration,
+    Future<T> Function() operation,
+  ) {
+    return runZoned(
+      operation,
+      zoneValues: {_kRetryConfigZoneKey: retryConfiguration},
+    );
+  }
 
   factory SatoriRestApiClient.init({
     String host = 'your-satoricloud-instance',
     String apiKey = 'your-satoricloud-instance-api-key',
     int port = 443,
     bool ssl = true,
+    SatoriRetryConfiguration retryConfiguration = const SatoriRetryConfiguration(),
   }) {
     return SatoriRestApiClient._(
       host: host,
       apiKey: apiKey,
       port: port,
       ssl: ssl,
+      retryConfiguration: retryConfiguration,
     );
   }
 
@@ -40,9 +125,11 @@ class SatoriRestApiClient extends SatoriBaseClient {
     required this.apiKey,
     required int port,
     required bool ssl,
+    required SatoriRetryConfiguration retryConfiguration,
   })  : _host = host,
         _port = port,
         _ssl = ssl,
+        _globalRetryConfiguration = retryConfiguration,
         super() {
     _initializeApi();
   }
@@ -52,20 +139,118 @@ class SatoriRestApiClient extends SatoriBaseClient {
         Uri(scheme: _ssl ? 'https' : 'http', host: _host, port: _port);
     final dio = Dio(BaseOptions(baseUrl: baseUrl.toString()));
 
-    dio.interceptors.add(InterceptorsWrapper(
-      onRequest: (options, handler) {
-        if (_session != null) {
-          options.headers
-              .putIfAbsent('Authorization', () => 'Bearer ${_session!.token}');
-        } else {
-          options.headers.putIfAbsent('Authorization',
-              () => 'Basic ${base64Encode('$apiKey:'.codeUnits)}');
-        }
-        handler.next(options);
-      },
-    ));
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          final zoneRetryConfiguration = Zone.current[_kRetryConfigZoneKey];
+          final retryConfiguration = zoneRetryConfiguration is SatoriRetryConfiguration
+              ? zoneRetryConfiguration
+              : _globalRetryConfiguration;
+          options.extra[_kRetryConfigKey] = retryConfiguration;
+
+          if (_session != null) {
+            options.headers
+                .putIfAbsent('Authorization', () => 'Bearer ${_session!.token}');
+          } else {
+            options.headers.putIfAbsent('Authorization',
+                () => 'Basic ${base64Encode('$apiKey:'.codeUnits)}');
+          }
+          handler.next(options);
+        },
+      ),
+    );
+
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onError: (error, handler) async {
+          final requestOptions = error.requestOptions;
+          final retryConfiguration = requestOptions.extra[_kRetryConfigKey] is SatoriRetryConfiguration
+              ? requestOptions.extra[_kRetryConfigKey] as SatoriRetryConfiguration
+              : _globalRetryConfiguration;
+
+          if (retryConfiguration.maxRetries <= 0) {
+            handler.next(error);
+            return;
+          }
+
+          final currentAttempt = (requestOptions.extra[_kRetryAttemptKey] as int?) ?? 0;
+          if (currentAttempt >= retryConfiguration.maxRetries ||
+              !_shouldRetry(error, requestOptions, retryConfiguration)) {
+            handler.next(error);
+            return;
+          }
+
+          final nextAttempt = currentAttempt + 1;
+          final delay = retryConfiguration.getDelay(nextAttempt);
+          final accumulatedDelayMs = (requestOptions.extra[_kRetryTotalDelayMsKey] as int?) ?? 0;
+          final newTotalDelayMs = accumulatedDelayMs + delay.inMilliseconds;
+
+          if (newTotalDelayMs > retryConfiguration.maxTotalDelay.inMilliseconds) {
+            handler.next(error);
+            return;
+          }
+
+          requestOptions.extra[_kRetryAttemptKey] = nextAttempt;
+          requestOptions.extra[_kRetryTotalDelayMsKey] = newTotalDelayMs;
+          retryConfiguration.onRetry?.call(nextAttempt, delay, error);
+
+          await Future<void>.delayed(delay);
+
+          try {
+            final response = await dio.fetch<dynamic>(requestOptions);
+            handler.resolve(response);
+          } on DioException catch (e) {
+            handler.next(e);
+          } catch (_) {
+            handler.next(error);
+          }
+        },
+      ),
+    );
 
     _api = SatoriApiClient(dio, baseUrl: baseUrl.toString());
+  }
+
+  bool _isIdempotentMethod(String method) {
+    switch (method.toUpperCase()) {
+      case 'GET':
+      case 'HEAD':
+      case 'OPTIONS':
+      case 'TRACE':
+      case 'PUT':
+      case 'DELETE':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  bool _shouldRetry(
+    DioException error,
+    RequestOptions requestOptions,
+    SatoriRetryConfiguration retryConfiguration,
+  ) {
+    if (requestOptions.cancelToken?.isCancelled == true || error.type == DioExceptionType.cancel) {
+      return false;
+    }
+
+    if (!retryConfiguration.retryNonIdempotentRequests && !_isIdempotentMethod(requestOptions.method)) {
+      return false;
+    }
+
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+        return retryConfiguration.retryOnTimeout;
+      case DioExceptionType.connectionError:
+        return retryConfiguration.retryOnConnectionError;
+      case DioExceptionType.badResponse:
+        final statusCode = error.response?.statusCode;
+        return statusCode != null && retryConfiguration.retryStatusCodes.contains(statusCode);
+      default:
+        return false;
+    }
   }
 
   @override

--- a/satori/lib/src/satori_client/satori_api_client.dart
+++ b/satori/lib/src/satori_client/satori_api_client.dart
@@ -1,6 +1,6 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
-import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:satori/src/models/event.dart';
@@ -16,27 +16,64 @@ import 'package:satori/src/satori_client/satori_client.dart';
 const _kRetryAttemptKey = 'satori_retry_attempt';
 const _kRetryConfigKey = 'satori_retry_configuration';
 const _kRetryTotalDelayMsKey = 'satori_retry_total_delay_ms';
-const _kRetryConfigZoneKey = #satoriRetryConfigurationZoneKey;
+final _retryConfigZoneKey = Object();
 
+/// Called before a retry attempt is scheduled.
+///
+/// - [attempt] The 1-based number of the upcoming retry.
+/// - [delay] The delay that is awaited before the upcoming retry.
+/// - [error] The error that triggered the retry.
 typedef SatoriRetryListener = void Function(
   int attempt,
   Duration delay,
   DioException error,
 );
 
-/// Retry behavior for transient HTTP failures in the REST API client.
+/// Retry behavior for transient failures in the REST API client.
+///
+/// The defaults mirror the other Satori client libraries: up to [maxRetries]
+/// retries with exponential backoff, capped by [maxTotalDelay].
 class SatoriRetryConfiguration {
   static final Random _random = Random();
 
+  /// Maximum number of retries made in addition to the initial attempt.
   final int maxRetries;
+
+  /// Delay before the first retry. It is doubled on every following retry.
   final Duration baseDelay;
+
+  /// Upper bound for the delay of a single retry.
   final Duration maxDelay;
+
+  /// Budget for the sum of all retry delays of a single request.
+  ///
+  /// A request stops retrying as soon as the next delay would exceed this
+  /// budget, even if [maxRetries] has not been reached yet. With the default
+  /// values this limits a request to two retries.
   final Duration maxTotalDelay;
+
+  /// Randomness applied to every delay, as a fraction of that delay.
+  ///
+  /// A value of `0.2` spreads the delay over ±20%.
   final double jitterFactor;
+
+  /// Response status codes that are treated as transient.
   final Set<int> retryStatusCodes;
+
+  /// Whether requests that failed without a response are retried.
   final bool retryOnConnectionError;
+
+  /// Whether requests that ran into a connect, send or receive timeout are
+  /// retried.
   final bool retryOnTimeout;
+
+  /// Whether requests using a non-idempotent method are retried.
+  ///
+  /// The Satori REST API is `POST` based, so setting this to `false` disables
+  /// retries for almost every call.
   final bool retryNonIdempotentRequests;
+
+  /// Invoked before every retry attempt.
   final SatoriRetryListener? onRetry;
 
   const SatoriRetryConfiguration({
@@ -48,14 +85,17 @@ class SatoriRetryConfiguration {
     this.retryStatusCodes = const {408, 429, 500, 502, 503, 504},
     this.retryOnConnectionError = true,
     this.retryOnTimeout = true,
-    this.retryNonIdempotentRequests = false,
+    this.retryNonIdempotentRequests = true,
     this.onRetry,
-  }) : assert(maxRetries >= 0),
-       assert(jitterFactor >= 0);
+  })  : assert(maxRetries >= 0),
+        assert(jitterFactor >= 0 && jitterFactor <= 1);
 
+  /// Returns the delay to await before the [attempt]th (1-based) retry.
   Duration getDelay(int attempt) {
-    final exponentialDelay = baseDelay * (1 << (attempt - 1));
-    final cappedDelay = exponentialDelay > maxDelay ? maxDelay : exponentialDelay;
+    final exponent = (attempt - 1).clamp(0, 30);
+    final exponentialDelay = baseDelay * (1 << exponent);
+    final cappedDelay =
+        exponentialDelay > maxDelay ? maxDelay : exponentialDelay;
 
     if (jitterFactor <= 0 || cappedDelay.inMilliseconds == 0) {
       return cappedDelay;
@@ -70,7 +110,9 @@ class SatoriRetryConfiguration {
     final delayMs = cappedDelay.inMilliseconds + jitter;
     final boundedMs = delayMs < 0
         ? 0
-        : (delayMs > maxDelay.inMilliseconds ? maxDelay.inMilliseconds : delayMs);
+        : (delayMs > maxDelay.inMilliseconds
+            ? maxDelay.inMilliseconds
+            : delayMs);
     return Duration(milliseconds: boundedMs);
   }
 }
@@ -82,25 +124,26 @@ class SatoriRestApiClient extends SatoriBaseClient {
   late final int _port;
   late final bool _ssl;
   late final String apiKey;
-  late SatoriRetryConfiguration _globalRetryConfiguration;
+
+  /// Retry behavior applied to every request that does not override it via
+  /// [withRetryConfiguration].
+  SatoriRetryConfiguration globalRetryConfiguration;
 
   Session? _session;
 
-  /// Global retry behavior used by all requests unless overridden per call.
-  SatoriRetryConfiguration get globalRetryConfiguration => _globalRetryConfiguration;
-
-  set globalRetryConfiguration(SatoriRetryConfiguration value) {
-    _globalRetryConfiguration = value;
-  }
-
-  /// Run a single operation with a temporary retry override.
+  /// Runs [operation] with [retryConfiguration] instead of
+  /// [globalRetryConfiguration].
+  ///
+  /// The override applies to every request that is *started* inside
+  /// [operation]; awaiting a future that was created outside of it is not
+  /// affected.
   Future<T> withRetryConfiguration<T>(
     SatoriRetryConfiguration retryConfiguration,
     Future<T> Function() operation,
   ) {
     return runZoned(
       operation,
-      zoneValues: {_kRetryConfigZoneKey: retryConfiguration},
+      zoneValues: {_retryConfigZoneKey: retryConfiguration},
     );
   }
 
@@ -109,7 +152,8 @@ class SatoriRestApiClient extends SatoriBaseClient {
     String apiKey = 'your-satoricloud-instance-api-key',
     int port = 443,
     bool ssl = true,
-    SatoriRetryConfiguration retryConfiguration = const SatoriRetryConfiguration(),
+    SatoriRetryConfiguration retryConfiguration =
+        const SatoriRetryConfiguration(),
   }) {
     return SatoriRestApiClient._(
       host: host,
@@ -129,7 +173,7 @@ class SatoriRestApiClient extends SatoriBaseClient {
   })  : _host = host,
         _port = port,
         _ssl = ssl,
-        _globalRetryConfiguration = retryConfiguration,
+        globalRetryConfiguration = retryConfiguration,
         super() {
     _initializeApi();
   }
@@ -142,15 +186,16 @@ class SatoriRestApiClient extends SatoriBaseClient {
     dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {
-          final zoneRetryConfiguration = Zone.current[_kRetryConfigZoneKey];
-          final retryConfiguration = zoneRetryConfiguration is SatoriRetryConfiguration
-              ? zoneRetryConfiguration
-              : _globalRetryConfiguration;
+          final zoneRetryConfiguration = Zone.current[_retryConfigZoneKey];
+          final retryConfiguration =
+              zoneRetryConfiguration is SatoriRetryConfiguration
+                  ? zoneRetryConfiguration
+                  : globalRetryConfiguration;
           options.extra[_kRetryConfigKey] = retryConfiguration;
 
           if (_session != null) {
-            options.headers
-                .putIfAbsent('Authorization', () => 'Bearer ${_session!.token}');
+            options.headers.putIfAbsent(
+                'Authorization', () => 'Bearer ${_session!.token}');
           } else {
             options.headers.putIfAbsent('Authorization',
                 () => 'Basic ${base64Encode('$apiKey:'.codeUnits)}');
@@ -164,16 +209,19 @@ class SatoriRestApiClient extends SatoriBaseClient {
       InterceptorsWrapper(
         onError: (error, handler) async {
           final requestOptions = error.requestOptions;
-          final retryConfiguration = requestOptions.extra[_kRetryConfigKey] is SatoriRetryConfiguration
-              ? requestOptions.extra[_kRetryConfigKey] as SatoriRetryConfiguration
-              : _globalRetryConfiguration;
+          final retryConfiguration =
+              requestOptions.extra[_kRetryConfigKey] is SatoriRetryConfiguration
+                  ? requestOptions.extra[_kRetryConfigKey]
+                      as SatoriRetryConfiguration
+                  : globalRetryConfiguration;
 
           if (retryConfiguration.maxRetries <= 0) {
             handler.next(error);
             return;
           }
 
-          final currentAttempt = (requestOptions.extra[_kRetryAttemptKey] as int?) ?? 0;
+          final currentAttempt =
+              (requestOptions.extra[_kRetryAttemptKey] as int?) ?? 0;
           if (currentAttempt >= retryConfiguration.maxRetries ||
               !_shouldRetry(error, requestOptions, retryConfiguration)) {
             handler.next(error);
@@ -182,10 +230,12 @@ class SatoriRestApiClient extends SatoriBaseClient {
 
           final nextAttempt = currentAttempt + 1;
           final delay = retryConfiguration.getDelay(nextAttempt);
-          final accumulatedDelayMs = (requestOptions.extra[_kRetryTotalDelayMsKey] as int?) ?? 0;
+          final accumulatedDelayMs =
+              (requestOptions.extra[_kRetryTotalDelayMsKey] as int?) ?? 0;
           final newTotalDelayMs = accumulatedDelayMs + delay.inMilliseconds;
 
-          if (newTotalDelayMs > retryConfiguration.maxTotalDelay.inMilliseconds) {
+          if (newTotalDelayMs >
+              retryConfiguration.maxTotalDelay.inMilliseconds) {
             handler.next(error);
             return;
           }
@@ -201,8 +251,14 @@ class SatoriRestApiClient extends SatoriBaseClient {
             handler.resolve(response);
           } on DioException catch (e) {
             handler.next(e);
-          } catch (_) {
-            handler.next(error);
+          } catch (e, stackTrace) {
+            handler.next(
+              DioException(
+                requestOptions: requestOptions,
+                error: e,
+                stackTrace: stackTrace,
+              ),
+            );
           }
         },
       ),
@@ -230,11 +286,13 @@ class SatoriRestApiClient extends SatoriBaseClient {
     RequestOptions requestOptions,
     SatoriRetryConfiguration retryConfiguration,
   ) {
-    if (requestOptions.cancelToken?.isCancelled == true || error.type == DioExceptionType.cancel) {
+    if (requestOptions.cancelToken?.isCancelled == true ||
+        error.type == DioExceptionType.cancel) {
       return false;
     }
 
-    if (!retryConfiguration.retryNonIdempotentRequests && !_isIdempotentMethod(requestOptions.method)) {
+    if (!retryConfiguration.retryNonIdempotentRequests &&
+        !_isIdempotentMethod(requestOptions.method)) {
       return false;
     }
 
@@ -247,7 +305,8 @@ class SatoriRestApiClient extends SatoriBaseClient {
         return retryConfiguration.retryOnConnectionError;
       case DioExceptionType.badResponse:
         final statusCode = error.response?.statusCode;
-        return statusCode != null && retryConfiguration.retryStatusCodes.contains(statusCode);
+        return statusCode != null &&
+            retryConfiguration.retryStatusCodes.contains(statusCode);
       default:
         return false;
     }

--- a/satori/lib/src/satori_client/stub/api_client.dart
+++ b/satori/lib/src/satori_client/stub/api_client.dart
@@ -6,10 +6,13 @@ SatoriBaseClient getSatoriClient({
   String apiKey = 'apikey',
   int port = 7450,
   bool ssl = false,
+  SatoriRetryConfiguration retryConfiguration =
+      const SatoriRetryConfiguration(),
 }) =>
     SatoriRestApiClient.init(
       host: host,
       apiKey: apiKey,
       port: port,
       ssl: ssl,
+      retryConfiguration: retryConfiguration,
     );

--- a/satori/lib/src/satori_client/stub/satori_client_stub.dart
+++ b/satori/lib/src/satori_client/stub/satori_client_stub.dart
@@ -1,3 +1,4 @@
+import 'package:satori/src/satori_client/satori_api_client.dart';
 import 'package:satori/src/satori_client/satori_client.dart';
 
 SatoriBaseClient getSatoriClient({
@@ -5,6 +6,8 @@ SatoriBaseClient getSatoriClient({
   String apiKey = 'apikey',
   int port = 7450,
   bool ssl = false,
+  SatoriRetryConfiguration retryConfiguration =
+      const SatoriRetryConfiguration(),
 }) =>
     throw UnsupportedError(
       'Satori client initialization failed. Platform not detected correctly (IO/JS/WASM required).',

--- a/satori/test/retry_test.dart
+++ b/satori/test/retry_test.dart
@@ -1,51 +1,59 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:satori/satori.dart';
 import 'package:test/test.dart';
 
+// TODO: Verify if there is a better setup than waiting for the DNS lookup (default param in init).
 const _kTestHost = '127.0.0.1';
-const _kTestApiKey = 'test-api-key';
 // Intentionally closed local port to force deterministic transport failures.
 const _kUnreachablePort = 65534;
 
+String _jwt(Map<String, dynamic> claims) {
+  String encode(Map<String, dynamic> value) =>
+      base64Url.encode(utf8.encode(jsonEncode(value))).replaceAll('=', '');
+
+  return '${encode({'alg': 'HS256', 'typ': 'JWT'})}'
+      '.${encode(claims)}'
+      '.signature';
+}
+
+SatoriRetryConfiguration _fastRetryConfiguration({
+  required int maxRetries,
+  bool retryNonIdempotentRequests = true,
+  void Function()? onRetry,
+}) {
+  return SatoriRetryConfiguration(
+    maxRetries: maxRetries,
+    baseDelay: const Duration(milliseconds: 1),
+    maxDelay: const Duration(milliseconds: 1),
+    maxTotalDelay: const Duration(milliseconds: 10),
+    jitterFactor: 0,
+    retryNonIdempotentRequests: retryNonIdempotentRequests,
+    onRetry: onRetry == null ? null : (_, __, ___) => onRetry(),
+  );
+}
+
 void main() {
   group('[REST] Retry configuration', () {
-    SatoriRestApiClient _newClient({
-      required SatoriRetryConfiguration retryConfiguration,
-    }) {
-      return SatoriRestApiClient.init(
+    late final SatoriRestApiClient client;
+
+    setUpAll(() {
+      client = SatoriRestApiClient.init(
         host: _kTestHost,
-        apiKey: _kTestApiKey,
         port: _kUnreachablePort,
         ssl: false,
-        retryConfiguration: retryConfiguration,
       );
-    }
+    });
 
-    SatoriRetryConfiguration _fastRetryConfig({
-      required int maxRetries,
-      required bool retryNonIdempotentRequests,
-      void Function()? onRetry,
-    }) {
-      return SatoriRetryConfiguration(
-        maxRetries: maxRetries,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 1),
-        maxTotalDelay: const Duration(milliseconds: 10),
-        jitterFactor: 0,
-        retryNonIdempotentRequests: retryNonIdempotentRequests,
-        onRetry: onRetry == null ? null : (_, __, ___) => onRetry(),
-      );
-    }
-
-    test('global retry configuration retries non-idempotent requests when enabled', () async {
+    test('retries transport failures until the attempts are exhausted',
+        () async {
       var retryCount = 0;
-
-      final client = _newClient(
-        retryConfiguration: _fastRetryConfig(
-          maxRetries: 2,
-          retryNonIdempotentRequests: true,
-          onRetry: () => retryCount++,
-        ),
+      client.globalRetryConfiguration = _fastRetryConfiguration(
+        maxRetries: 2,
+        onRetry: () => retryCount++,
       );
 
       await expectLater(
@@ -56,42 +64,34 @@ void main() {
       expect(retryCount, equals(2));
     });
 
-    test('default policy does not retry non-idempotent requests', () async {
+    test('does not retry non-idempotent requests when disabled', () async {
       var retryCount = 0;
-
-      final client = _newClient(
-        retryConfiguration: _fastRetryConfig(
-          maxRetries: 2,
-          retryNonIdempotentRequests: false,
-          onRetry: () => retryCount++,
-        ),
+      client.globalRetryConfiguration = _fastRetryConfiguration(
+        maxRetries: 2,
+        retryNonIdempotentRequests: false,
+        onRetry: () => retryCount++,
       );
 
       await expectLater(
-        client.authenticate(id: 'retry-test-user-default-policy'),
+        client.authenticate(id: 'retry-test-user-idempotent'),
         throwsA(isA<DioException>()),
       );
 
       expect(retryCount, equals(0));
     });
 
-    test('per-request retry configuration overrides global configuration', () async {
+    test('per-request configuration overrides the global one', () async {
       var globalRetryCount = 0;
       var requestRetryCount = 0;
-
-      final client = _newClient(
-        retryConfiguration: _fastRetryConfig(
-          maxRetries: 0,
-          retryNonIdempotentRequests: true,
-          onRetry: () => globalRetryCount++,
-        ),
+      client.globalRetryConfiguration = _fastRetryConfiguration(
+        maxRetries: 0,
+        onRetry: () => globalRetryCount++,
       );
 
       await expectLater(
         client.withRetryConfiguration(
-          _fastRetryConfig(
+          _fastRetryConfiguration(
             maxRetries: 1,
-            retryNonIdempotentRequests: true,
             onRetry: () => requestRetryCount++,
           ),
           () => client.authenticate(id: 'retry-test-user-override'),
@@ -101,6 +101,76 @@ void main() {
 
       expect(globalRetryCount, equals(0));
       expect(requestRetryCount, equals(1));
+    });
+
+    test('stops retrying once the total delay budget is exhausted', () async {
+      var retryCount = 0;
+      client.globalRetryConfiguration = SatoriRetryConfiguration(
+        maxRetries: 10,
+        baseDelay: const Duration(milliseconds: 4),
+        maxDelay: const Duration(milliseconds: 8),
+        maxTotalDelay: const Duration(milliseconds: 12),
+        jitterFactor: 0,
+        onRetry: (_, __, ___) => retryCount++,
+      );
+
+      await expectLater(
+        client.authenticate(id: 'retry-test-user-budget'),
+        throwsA(isA<DioException>()),
+      );
+
+      // 4ms + 8ms fit into the budget, the third delay of 8ms does not.
+      expect(retryCount, equals(2));
+    });
+
+    test('retries transient status codes and resolves the retried response',
+        () async {
+      final expiresAt =
+          DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/
+              1000;
+      final token = _jwt({'iid': 'identity-id', 'exp': expiresAt});
+
+      var requestCount = 0;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+
+      unawaited(Future(() async {
+        await for (final request in server) {
+          requestCount++;
+          await request.drain<void>();
+
+          if (requestCount <= 2) {
+            request.response.statusCode = HttpStatus.serviceUnavailable;
+          } else {
+            request.response
+              ..headers.contentType = ContentType.json
+              ..write(jsonEncode({
+                'token': token,
+                'refresh_token': token,
+              }));
+          }
+
+          await request.response.close();
+        }
+      }));
+
+      var retryCount = 0;
+      final serverClient = SatoriRestApiClient.init(
+        host: _kTestHost,
+        port: server.port,
+        ssl: false,
+        retryConfiguration: _fastRetryConfiguration(
+          maxRetries: 3,
+          onRetry: () => retryCount++,
+        ),
+      );
+
+      final session =
+          await serverClient.authenticate(id: 'retry-test-user-status');
+
+      expect(retryCount, equals(2));
+      expect(requestCount, equals(3));
+      expect(session.identityId, equals('identity-id'));
     });
   });
 }

--- a/satori/test/retry_test.dart
+++ b/satori/test/retry_test.dart
@@ -1,0 +1,106 @@
+import 'package:dio/dio.dart';
+import 'package:satori/satori.dart';
+import 'package:test/test.dart';
+
+const _kTestHost = '127.0.0.1';
+const _kTestApiKey = 'test-api-key';
+// Intentionally closed local port to force deterministic transport failures.
+const _kUnreachablePort = 65534;
+
+void main() {
+  group('[REST] Retry configuration', () {
+    SatoriRestApiClient _newClient({
+      required SatoriRetryConfiguration retryConfiguration,
+    }) {
+      return SatoriRestApiClient.init(
+        host: _kTestHost,
+        apiKey: _kTestApiKey,
+        port: _kUnreachablePort,
+        ssl: false,
+        retryConfiguration: retryConfiguration,
+      );
+    }
+
+    SatoriRetryConfiguration _fastRetryConfig({
+      required int maxRetries,
+      required bool retryNonIdempotentRequests,
+      void Function()? onRetry,
+    }) {
+      return SatoriRetryConfiguration(
+        maxRetries: maxRetries,
+        baseDelay: const Duration(milliseconds: 1),
+        maxDelay: const Duration(milliseconds: 1),
+        maxTotalDelay: const Duration(milliseconds: 10),
+        jitterFactor: 0,
+        retryNonIdempotentRequests: retryNonIdempotentRequests,
+        onRetry: onRetry == null ? null : (_, __, ___) => onRetry(),
+      );
+    }
+
+    test('global retry configuration retries non-idempotent requests when enabled', () async {
+      var retryCount = 0;
+
+      final client = _newClient(
+        retryConfiguration: _fastRetryConfig(
+          maxRetries: 2,
+          retryNonIdempotentRequests: true,
+          onRetry: () => retryCount++,
+        ),
+      );
+
+      await expectLater(
+        client.authenticate(id: 'retry-test-user'),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(retryCount, equals(2));
+    });
+
+    test('default policy does not retry non-idempotent requests', () async {
+      var retryCount = 0;
+
+      final client = _newClient(
+        retryConfiguration: _fastRetryConfig(
+          maxRetries: 2,
+          retryNonIdempotentRequests: false,
+          onRetry: () => retryCount++,
+        ),
+      );
+
+      await expectLater(
+        client.authenticate(id: 'retry-test-user-default-policy'),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(retryCount, equals(0));
+    });
+
+    test('per-request retry configuration overrides global configuration', () async {
+      var globalRetryCount = 0;
+      var requestRetryCount = 0;
+
+      final client = _newClient(
+        retryConfiguration: _fastRetryConfig(
+          maxRetries: 0,
+          retryNonIdempotentRequests: true,
+          onRetry: () => globalRetryCount++,
+        ),
+      );
+
+      await expectLater(
+        client.withRetryConfiguration(
+          _fastRetryConfig(
+            maxRetries: 1,
+            retryNonIdempotentRequests: true,
+            onRetry: () => requestRetryCount++,
+          ),
+          () => client.authenticate(id: 'retry-test-user-override'),
+        ),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(globalRetryCount, equals(0));
+      expect(requestRetryCount, equals(1));
+    });
+  });
+}


### PR DESCRIPTION
Missing notes to consider before converting the draft.

- Jitter is not matching dotnet implementation. Might be worth making it a callback?
dotnet uses full jitter and exposes a delegate + RetryJitterSeed. This change sets a fixed 20% band. 

- Default configuration might be misleading? Worth double checking.
maxTotalDelay 1500ms + maxDelay: 5s? Also, the default 1500ms window could silently cap at 2 retries despite maxRetries: 4. 

- Should gRPC also have a retry?

- Should we base the retry on Retry-After? 429/503 are retryable, seems to be standard practice.

- Check satori/nakama clients, they should be identical.

- Should we add analysis_options.yaml for satori?

- On retry, the auth header uses putIfAbsent, so a session refreshed between attempts might not picked up. 
It doesnt see to be a problem now but it will be as soon as we will start refreshing on 401 (auto-session refresh)

- Check todo in satori test file. Worth exploring a more robust implementation.